### PR TITLE
added DynamicCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ More information in [wiki page](https://github.com/adireddy/haxe-checkstyle/wiki
 			}
 		},
 		{
+			"type": "Dynamic",
+			"props": {
+				"severity": "INFO"
+			}
+		},
+		{
 			"type": "EmptyLines",
 			"props": {
 				"severity": "INFO",

--- a/checkstyle/ComplexTypeUtils.hx
+++ b/checkstyle/ComplexTypeUtils.hx
@@ -114,8 +114,8 @@ class ComplexTypeUtils {
 		if (c.expr != null) walkExpr(c.expr, cb);
 	}
 
-	public static function walkCatch(c:Catch, pos:Position, cb:ComplexTypeCallback) {
-		walkComplexType(c.type, c.name, pos, cb);
+	public static function walkCatch(c:Catch, cb:ComplexTypeCallback) {
+		walkComplexType(c.type, c.name, c.expr.pos, cb);
 		walkExpr(c.expr, cb);
 	}
 
@@ -188,7 +188,7 @@ class ComplexTypeUtils {
 				if (edef != null && edef.expr != null) walkExpr(edef, cb);
 			case ETry(e, catches):
 				walkExpr(e, cb);
-				for (c in catches) walkCatch(c, e.pos, cb);
+				for (c in catches) walkCatch(c, cb);
 			case EReturn(e):
 				if (e != null) walkExpr(e, cb);
 			case EBreak:
@@ -197,16 +197,16 @@ class ComplexTypeUtils {
 			case EThrow(e): walkExpr(e, cb);
 			case ECast(e, t):
 				walkExpr(e, cb);
-				if (t != null) walkComplexType(t, t.getName(), e.pos, cb);
+				if (t != null) walkComplexType(t, "", e.pos, cb);
 			case EDisplay(e, isCall): walkExpr(e, cb);
-			case EDisplayNew(t): walkTypePath(t, "", e.pos, cb);
+			case EDisplayNew(t): walkTypePath(t, t.name, e.pos, cb);
 			case ETernary(econd, eif, eelse):
 				walkExpr(econd, cb);
 				walkExpr(eif, cb);
 				walkExpr(eelse, cb);
 			case ECheckType(e, t):
 				walkExpr(e, cb);
-				walkComplexType(t, t.getName(), e.pos, cb);
+				walkComplexType(t, "", e.pos, cb);
 			case EMeta(s, e):
 				if (s.params != null) for (mp in s.params) walkExpr(mp, cb);
 				walkExpr(e, cb);

--- a/checkstyle/ComplexTypeUtils.hx
+++ b/checkstyle/ComplexTypeUtils.hx
@@ -10,149 +10,149 @@ import haxe.macro.Expr;
 
 class ComplexTypeUtils {
 
-	public static function walkFile(file:{pack:Array<String>, decls:Array<TypeDecl> }, cb:ComplexType -> Void) {
+	public static function walkFile(file:{pack:Array<String>, decls:Array<TypeDecl> }, cb:ComplexTypeCallback) {
 		for (decl in file.decls) walkTypeDecl(decl, cb);
 	}
 
-	public static function walkTypeDecl(td:TypeDecl, cb:ComplexType -> Void) {
+	public static function walkTypeDecl(td:TypeDecl, cb:ComplexTypeCallback) {
 		switch(td.decl){
 			case EClass(d):
-				walkClass(d, cb);
+				walkClass(d, td.pos, cb);
 			case EEnum(d):
-				walkEnum(d, cb);
+				walkEnum(d, td.pos, cb);
 			case EAbstract(a):
-				walkAbstract(a, cb);
+				walkAbstract(a, td.pos, cb);
 			case EImport(sl, mode):
 				walkImport(sl, mode, cb);
 			case ETypedef(d):
-				walkTypedef(d, cb);
+				walkTypedef(d, td.pos, cb);
 			case EUsing(path):
-				walkTypePath(path, cb);
+				walkTypePath(path, path.name, td.pos, cb);
 		}
 	}
 
-	static function walkMeta(meta:Metadata, cb:ComplexType -> Void) {
+	static function walkMeta(meta:Metadata, cb:ComplexTypeCallback) {
 		for (m in meta) for (p in m.params) walkExpr(p, cb);
 	}
 
-	static function walkCommonDefinition<A, B>(d:Definition<A, B>, cb:ComplexType -> Void) {
-		for (p in d.params) walkTypeParamDecl(p, cb);
+	static function walkCommonDefinition<A, B>(d:Definition<A, B>, pos:Position, cb:ComplexTypeCallback) {
+		for (p in d.params) walkTypeParamDecl(p, pos, cb);
 		walkMeta(d.meta, cb);
 	}
 
-	public static function walkClass(d:Definition<ClassFlag, Array<Field>>, cb:ComplexType -> Void) {
-		walkCommonDefinition(d, cb);
+	public static function walkClass(d:Definition<ClassFlag, Array<Field>>, pos:Position, cb:ComplexTypeCallback) {
+		walkCommonDefinition(d, pos, cb);
 		for (f in d.flags) switch f {
-			case HExtends(t) | HImplements(t): walkTypePath(t, cb);
+			case HExtends(t) | HImplements(t): walkTypePath(t, d.name, pos, cb);
 			default:
 		}
 		for (f in d.data) walkField(f, cb);
 	}
 
-	public static function walkEnum(d:Definition<EnumFlag, Array<EnumConstructor>>, cb:ComplexType -> Void) {
-		walkCommonDefinition(d, cb);
+	public static function walkEnum(d:Definition<EnumFlag, Array<EnumConstructor>>, pos:Position, cb:ComplexTypeCallback) {
+		walkCommonDefinition(d, pos, cb);
 		for (ec in d.data) {
 			walkMeta(ec.meta, cb);
-			for (arg in ec.args) walkComplexType(arg.type, cb);
-			for (param in ec.params) walkTypeParamDecl(param, cb);
-			if (ec.type != null) walkComplexType(ec.type, cb);
+			for (arg in ec.args) walkComplexType(arg.type, ec.name, pos, cb);
+			for (param in ec.params) walkTypeParamDecl(param, pos, cb);
+			if (ec.type != null) walkComplexType(ec.type, ec.name, pos, cb);
 		}
 	}
 
-	public static function walkAbstract(d:Definition<AbstractFlag, Array<Field>>, cb:ComplexType -> Void) {
-		walkCommonDefinition(d, cb);
+	public static function walkAbstract(d:Definition<AbstractFlag, Array<Field>>, pos:Position, cb:ComplexTypeCallback) {
+		walkCommonDefinition(d, pos, cb);
 		for (f in d.flags) switch f {
-			case AFromType(ct) | AToType(ct) | AIsType(ct): walkComplexType(ct, cb);
+			case AFromType(ct) | AToType(ct) | AIsType(ct): walkComplexType(ct, f.getName(), pos, cb);
 			default:
 		}
 		for (f in d.data) walkField(f, cb);
 	}
 
-	public static function walkImport(sl, mode, cb:ComplexType -> Void) {
+	public static function walkImport(sl, mode, cb:ComplexTypeCallback) {
 		//Do nothing
 	}
 
-	public static function walkTypedef(d:Definition<EnumFlag, ComplexType>, cb:ComplexType -> Void) {
-		walkCommonDefinition(d, cb);
-		walkComplexType(d.data, cb);
+	public static function walkTypedef(d:Definition<EnumFlag, ComplexType>, pos:Position, cb:ComplexTypeCallback) {
+		walkCommonDefinition(d, pos, cb);
+		walkComplexType(d.data, d.name, pos, cb);
 	}
 
-	public static function walkTypePath(tp:TypePath, cb:ComplexType -> Void) {
+	public static function walkTypePath(tp:TypePath, name:String, pos:Position, cb:ComplexTypeCallback) {
 		if (tp.params != null) {
 			for (p in tp.params) {
 				switch(p){
-					case TPType(t): walkComplexType(t, cb);
+					case TPType(t): walkComplexType(t, name, pos, cb);
 					case TPExpr(e): walkExpr(e, cb);
 				}
 			}
 		}
 	}
 
-	public static function walkVar(v:Var, cb:ComplexType -> Void) {
-		if (v.type != null) walkComplexType(v.type, cb);
+	public static function walkVar(v:Var, pos:Position, cb:ComplexTypeCallback) {
+		if (v.type != null) walkComplexType(v.type, v.name, pos, cb);
 		if (v.expr != null) walkExpr(v.expr, cb);
 	}
 
-	public static function walkTypeParamDecl(tp:TypeParamDecl, cb:ComplexType -> Void) {
-		if (tp.constraints != null) for (c in tp.constraints) walkComplexType(c, cb);
-		if (tp.params != null) for (t in tp.params) walkTypeParamDecl(t, cb);
+	public static function walkTypeParamDecl(tp:TypeParamDecl, pos:Position, cb:ComplexTypeCallback) {
+		if (tp.constraints != null) for (c in tp.constraints) walkComplexType(c, tp.name, pos, cb);
+		if (tp.params != null) for (t in tp.params) walkTypeParamDecl(t, pos, cb);
 	}
 
-	public static function walkFunction(f:Function, cb:ComplexType -> Void) {
+	public static function walkFunction(f:Function, name:String, pos:Position, cb:ComplexTypeCallback) {
 		for (a in f.args) {
-			if (a.type != null) walkComplexType(a.type, cb);
+			if (a.type != null) walkComplexType(a.type, a.name, pos, cb);
 			if (a.value != null) walkExpr(a.value, cb);
 		}
-		if (f.ret != null) walkComplexType(f.ret, cb);
+		if (f.ret != null) walkComplexType(f.ret, name, pos, cb);
 		if (f.expr != null) walkExpr(f.expr, cb);
-		if (f.params != null) for (tp in f.params) walkTypeParamDecl(tp, cb);
+		if (f.params != null) for (tp in f.params) walkTypeParamDecl(tp, pos, cb);
 	}
 
-	public static function walkCase(c:Case, cb:ComplexType -> Void) {
+	public static function walkCase(c:Case, cb:ComplexTypeCallback) {
 		for (v in c.values) walkExpr(v, cb);
 		if (c.guard != null) walkExpr(c.guard, cb);
 		if (c.expr != null) walkExpr(c.expr, cb);
 	}
 
-	public static function walkCatch(c:Catch, cb:ComplexType -> Void) {
-		walkComplexType(c.type, cb);
+	public static function walkCatch(c:Catch, pos:Position, cb:ComplexTypeCallback) {
+		walkComplexType(c.type, c.name, pos, cb);
 		walkExpr(c.expr, cb);
 	}
 
-	public static function walkField(f:Field, cb:ComplexType -> Void) {
+	public static function walkField(f:Field, cb:ComplexTypeCallback) {
 		switch(f.kind){
 			case FVar(t, e):
-				if (t != null) walkComplexType(t, cb);
+				if (t != null) walkComplexType(t, f.name, f.pos, cb);
 				if (e != null) walkExpr(e, cb);
-			case FFun(f):
-				walkFunction(f, cb);
+			case FFun(fun):
+				walkFunction(fun, f.name, f.pos, cb);
 			case FProp(get, set, t, e):
-				if (t != null) walkComplexType(t, cb);
+				if (t != null) walkComplexType(t, f.name, f.pos, cb);
 				if (e != null) walkExpr(e, cb);
 		}
 	}
 
-	public static function walkComplexType(t:ComplexType, cb:ComplexType -> Void) {
-		cb(t);
+	public static function walkComplexType(t:ComplexType, name:String, pos:Position, cb:ComplexTypeCallback) {
+		cb(t, name, pos);
 
 		switch(t){
-			case TPath(p): walkTypePath(p, cb);
+			case TPath(p): walkTypePath(p, name, pos, cb);
 			case TFunction(args, ret):
-				for (a in args) walkComplexType(a, cb);
-				walkComplexType(ret, cb);
+				for (a in args) walkComplexType(a, name, pos, cb);
+				walkComplexType(ret, name, pos, cb);
 			case TAnonymous(fields):
 				for (f in fields) walkField(f, cb);
 			case TParent(t):
-				walkComplexType(t, cb);
+				walkComplexType(t, name, pos, cb);
 			case TExtend(p, fields):
-				for (tp in p) walkTypePath(tp, cb);
+				for (tp in p) walkTypePath(tp, name, pos, cb);
 				for (f in fields) walkField(f, cb);
 			case TOptional(t):
-				walkComplexType(t, cb);
+				walkComplexType(t, name, pos, cb);
 		}
 	}
 
-	public static function walkExpr(e:Expr, cb:ComplexType -> Void) {
+	public static function walkExpr(e:Expr, cb:ComplexTypeCallback) {
 		switch(e.expr){
 			case EConst(c):
 			case EArray(e1, e2): walkExpr(e1, cb); walkExpr(e2, cb);
@@ -167,12 +167,12 @@ class ComplexTypeUtils {
 				walkExpr(e, cb);
 				for (p in params) walkExpr(p, cb);
 			case ENew(t, params):
-				walkTypePath(t, cb);
+				walkTypePath(t, "", e.pos, cb);
 				for (p in params) walkExpr(p, cb);
 			case EUnop(op, postFix, e): walkExpr(e, cb);
 			case EVars(vars):
-				for (v in vars) walkVar(v, cb);
-			case EFunction(name, f): walkFunction(f, cb);
+				for (v in vars) walkVar(v, e.pos, cb);
+			case EFunction(name, f): walkFunction(f, name, e.pos, cb);
 			case EBlock(exprs):
 				for (e in exprs) walkExpr(e, cb);
 			case EFor(it, expr): walkExpr(it, cb); walkExpr(expr, cb);
@@ -188,7 +188,7 @@ class ComplexTypeUtils {
 				if (edef != null && edef.expr != null) walkExpr(edef, cb);
 			case ETry(e, catches):
 				walkExpr(e, cb);
-				for (c in catches) walkCatch(c, cb);
+				for (c in catches) walkCatch(c, e.pos, cb);
 			case EReturn(e):
 				if (e != null) walkExpr(e, cb);
 			case EBreak:
@@ -197,19 +197,21 @@ class ComplexTypeUtils {
 			case EThrow(e): walkExpr(e, cb);
 			case ECast(e, t):
 				walkExpr(e, cb);
-				if (t != null) walkComplexType(t, cb);
+				if (t != null) walkComplexType(t, t.getName(), e.pos, cb);
 			case EDisplay(e, isCall): walkExpr(e, cb);
-			case EDisplayNew(t): walkTypePath(t, cb);
+			case EDisplayNew(t): walkTypePath(t, "", e.pos, cb);
 			case ETernary(econd, eif, eelse):
 				walkExpr(econd, cb);
 				walkExpr(eif, cb);
 				walkExpr(eelse, cb);
 			case ECheckType(e, t):
 				walkExpr(e, cb);
-				walkComplexType(t, cb);
+				walkComplexType(t, t.getName(), e.pos, cb);
 			case EMeta(s, e):
 				if (s.params != null) for (mp in s.params) walkExpr(mp, cb);
 				walkExpr(e, cb);
 		}
 	}
 }
+
+typedef ComplexTypeCallback = ComplexType -> String -> Position -> Void;

--- a/checkstyle/checks/Check.hx
+++ b/checkstyle/checks/Check.hx
@@ -63,27 +63,20 @@ class Check {
 		for (j in 0 ... i + 1) {
 			pos += _checker.lines[j].length;
 		}
+		return isCharPosSuppressed (pos);
+	}
+
+	function isPosSuppressed(pos:Position):Bool {
+		return isCharPosSuppressed (pos.min);
+	}
+
+	function isCharPosSuppressed(pos:Int):Bool {
 		for (td in _checker.ast.decls) {
 			switch (td.decl){
 				case EClass(d):
 					for (field in d.data) {
 						if (pos > field.pos.max) continue;
 						if (pos < field.pos.min) continue;
-						return isCheckSuppressed (field);
-					}
-				default:
-			}
-		}
-		return false;
-	}
-
-	function isPosSuppressed(pos:Position):Bool {
-		for (td in _checker.ast.decls) {
-			switch (td.decl){
-				case EClass(d):
-					for (field in d.data) {
-						if (pos.min > field.pos.max) continue;
-						if (pos.min < field.pos.min) continue;
 						return isCheckSuppressed (field);
 					}
 				default:

--- a/checkstyle/checks/Check.hx
+++ b/checkstyle/checks/Check.hx
@@ -59,17 +59,31 @@ class Check {
 	}
 
 	function isLineSuppressed(i:Int):Bool {
-		var startPos:Int = 0;
+		var pos:Int = 0;
 		for (j in 0 ... i + 1) {
-			startPos += _checker.lines[j].length;
+			pos += _checker.lines[j].length;
 		}
-
 		for (td in _checker.ast.decls) {
 			switch (td.decl){
 				case EClass(d):
 					for (field in d.data) {
-						if (startPos > field.pos.max) continue;
-						if (startPos < field.pos.min) continue;
+						if (pos > field.pos.max) continue;
+						if (pos < field.pos.min) continue;
+						return isCheckSuppressed (field);
+					}
+				default:
+			}
+		}
+		return false;
+	}
+
+	function isPosSuppressed(pos:Position):Bool {
+		for (td in _checker.ast.decls) {
+			switch (td.decl){
+				case EClass(d):
+					for (field in d.data) {
+						if (pos.min > field.pos.max) continue;
+						if (pos.min < field.pos.min) continue;
 						return isCheckSuppressed (field);
 					}
 				default:

--- a/checkstyle/checks/DynamicCheck.hx
+++ b/checkstyle/checks/DynamicCheck.hx
@@ -1,0 +1,37 @@
+package checkstyle.checks;
+
+import checkstyle.LintMessage.SeverityLevel;
+import haxeparser.Data;
+import haxe.macro.Expr;
+import checkstyle.ComplexTypeUtils;
+
+@name("Dynamic")
+@desc("Checks for use of Dynamic type")
+class DynamicCheck extends Check {
+
+	public var severity:String;
+
+	public function new () {
+		super ();
+		severity = "INFO";
+	}
+
+	override function _actualRun() {
+		ComplexTypeUtils.walkFile (_checker.ast, callbackComplexType);
+	}
+
+	function callbackComplexType(t:ComplexType, name:String, pos:Position):Void {
+		if (t == null) return;
+		if (isPosSuppressed (pos)) return;
+		switch (t) {
+			case TPath(p):
+				if (Std.string (p).indexOf ("name => Dynamic") > -1) _error (name, pos);
+			default:
+		}
+	}
+
+	function _error(name:String, pos:Position) {
+		logPos('Dynamic type used: ${name}',
+				pos, Reflect.field(SeverityLevel, severity));
+	}
+}

--- a/checkstyle/checks/DynamicCheck.hx
+++ b/checkstyle/checks/DynamicCheck.hx
@@ -25,7 +25,7 @@ class DynamicCheck extends Check {
 		if (isPosSuppressed (pos)) return;
 		switch (t) {
 			case TPath(p):
-				if (Std.string (p).indexOf ("name => Dynamic") > -1) _error (name, pos);
+				if (p.name == "Dynamic") _error (name, pos);
 			default:
 		}
 	}

--- a/resources/config.json
+++ b/resources/config.json
@@ -55,6 +55,12 @@
 			}
 		},
 		{
+			"type": "Dynamic",
+			"props": {
+				"severity": "INFO"
+			}
+		},
+		{
 			"type": "EmptyLines",
 			"props": {
 				"severity": "INFO",

--- a/test/DynamicCheckTest.hx
+++ b/test/DynamicCheckTest.hx
@@ -1,0 +1,89 @@
+package ;
+
+import checkstyle.checks.DynamicCheck;
+
+class DynamicCheckTest extends CheckTestCase {
+
+	public function testNoDynamic() {
+		var check = new DynamicCheck ();
+		assertMsg(check, DynamicTests.TEST, '');
+	}
+
+	public function testDetectDynamic() {
+		var check = new DynamicCheck ();
+		assertMsg(check, DynamicTests.TEST1, 'Dynamic type used: Count');
+		assertMsg(check, DynamicTests.TEST2, 'Dynamic type used: test');
+		assertMsg(check, DynamicTests.TEST3, 'Dynamic type used: Count');
+		assertMsg(check, DynamicTests.TEST4, 'Dynamic type used: param');
+		assertMsg(check, DynamicTests.TEST5, 'Dynamic type used: test');
+		assertMsg(check, DynamicTests.TEST6, 'Dynamic type used: Test');
+	}
+}
+
+class DynamicTests {
+	public static inline var TEST:String = "
+	class Test {
+		public var a:Int;
+		private var b:Int;
+		static var COUNT:Int = 1;
+		static inline var COUNT2:Int = 1;
+		var count5:Int = 1;
+
+		@SuppressWarnings('checkstyle:Dynamic')
+		var count6:Dynamic;
+
+		@SuppressWarnings('checkstyle:Dynamic')
+		function calc(val:Dynamic, val2:Dynamic):Dynamic {
+			return null;
+		}
+	}
+
+	enum Test2 {
+		count;
+		a;
+	}
+	
+	typedef Test3 = {
+		var count1:Int;
+		var count2:String;
+	}";
+
+	public static inline var TEST1:String = "
+	class Test {
+		public var Count:Dynamic = 1;
+		public function test() {
+		}
+	}";
+
+	public static inline var TEST2:String = "
+	class Test {
+		var Count:Int = 1;
+		public function test():Dynamic {
+		}
+	}";
+
+	public static inline var TEST3:String =
+	"typedef Test = {
+		var Count:Dynamic;
+	}";
+
+	public static inline var TEST4:String =
+	"extern class Test {
+		var Count:Int = 1;
+		static inline var Count:Int = 1;
+		public function test(param:Dynamic) {
+		}
+	}";
+
+	public static inline var TEST5:String = "
+	class Test {
+		var Count:Int = 1;
+		public function test() {
+			var test:Dynamic = null;
+		}
+	}";
+
+	public static inline var TEST6:String =
+	"typedef Test = String -> Dynamic;";
+
+}

--- a/test/TestMain.hx
+++ b/test/TestMain.hx
@@ -8,6 +8,7 @@ class TestMain {
 		runner.add(new ArrayInstantiationCheckTest());
 		runner.add(new BlockFormatCheckTest());
 		runner.add(new ConstantNameCheckTest());
+		runner.add(new DynamicCheckTest());
 		runner.add(new EmptyLinesCheckTest());
 		runner.add(new ERegInstantiationCheckTest());
 		runner.add(new HexadecimalLiteralsCheckTest());


### PR DESCRIPTION
DynamicCheck checks for use of data type  `Dynamic` and generates an info level checkstyle error
supports @SuppressWarnings("checkstyle:Dynamic")

I had to extend ComplexTypeUtils since it only provided a ComplexType object in the callback, without name or position info, so you only knew that what you are looking for is in the file, but you had no idea where.
