### PR TITLE
added LeftCurlyCheck and EmptyBlockCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ More information in [wiki page](https://github.com/adireddy/haxe-checkstyle/wiki
 			}
 		},
 		{
+			"type": "LeftCurly",
+			"props": {
+				"severity": "WARNING",
+				"option": "eol",
+				"tokens": [
+					"CLASS_DEF",
+					"ENUM_DEF",
+					"ABSTRACT_DEF",
+					"TYPEDEF_DEF",
+					"CLASS_DEF",
+					"INTERFACE_DEF",
+					"OBJECT_DECL",
+					"FUNCTION",
+					"FOR",
+					"IF",
+					"WHILE",
+					"SWITCH",
+					"TRY",
+					"CATCH"
+				]
+			}
+		},
+		{
 			"type": "LineLength",
 			"props": {
 				"severity": "ERROR",

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ More information in [wiki page](https://github.com/adireddy/haxe-checkstyle/wiki
 			}
 		},
 		{
+			"type": "EmptyBlock",
+			"props": {
+				"severity": "ERROR",
+				"option": "empty",
+				"tokens": []
+			}
+		{
 			"type": "EmptyLines",
 			"props": {
 				"severity": "INFO",

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ More information in [wiki page](https://github.com/adireddy/haxe-checkstyle/wiki
 			"type": "EmptyBlock",
 			"props": {
 				"severity": "ERROR",
-				"option": "empty",
-				"tokens": []
+				"option": "empty"
 			}
+		},
 		{
 			"type": "EmptyLines",
 			"props": {

--- a/checkstyle/ComplexTypeUtils.hx
+++ b/checkstyle/ComplexTypeUtils.hx
@@ -9,7 +9,7 @@ import haxeparser.Data.EnumConstructor;
 import haxe.macro.Expr;
 
 class ComplexTypeUtils {
-	
+
 	public static function walkFile(file:{ pack:Array<String>, decls:Array<TypeDecl> }, cb:ComplexTypeCallback) {
 		for (decl in file.decls) walkTypeDecl(decl, cb);
 	}
@@ -133,7 +133,7 @@ class ComplexTypeUtils {
 				if (e != null) walkExpr(e, cb);
 		}
 	}
-	
+
 	public static function walkComplexType(t:ComplexType, name:String, pos:Position, cb:ComplexTypeCallback) {
 		cb(t, name, pos);
 		switch(t){

--- a/checkstyle/ComplexTypeUtils.hx
+++ b/checkstyle/ComplexTypeUtils.hx
@@ -43,7 +43,7 @@ class ComplexTypeUtils {
 	public static function walkClass(d:Definition<ClassFlag, Array<Field>>, pos:Position, cb:ComplexTypeCallback) {
 		walkCommonDefinition(d, pos, cb);
 		for (f in d.flags) {
-			switch f {
+			switch(f) {
 				case HExtends(t) | HImplements(t): walkTypePath(t, d.name, pos, cb);
 				default:
 			}
@@ -64,7 +64,7 @@ class ComplexTypeUtils {
 	public static function walkAbstract(d:Definition<AbstractFlag, Array<Field>>, pos:Position, cb:ComplexTypeCallback) {
 		walkCommonDefinition(d, pos, cb);
 		for (f in d.flags) {
-			switch f {
+			switch(f) {
 				case AFromType(ct) | AToType(ct) | AIsType(ct): walkComplexType(ct, f.getName(), pos, cb);
 				default:
 			}

--- a/checkstyle/ExprUtils.hx
+++ b/checkstyle/ExprUtils.hx
@@ -9,7 +9,7 @@ import haxeparser.Data.EnumConstructor;
 import haxe.macro.Expr;
 
 class ExprUtils {
-	
+
 	public static function walkFile(file:{ pack: Array<String>, decls: Array<TypeDecl> }, cb:Expr -> Void) {
 		for (decl in file.decls) walkTypeDecl(decl, cb);
 	}
@@ -133,7 +133,7 @@ class ExprUtils {
 				if (e != null) walkExpr(e, cb);
 		}
 	}
-	
+
 	public static function walkComplexType(t:ComplexType, cb:Expr -> Void) {
 		switch(t){
 			case TPath(p): walkTypePath(p, cb);

--- a/checkstyle/ExprUtils.hx
+++ b/checkstyle/ExprUtils.hx
@@ -43,7 +43,7 @@ class ExprUtils {
 	public static function walkClass(d:Definition<ClassFlag, Array<Field>>, cb:Expr -> Void) {
 		walkCommonDefinition(d, cb);
 		for (f in d.flags) {
-			switch f {
+			switch(f) {
 				case HExtends(t) | HImplements(t): walkTypePath(t,cb);
 				default:
 			}
@@ -64,7 +64,7 @@ class ExprUtils {
 	public static function walkAbstract(d:Definition<AbstractFlag, Array<Field>>, cb:Expr -> Void) {
 		walkCommonDefinition(d, cb);
 		for (f in d.flags) {
-			switch f {
+			switch(f) {
 				case AFromType(ct) | AToType(ct) | AIsType(ct): walkComplexType(ct,cb);
 				default:
 			}

--- a/checkstyle/Report.hx
+++ b/checkstyle/Report.hx
@@ -23,7 +23,7 @@ class Report {
 		reportFile = File.write("CHECKS.md", false);
 		reportFile.writeString("###Report of default checks on CheckStyle library itself\n\n");
 		#end
-		
+
 		var errors = 0;
 		var warnings = 0;
 		var infos = 0;

--- a/checkstyle/checks/AnonymousCheck.hx
+++ b/checkstyle/checks/AnonymousCheck.hx
@@ -29,7 +29,7 @@ class AnonymousCheck extends Check {
 			}
 		}
 	}
-	
+
 	function checkField(f:Field) {
 		switch(f.kind) {
 			case FVar(TAnonymous(fields), val):
@@ -37,7 +37,7 @@ class AnonymousCheck extends Check {
 			default:
 		}
 	}
-	
+
 	function checkLocalVars() {
 		ExprUtils.walkFile(checker.ast, function(e) {
 			switch(e.expr){

--- a/checkstyle/checks/ArrayInstantiationCheck.hx
+++ b/checkstyle/checks/ArrayInstantiationCheck.hx
@@ -7,7 +7,7 @@ import haxeparser.Data.Token;
 @name("ArrayInstantiation")
 @desc("Checks if the array is instantiated using [], not with new")
 class ArrayInstantiationCheck extends Check {
-	
+
 	override function actualRun() {
 		ExprUtils.walkFile(checker.ast, function(e:Expr) {
 			switch(e.expr){

--- a/checkstyle/checks/BlockFormatCheck.hx
+++ b/checkstyle/checks/BlockFormatCheck.hx
@@ -5,7 +5,7 @@ import checkstyle.LintMessage.SeverityLevel;
 @name("BlockFormat")
 @desc("Checks empty blocks and first/last lines of a block")
 class BlockFormatCheck extends Check {
-	
+
 	public var emptyBlockCheck:Bool;
 
 	var firstLineRE:EReg;
@@ -20,6 +20,7 @@ class BlockFormatCheck extends Check {
 
 	override function actualRun() {
 		ExprUtils.walkFile(checker.ast, function(e) {
+			if (isPosSuppressed(e.pos)) return;
 			switch(e.expr){
 				case EBlock([]) | EObjectDecl([]):
 					if (emptyBlockCheck && e.pos.max - e.pos.min > "{}".length) {

--- a/checkstyle/checks/CyclomaticComplexityCheck.hx
+++ b/checkstyle/checks/CyclomaticComplexityCheck.hx
@@ -22,7 +22,7 @@ class CyclomaticComplexityCheck extends Check {
 			{ severity : "ERROR", complexity : 25 }
 		];
 	}
-	
+
 	override function actualRun() {
 		checker.ast.decls.map(function(type:TypeDecl):Null<Definition<ClassFlag, Array<Field>>> {
 			return switch (type.decl) {
@@ -33,7 +33,7 @@ class CyclomaticComplexityCheck extends Check {
 			return definition != null;
 		}).iter(checkFields);
 	}
-	
+
 	function checkFields(definition:Definition<ClassFlag, Array<Field>>) {
 		definition.data.map(function(field:Field):Null<Target> {
 			return switch (field.kind) {
@@ -46,7 +46,7 @@ class CyclomaticComplexityCheck extends Check {
 			return f != null;
 		}).iter(calculateComplexity);
 	}
-	
+
 	function calculateComplexity(method:Target) {
 		var complexity:Int = 1 + evaluateExpr(method.expr);
 
@@ -61,7 +61,7 @@ class CyclomaticComplexityCheck extends Check {
 
 	// This would not pass the cyclomatic complexity test.
 
-	@SuppressWarnings('checkstyle:CyclomaticComplexity')
+	@SuppressWarnings(['checkstyle:CyclomaticComplexity', 'checkstyle:LeftCurly'])
 	function evaluateExpr(e:Expr):Int {
 		if (e == null || e.expr == null) return 0;
 		return switch(e.expr) {

--- a/checkstyle/checks/ERegInstantiationCheck.hx
+++ b/checkstyle/checks/ERegInstantiationCheck.hx
@@ -13,6 +13,7 @@ class ERegInstantiationCheck extends Check {
 
 	override function actualRun() {
 		ExprUtils.walkFile(checker.ast, function(e) {
+			if (isPosSuppressed(e.pos)) return;
 			switch(e.expr){
 				case ENew(
 					{pack:[], name:"EReg"},

--- a/checkstyle/checks/EmptyBlockCheck.hx
+++ b/checkstyle/checks/EmptyBlockCheck.hx
@@ -7,39 +7,24 @@ import haxe.macro.Expr;
 @desc("Checks empty blocks / object declarations")
 class EmptyBlockCheck extends Check {
 
-	public static inline var BLOCK:String = "BLOCK";
-	public static inline var OBJECT_DECL:String = "OBJECT_DECL";
-
 	// require comment in empty block / object decl
 	public static inline var TEXT:String = "text";
 	// empty block / object decl can be empty or have comments
 	// if block has no comments, enforces {} notation
 	public static inline var EMPTY:String = "empty";
 
-	public var tokens:Array<String>;
 	public var option:String;
 
 	public function new() {
 		super();
-		tokens = [];
 		option = EMPTY;
-	}
-
-	function hasToken(token:String):Bool {
-		if (tokens.length == 0) return true;
-		if (tokens.indexOf(token) > -1) return true;
-		return false;
 	}
 
 	override function actualRun() {
 		ExprUtils.walkFile(checker.ast, function(e) {
 			if (isPosSuppressed(e.pos)) return;
 			switch(e.expr){
-				case EBlock([]):
-					if (!hasToken(BLOCK)) return;
-					checkEmptyBlock(e);
-				case EObjectDecl([]):
-					if (!hasToken(OBJECT_DECL)) return;
+				case EBlock([]) | EObjectDecl([]):
 					checkEmptyBlock(e);
 				default:
 			}

--- a/checkstyle/checks/EmptyBlockCheck.hx
+++ b/checkstyle/checks/EmptyBlockCheck.hx
@@ -1,0 +1,66 @@
+package checkstyle.checks;
+
+import checkstyle.LintMessage.SeverityLevel;
+import haxe.macro.Expr;
+
+@name("EmptyBlock")
+@desc("Checks empty blocks / object declarations")
+class EmptyBlockCheck extends Check {
+
+	public static inline var BLOCK:String = "BLOCK";
+	public static inline var OBJECT_DECL:String = "OBJECT_DECL";
+
+	// require comment in empty block / object decl
+	public static inline var TEXT:String = "text";
+	// empty block / object decl can be empty or have comments
+	// if block has no comments, enforces {} notation
+	public static inline var EMPTY:String = "empty";
+
+	public var tokens:Array<String>;
+	public var option:String;
+
+	public function new() {
+		super();
+		tokens = [];
+		option = EMPTY;
+	}
+
+	function hasToken(token:String):Bool {
+		if (tokens.length == 0) return true;
+		if (tokens.indexOf(token) > -1) return true;
+		return false;
+	}
+
+	override function actualRun() {
+		ExprUtils.walkFile(checker.ast, function(e) {
+			if (isPosSuppressed(e.pos)) return;
+			switch(e.expr){
+				case EBlock([]):
+					if (!hasToken(BLOCK)) return;
+					checkEmptyBlock(e);
+				case EObjectDecl([]):
+					if (!hasToken(OBJECT_DECL)) return;
+					checkEmptyBlock(e);
+				default:
+			}
+		});
+	}
+
+	function checkEmptyBlock(e:Expr) {
+		if ((e == null) || (e.expr == null)) return;
+
+		var block:String = checker.file.content.substring(e.pos.min, e.pos.max);
+		var containsOnlyWS:Bool = (~/\{\s+\}/m.match(block));
+		var containsText:Bool = (~/\{\s*\S.*\S\s*\}/m.match(block));
+
+		if (option == TEXT) {
+			if (!containsText) {
+				logPos("Empty block should contain a comment", e.pos, Reflect.field(SeverityLevel, severity));
+			}
+			return;
+		}
+		if (containsOnlyWS) {
+			logPos("Empty block should be written as {}", e.pos, Reflect.field(SeverityLevel, severity));
+		}
+	}
+}

--- a/checkstyle/checks/LeftCurlyCheck.hx
+++ b/checkstyle/checks/LeftCurlyCheck.hx
@@ -197,10 +197,12 @@ class LeftCurlyCheck extends Check {
 	@SuppressWarnings("checkstyle:BlockFormat")
 	function checkLeftCurly(line:String, pos:Position) {
 		var lineLength:Int = line.length;
-		line = StringTools.trim(line);
 
-		var curlyAtEOL:Bool = ~/^.+\{\}?([ \t]*|[ \t]*\/\/.*)$/.match(line);
-		var curlyOnNL:Bool = ~/^\{\}?/.match(line);
+		// must have at least one non whitespace character before curly
+		// and only whitespace, } or // + comment after curly
+		var curlyAtEOL:Bool = ~/^\s*\S.*\{\}?\s*(|\/\/.*)$/.match(line);
+		// must have only whitespace before curly
+		var curlyOnNL:Bool = ~/^\s*\{\}?/.match(line);
 
 		try {
 			if (curlyAtEOL) {

--- a/checkstyle/checks/LeftCurlyCheck.hx
+++ b/checkstyle/checks/LeftCurlyCheck.hx
@@ -102,6 +102,7 @@ class LeftCurlyCheck extends Check {
 			if (isCheckSuppressed(field)) return;
 			switch (field.kind) {
 				case FFun(f):
+					if (!hasToken(FUNCTION)) return;
 					checkBlocks(f.expr);
 				default:
 			}
@@ -115,6 +116,7 @@ class LeftCurlyCheck extends Check {
 			if (firstPos == null) {
 				if (pos != td.pos) firstPos = pos;
 			}
+			if (!hasToken(OBJECT_DECL)) return;
 			switch(t) {
 				case TAnonymous(_):
 					checkLinesBetween(pos.min, pos.max, pos);
@@ -224,13 +226,14 @@ class LeftCurlyCheck extends Check {
 
 		try {
 			if (curlyAtEOL) {
-				logErrorIf ((option == NL), 'Left curly should be on new line', pos);
+				logErrorIf ((option == NL), 'Left curly should be on new line (only whitespace before curly)', pos);
 				logErrorIf ((lineLength > maxLineLength), 'Left curly placement exceeds ${maxLineLength} character limit', pos);
 				logErrorIf ((option != EOL), 'Left curly unknown option ${option}', pos);
 				return;
 			}
-			logErrorIf ((option == EOL), 'Left curly should be at EOL', pos);
-			logErrorIf ((!curlyOnNL), 'Left curly should be on NL', pos);
+			logErrorIf ((option == EOL), 'Left curly should be at EOL (only linebreak or comment after curly)', pos);
+			logErrorIf ((lineLength > maxLineLength), 'Left curly placement exceeds ${maxLineLength} character limit', pos);
+			logErrorIf ((!curlyOnNL), 'Left curly should be on new line (only whitespace before curly)', pos);
 			logErrorIf ((option != NL), 'Left curly unknown option ${option}', pos);
 		}
 		catch (e:String) {

--- a/checkstyle/checks/LeftCurlyCheck.hx
+++ b/checkstyle/checks/LeftCurlyCheck.hx
@@ -176,8 +176,6 @@ class LeftCurlyCheck extends Check {
 		if ((e == null) || (e.expr == null)) return;
 
 		switch(e.expr) {
-			case EBlock([]):
-				checkEmptyBlock(e);
 			case EBlock(_):
 				var linePos:LinePos = checker.getLinePos(e.pos.min);
 				var line:String = checker.lines[linePos.line];
@@ -194,26 +192,6 @@ class LeftCurlyCheck extends Check {
 		var lineNum:Int = checker.getLinePos(bracePos).line;
 		var line:String = checker.lines[lineNum];
 		checkLeftCurly(line, pos);
-	}
-
-	function checkEmptyBlock(e:Expr) {
-		if ((e == null) || (e.expr == null)) return;
-
-		var lineMin:Int = checker.getLinePos(e.pos.min).line;
-		var lineMax:Int = checker.getLinePos(e.pos.max).line;
-		if (lineMin != lineMax) {
-			var block:String = "";
-			for (lineIndex in lineMin...(lineMax + 1)) {
-				block += StringTools.trim(checker.lines[lineIndex]);
-			}
-			if (~/.*\{\}($|[ \t]*\/\/.*$)/.match(block)) {
-				logPos("Empty block should be written as {}", e.pos, Reflect.field(SeverityLevel, severity));
-			}
-		}
-
-		var linePos:LinePos = checker.getLinePos(e.pos.min);
-		var line:String = checker.lines[linePos.line];
-		checkLeftCurly(line, e.pos);
 	}
 
 	@SuppressWarnings("checkstyle:BlockFormat")

--- a/checkstyle/checks/LeftCurlyCheck.hx
+++ b/checkstyle/checks/LeftCurlyCheck.hx
@@ -1,0 +1,246 @@
+package checkstyle.checks;
+
+import checkstyle.Checker.LinePos;
+import checkstyle.LintMessage.SeverityLevel;
+import haxeparser.Data;
+import haxe.macro.Expr;
+
+@name("LeftCurly")
+@desc("Checks for placement of left curly braces")
+class LeftCurlyCheck extends Check {
+
+	public static inline var CLASS_DEF:String = "CLASS_DEF";
+	public static inline var ENUM_DEF:String = "ENUM_DEF";
+	public static inline var ABSTRACT_DEF:String = "ABSTRACT_DEF";
+	public static inline var TYPEDEF_DEF:String = "TYPEDEF_DEF";
+	public static inline var INTERFACE_DEF:String = "INTERFACE_DEF";
+
+	public static inline var OBJECT_DECL:String = "OBJECT_DECL";
+	public static inline var FUNCTION:String = "FUNCTION";
+	public static inline var FOR:String = "FOR";
+	public static inline var IF:String = "IF";
+	public static inline var ELSE_IF:String = "ELSE_IF";
+	public static inline var WHILE:String = "WHILE";
+	public static inline var SWITCH:String = "SWITCH";
+	public static inline var TRY:String = "TRY";
+	public static inline var CATCH:String = "CATCH";
+
+	public static inline var EOL:String = "eol";
+	public static inline var NL:String = "nl";
+	public static inline var INLINE:String = "inline";
+
+	public var tokens:Array<String>;
+	public var option:String;
+	public var maxLineLength:Int;
+
+	public function new() {
+		super();
+		tokens = [
+			CLASS_DEF,
+			ENUM_DEF,
+			ABSTRACT_DEF,
+			TYPEDEF_DEF,
+			INTERFACE_DEF,
+			FUNCTION,
+			FOR,
+			IF,
+			ELSE_IF,
+			WHILE,
+			SWITCH,
+			TRY,
+			CATCH
+		];
+		option = EOL;
+		maxLineLength = 120;
+	}
+
+	function hasToken(token:String):Bool {
+		if (tokens.length == 0) return true;
+		if (tokens.indexOf (token) > -1) return true;
+		return false;
+	}
+
+	override function actualRun() {
+		walkDecl();
+		walkFile();
+	}
+
+	function walkDecl() {
+
+		for (td in checker.ast.decls) {
+			switch (td.decl) {
+				case EClass (d):
+					for (field in d.data) {
+						switch (field.kind) {
+							case FFun(f):
+								checkBlocks(f.expr);
+							default:
+						}
+					}
+					if (d.flags.indexOf(HInterface) > -1 && !hasToken(INTERFACE_DEF)) return;
+					if (d.flags.indexOf(HInterface) < 0 && !hasToken(CLASS_DEF)) return;
+					if (d.data.length == 0) {
+						checkLinesBetween(td.pos.min, td.pos.max, td.pos);
+						return;
+					}
+					checkLinesBetween(td.pos.min, d.data[0].pos.min, td.pos);
+				case EEnum (d):
+					if (!hasToken(ENUM_DEF)) return;
+					if (d.data.length == 0) {
+						checkLinesBetween(td.pos.min, td.pos.max, td.pos);
+						return;
+					}
+					checkLinesBetween(td.pos.min, d.data[0].pos.min, td.pos);
+				case EAbstract (d):
+					for (field in d.data) {
+						switch (field.kind) {
+							case FFun(f):
+								checkBlocks(f.expr);
+							default:
+						}
+					}
+					if (!hasToken(ABSTRACT_DEF)) return;
+					if (d.data.length == 0) {
+						checkLinesBetween(td.pos.min, td.pos.max, td.pos);
+						return;
+					}
+					checkLinesBetween(td.pos.min, d.data[0].pos.min, td.pos);
+				case ETypedef (d):
+					if (!hasToken(TYPEDEF_DEF)) return;
+					// TODO handling of typedefs
+					//checkLinesBetween(td.pos.min, td.pos.max, td.pos);
+				default:
+			}
+		}
+	}
+
+	//function checkTypedef(d:ComplexType, pos:Position) {
+	//    switch(d) {
+	//        case TAnonymous(fields):
+	//            for (field in fields) {
+	//                //checkBlocks(field.expr);
+	//            }
+	//        default:
+	//    }
+	//}
+
+	function walkFile() {
+		ExprUtils.walkFile(checker.ast, function(e) {
+			if (isPosSuppressed(e.pos)) return;
+			switch(e.expr) {
+				case EObjectDecl (fields):
+					if (!hasToken(OBJECT_DECL)) return;
+					var linePos:LinePos = checker.getLinePos(e.pos.min);
+					var line:String = checker.lines[linePos.line];
+					checkLeftCurly(line, e.pos);
+				case EFunction (_, f):
+					if (!hasToken(FUNCTION)) return;
+					checkBlocks(f.expr);
+				case EFor (it, expr):
+					if (!hasToken(FOR)) return;
+					checkBlocks(expr);
+				case EIf(econd, eif, eelse):
+					if (!hasToken(IF)) return;
+					checkBlocks(eif);
+					checkBlocks(eelse);
+				case EWhile(econd, expr, _):
+					if (!hasToken(WHILE)) return;
+					checkBlocks(expr);
+				case ESwitch(expr, cases, edef):
+					if (!hasToken(SWITCH)) return;
+					var firstCase:Expr = edef;
+					if (cases.length > 0) {
+						firstCase = cases[0].expr;
+					}
+					if (firstCase == null) {
+						checkLinesBetween(e.pos.min, e.pos.max, e.pos);
+						return;
+					}
+					checkLinesBetween(expr.pos.max, firstCase.pos.min, e.pos);
+				case ETry(expr, catches):
+					if (!hasToken(TRY)) return;
+					checkBlocks(expr);
+					for (ecatch in catches) {
+						checkBlocks(ecatch.expr);
+					}
+				default:
+			}
+		});
+	}
+
+	function checkBlocks(e:Expr) {
+		if ((e == null) || (e.expr == null)) return;
+
+		switch (e.expr) {
+			case EBlock([]):
+				checkEmptyBlock(e);
+			case EBlock(_):
+				var linePos:LinePos = checker.getLinePos(e.pos.min);
+				var line:String = checker.lines[linePos.line];
+				checkLeftCurly(line, e.pos);
+			default:
+		}
+	}
+
+	function checkLinesBetween(min:Int, max:Int, pos:Position) {
+
+		var bracePos:Int = checker.file.content.lastIndexOf("{", max);
+		if (bracePos < 0 || bracePos < min) return;
+
+		var lineNum:Int = checker.getLinePos(bracePos).line;
+		var line:String = checker.lines[lineNum];
+		checkLeftCurly(line, pos);
+	}
+
+	function checkEmptyBlock(e:Expr) {
+		if ((e == null) || (e.expr == null)) return;
+
+		var lineMin:Int = checker.getLinePos(e.pos.min).line;
+		var lineMax:Int = checker.getLinePos(e.pos.max).line;
+		if (lineMin != lineMax) {
+			var block:String = "";
+			for (lineIndex in lineMin...(lineMax + 1)) {
+				block += StringTools.trim(checker.lines[lineIndex]);
+			}
+			if (~/.*\{\}($|[ \t]*\/\/.*$)/.match(block)) {
+				logPos("Empty block should be written as {}", e.pos, Reflect.field(SeverityLevel, severity));
+			}
+		}
+
+		var linePos:LinePos = checker.getLinePos(e.pos.min);
+		var line:String = checker.lines[linePos.line];
+		checkLeftCurly(line, e.pos);
+	}
+
+	function checkLeftCurly(line:String, pos:Position) {
+		var lineLength:Int = line.length;
+		line = StringTools.trim(line);
+
+		var curlyAtEOL:Bool = ~/^.+\{\}?([ \t]*|[ \t]*\/\/.*)$/.match(line);
+		var curlyOnNL:Bool = ~/^\{\}?/.match(line);
+
+		try {
+			if (curlyAtEOL) {
+				logErrorIf ((option == NL), 'Left curly should be on new line', pos);
+				logErrorIf ((lineLength > maxLineLength), 'Left curly placement exceeds ${maxLineLength} character limit', pos);
+				if (option == INLINE) return;
+				logErrorIf ((option != EOL), 'Left curly unknown option ${option}', pos);
+				return;
+			}
+			logErrorIf ((option == EOL), 'Left curly should be at EOL', pos);
+			logErrorIf ((option == INLINE), 'Left curly should be on same line', pos);
+			logErrorIf (!curlyOnNL, 'Left curly should be on NL', pos);
+			logErrorIf ((option != NL), 'Left curly unknown option ${option}', pos);
+		}
+		catch (e:String) {
+			// return
+		}
+	}
+
+	function logErrorIf(condition:Bool, msg:String, pos:Position) {
+		if (condition) {
+			logPos(msg, pos, Reflect.field(SeverityLevel, severity));
+			throw "exit";
+		}
+	}
+}

--- a/checkstyle/checks/LeftCurlyCheck.hx
+++ b/checkstyle/checks/LeftCurlyCheck.hx
@@ -212,7 +212,6 @@ class LeftCurlyCheck extends Check {
 				return;
 			}
 			logErrorIf ((option == EOL), 'Left curly should be at EOL (only linebreak or comment after curly)', pos);
-			logErrorIf ((lineLength > maxLineLength), 'Left curly placement exceeds ${maxLineLength} character limit', pos);
 			logErrorIf ((!curlyOnNL), 'Left curly should be on new line (only whitespace before curly)', pos);
 			logErrorIf ((option != NL), 'Left curly unknown option ${option}', pos);
 		}

--- a/checkstyle/checks/MemberNameCheck.hx
+++ b/checkstyle/checks/MemberNameCheck.hx
@@ -32,7 +32,7 @@ class MemberNameCheck extends NameCheckBase {
 	override function checkAbstractType(d:Definition<AbstractFlag, Array<Field>>, pos:Position) {
 		checkFields(d.data);
 	}
-	
+
 	override function checkTypedefType(d:Definition<EnumFlag, ComplexType>, pos:Position) {
 		if (!hasToken(TYPEDEF)) return;
 		if (ignoreExtern && (d.flags.indexOf(EExtern) > -1)) return;

--- a/checkstyle/checks/MethodNameCheck.hx
+++ b/checkstyle/checks/MethodNameCheck.hx
@@ -30,7 +30,7 @@ class MethodNameCheck extends NameCheckBase {
 	override function checkAbstractType(d:Definition<AbstractFlag, Array<Field>>, pos:Position) {
 		checkFields(d.data);
 	}
-	
+
 	override function checkTypedefType(d:Definition<EnumFlag, ComplexType>, pos:Position) {
 		if (ignoreExtern && (d.flags.indexOf(EExtern) > -1)) return;
 

--- a/checkstyle/checks/NameCheckBase.hx
+++ b/checkstyle/checks/NameCheckBase.hx
@@ -6,7 +6,7 @@ import haxe.macro.Expr;
 
 @ignore("Base class for name checks")
 class NameCheckBase extends Check {
-	
+
 	public var format:String;
 	public var tokens:Array<String>;
 	public var ignoreExtern:Bool;

--- a/checkstyle/checks/NestedIfDepthCheck.hx
+++ b/checkstyle/checks/NestedIfDepthCheck.hx
@@ -7,7 +7,7 @@ import haxe.macro.Expr;
 @name("NestedIfDepth")
 @desc("Max number of nested if-else blocks (default 1)")
 class NestedIfDepthCheck extends Check {
-	
+
 	public var max:Int;
 
 	public function new() {

--- a/checkstyle/checks/NestedTryDepthCheck.hx
+++ b/checkstyle/checks/NestedTryDepthCheck.hx
@@ -7,7 +7,7 @@ import haxe.macro.Expr;
 @name("NestedTryDepth")
 @desc("Max number of nested try blocks (default 1)")
 class NestedTryDepthCheck extends Check {
-	
+
 	public var max:Int;
 
 	public function new() {

--- a/checkstyle/checks/ParameterNumberCheck.hx
+++ b/checkstyle/checks/ParameterNumberCheck.hx
@@ -7,7 +7,7 @@ import haxe.macro.Expr;
 @name("ParameterNumber")
 @desc("Max number of parameters per method (default 7)")
 class ParameterNumberCheck extends Check {
-	
+
 	public var max:Int;
 	public var ignoreOverriddenMethods:Bool;
 

--- a/checkstyle/checks/PublicPrivateCheck.hx
+++ b/checkstyle/checks/PublicPrivateCheck.hx
@@ -7,7 +7,7 @@ import haxe.macro.Expr;
 @name("PublicPrivate")
 @desc("Check for explicit use of private in classes and public in interfaces/externs")
 class PublicPrivateCheck extends Check {
-	
+
 	public var enforcePublicPrivate:Bool;
 
 	public function new() {

--- a/checkstyle/checks/ReturnCheck.hx
+++ b/checkstyle/checks/ReturnCheck.hx
@@ -35,7 +35,7 @@ class ReturnCheck extends Check {
 			if (field.name != "new" && d.flags.indexOf(HInterface) == -1) checkField(field);
 		}
 	}
-	
+
 	function checkField(f:Field) {
 		var noReturn = false;
 		switch(f.kind) {

--- a/checkstyle/checks/SpacingCheck.hx
+++ b/checkstyle/checks/SpacingCheck.hx
@@ -32,7 +32,7 @@ class SpacingCheck extends Check {
 				return;
 			}
 
-			switch e.expr {
+			switch(e.expr) {
 				case EBinop(bo, l, r) if (spaceAroundBinop):
 					if (ignoreRangeOperator && binopString(bo) == "...") return;
 					if (r.pos.min - l.pos.max < binopSize(bo) + 2) logPos('No space around ${binopString(bo)}', e.pos, Reflect.field(SeverityLevel, severity));

--- a/checkstyle/checks/TODOCommentCheck.hx
+++ b/checkstyle/checks/TODOCommentCheck.hx
@@ -10,7 +10,7 @@ class TODOCommentCheck extends Check {
 	override function actualRun() {
 		var re = ~/TODO|FIXME/;
 		for (tk in checker.tokens) {
-			switch tk.tok {
+			switch(tk.tok) {
 				case Comment(s) | CommentLine(s):
 					var lp = checker.getLinePos(tk.pos.min);
 					if (re.match(s)) log('TODO comment:' + s, lp.line + 1, lp.ofs + 1, Reflect.field(SeverityLevel, severity));

--- a/checkstyle/checks/TrailingWhitespaceCheck.hx
+++ b/checkstyle/checks/TrailingWhitespaceCheck.hx
@@ -8,7 +8,7 @@ import haxeparser.Data.Token;
 class TrailingWhitespaceCheck extends Check {
 
 	override function actualRun() {
-		var re = ~/\S\s+$/;
+		var re = ~/\s+$/;
 		for (i in 0 ... checker.lines.length) {
 			var line = checker.lines[i];
 			if (re.match(line)) log('Trailing whitespace', i + 1, line.length, Reflect.field(SeverityLevel, severity));

--- a/resources/config.json
+++ b/resources/config.json
@@ -90,6 +90,28 @@
 			}
 		},
 		{
+			"type": "LeftCurly",
+			"props": {
+				"severity": "WARNING",
+				"option": "eol",
+				"tokens": [
+					"CLASS_DEF",
+					"ENUM_DEF",
+					"ABSTRACT_DEF",
+					"TYPEDEF_DEF",
+					"CLASS_DEF",
+					"INTERFACE_DEF",
+					"FUNCTION",
+					"FOR",
+					"IF",
+					"WHILE",
+					"SWITCH",
+					"TRY",
+					"CATCH"
+				]
+			}
+		},
+		{
 			"type": "LineLength",
 			"props": {
 				"severity": "ERROR",

--- a/resources/config.json
+++ b/resources/config.json
@@ -57,6 +57,14 @@
 			}
 		},
 		{
+			"type": "EmptyBlock",
+			"props": {
+				"severity": "ERROR",
+				"option": "empty",
+				"tokens": []
+			}
+		},
+		{
 			"type": "EmptyLines",
 			"props": {
 				"severity": "INFO",

--- a/resources/config.json
+++ b/resources/config.json
@@ -60,8 +60,7 @@
 			"type": "EmptyBlock",
 			"props": {
 				"severity": "ERROR",
-				"option": "empty",
-				"tokens": []
+				"option": "empty"
 			}
 		},
 		{

--- a/test/EmptyBlockCheckTest.hx
+++ b/test/EmptyBlockCheckTest.hx
@@ -1,0 +1,84 @@
+package ;
+
+import checkstyle.checks.EmptyBlockCheck;
+
+class EmptyBlockCheckTest extends CheckTestCase {
+
+	public function testCorrectEmptyBlock() {
+		var check = new EmptyBlockCheck ();
+		assertMsg(check, EmptyBlockTests.TEST, '');
+		assertMsg(check, EmptyBlockTests.TEST2, '');
+		assertMsg(check, EmptyBlockTests.TEST3, '');
+		assertMsg(check, EmptyBlockTests.TEST5, '');
+	}
+
+	public function testWrongEmptyBlock() {
+		var check = new EmptyBlockCheck ();
+		assertMsg(check, EmptyBlockTests.TEST1, 'Empty block should be written as {}');
+		assertMsg(check, EmptyBlockTests.TEST4, 'Empty block should be written as {}');
+		assertMsg(check, EmptyBlockTests.TEST6, 'Empty block should be written as {}');
+	}
+
+	public function testOptionText () {
+		var check = new EmptyBlockCheck ();
+		check.option = EmptyBlockCheck.TEXT;
+
+		assertMsg(check, EmptyBlockTests.TEST, 'Empty block should contain a comment');
+		assertMsg(check, EmptyBlockTests.TEST1, 'Empty block should contain a comment');
+		assertMsg(check, EmptyBlockTests.TEST2, '');
+		assertMsg(check, EmptyBlockTests.TEST3, 'Empty block should contain a comment');
+		assertMsg(check, EmptyBlockTests.TEST4, 'Empty block should contain a comment');
+		assertMsg(check, EmptyBlockTests.TEST5, '');
+	}
+}
+
+class EmptyBlockTests {
+	public static inline var TEST:String = "
+	class Test {
+		public function new() {}
+	}";
+
+	public static inline var TEST1:String = "
+	class Test {
+		public function new(){
+
+		}
+	}";
+
+	public static inline var TEST2:String =
+	"class Test {
+		public function new() {
+			// comment
+		}
+	}";
+
+	public static inline var TEST3:String =
+	"class Test {
+		public function new() {
+			var a = {};
+		}
+	}";
+
+	public static inline var TEST4:String = "
+	class Test {
+		public function new() {
+			var a = {
+			};
+		}
+	}";
+
+	public static inline var TEST5:String = "
+	class Test {
+		public function new() {
+			var a = {
+				// comment
+			};
+		}
+	}";
+
+	public static inline var TEST6:String = "
+	class Test {
+		public function new() {
+		}
+	}";
+}

--- a/test/LeftCurlyCheckTest.hx
+++ b/test/LeftCurlyCheckTest.hx
@@ -1,0 +1,234 @@
+package ;
+
+import checkstyle.checks.LeftCurlyCheck;
+
+class LeftCurlyCheckTest extends CheckTestCase {
+
+	public function testCorrectBraces() {
+		var check = new LeftCurlyCheck ();
+		assertMsg(check, LeftCurlyTests.TEST, '');
+		assertMsg(check, LeftCurlyTests.TEST4, '');
+		assertMsg(check, LeftCurlyTests.TEST6, '');
+		assertMsg(check, LeftCurlyTests.TEST8, '');
+		assertMsg(check, LeftCurlyTests.TEST9, '');
+		assertMsg(check, LeftCurlyTests.TEST14, '');
+	}
+
+	public function testWrongBraces() {
+		var check = new LeftCurlyCheck ();
+		assertMsg(check, LeftCurlyTests.TEST1, 'Left curly should be at EOL (only linebreak or comment after curly)');
+		assertMsg(check, LeftCurlyTests.TEST2, 'Left curly should be at EOL (only linebreak or comment after curly)');
+		assertMsg(check, LeftCurlyTests.TEST3, 'Left curly should be at EOL (only linebreak or comment after curly)');
+		assertMsg(check, LeftCurlyTests.TEST3, 'Left curly should be at EOL (only linebreak or comment after curly)');
+		assertMsg(check, LeftCurlyTests.TEST5, 'Left curly should be at EOL (only linebreak or comment after curly)');
+		assertMsg(check, LeftCurlyTests.TEST7, 'Left curly should be at EOL (only linebreak or comment after curly)');
+		assertMsg(check, LeftCurlyTests.TEST10, 'Left curly should be at EOL (only linebreak or comment after curly)');
+		assertMsg(check, LeftCurlyTests.TEST11, 'Left curly placement exceeds 120 character limit');
+	}
+
+	public function testBraceOnNL() {
+		var check = new LeftCurlyCheck ();
+		check.option = LeftCurlyCheck.NL;
+
+		assertMsg(check, LeftCurlyTests.TEST, 'Left curly should be on new line (only whitespace before curly)');
+		assertMsg(check, LeftCurlyTests.TEST13, '');
+
+		check.tokens = [LeftCurlyCheck.OBJECT_DECL];
+		assertMsg(check, LeftCurlyTests.TEST4, 'Left curly should be on new line (only whitespace before curly)');
+		assertMsg(check, LeftCurlyTests.TEST14, 'Left curly should be on new line (only whitespace before curly)');
+
+		check.tokens = [LeftCurlyCheck.IF];
+		assertMsg(check, LeftCurlyTests.TEST1, '');
+		assertMsg(check, LeftCurlyTests.TEST13, '');
+
+		check.tokens = [LeftCurlyCheck.FOR];
+		assertMsg(check, LeftCurlyTests.TEST5, '');
+		assertMsg(check, LeftCurlyTests.TEST13, '');
+
+		check.tokens = [LeftCurlyCheck.FUNCTION];
+		assertMsg(check, LeftCurlyTests.TEST13, '');
+	}
+}
+
+class LeftCurlyTests {
+	public static inline var TEST:String = "
+	class Test {
+		function test() {
+			if (true) {
+				return;
+			}
+
+			if (true) return;
+			else {
+				return;
+			}
+
+			if (true) { // comment
+				return;
+			}
+			else if (false) {
+				return;
+			}
+
+			for (i in 0...10) {
+				return i;
+			}
+
+			while (true) {
+				return;
+			}
+		}
+		@SuppressWarnings('checkstyle:LeftCurly')
+		function test1()
+		{
+			if (true)
+			{
+				return;
+			}
+
+			for (i in 0...10)
+			{
+				return i;
+			}
+
+			while (true)
+			{
+				return;
+			}
+		}
+	}";
+
+	public static inline var TEST1:String = "
+	class Test {
+		function test() {
+			if (true)
+			{
+				return;
+			}
+		}
+	}";
+
+	public static inline var TEST2:String = "
+	class Test {
+		function test() {
+			if (true)
+			{ // comment
+				return;
+			}
+			else
+				return;
+		}
+	}";
+
+	public static inline var TEST3:String = "
+	class Test {
+		function test()
+		{
+			if (true) {
+				return;
+			}
+			else {
+				return;
+			}
+		}
+	}";
+
+	public static inline var TEST4:String = "
+	class Test {
+		function test() {
+			if (true) return { x:1,
+				y:2,
+				z:3 };
+		}
+	}";
+
+	public static inline var TEST5:String = "
+	class Test {
+		function test() {
+			for (i in 0...10)
+			{
+				return i;
+			}
+		}
+	}";
+
+	public static inline var TEST6:String = "
+	class Test {
+		function test() {
+			for (i in 0...10) if (i < 5) {
+				return i;
+			}
+		}
+	}";
+
+	public static inline var TEST7:String = "
+	class Test {
+		function test() {
+			while (true) { return i; }
+		}
+	}";
+
+	public static inline var TEST8:String = "
+	class Test {
+		function test() {
+			while (true) {
+				return i;
+			}
+		}
+	}";
+
+	public static inline var TEST9:String = "
+	class Test {
+		function test() {
+			for (i in 0....10) return i;
+		}
+	}";
+
+	public static inline var TEST10:String = "
+	class Test
+	{
+		function test() {
+			if (true) return;
+		}
+	}";
+
+	public static inline var TEST11:String = "
+	class Test {
+		function test():Array<Array<Array<Array<Array<Array<Array<Array<Array<Array<Array<Array<Array<Array<Array<String>>>>>>>>>>>>>>> {
+		}
+	}";
+
+	public static inline var TEST12:String = "
+	class Test {
+		function test() {
+			var struct = {x:10, y:10, z:20};
+		}
+	}";
+
+	public static inline var TEST13:String = "
+	class Test
+	{
+		function test()
+		{
+			if (true)
+			{ // comment
+				return;
+			}
+			else
+			{
+				if (false)
+				{
+					return;
+				}
+			}
+		}
+	}";
+
+	public static inline var TEST14:String = "
+	typedef Test = {
+		x:Int,
+		y:Int,
+		z:Int,
+		point:{x:Int, y:Int, z:Int}
+	}";
+}

--- a/test/TestMain.hx
+++ b/test/TestMain.hx
@@ -14,6 +14,7 @@ class TestMain {
 		runner.add(new FileLengthCheckTest());
 		runner.add(new HexadecimalLiteralsCheckTest());
 		runner.add(new IndentationCharacterCheckTest());
+		runner.add(new LeftCurlyCheckTest());
 		runner.add(new LineLengthCheckTest());
 		runner.add(new ListenerNameCheckTest());
 		runner.add(new LocalVariableNameCheckTest());

--- a/test/TestMain.hx
+++ b/test/TestMain.hx
@@ -9,6 +9,7 @@ class TestMain {
 		runner.add(new BlockFormatCheckTest());
 		runner.add(new ConstantNameCheckTest());
 		runner.add(new DynamicCheckTest());
+		runner.add(new EmptyBlockCheckTest());
 		runner.add(new EmptyLinesCheckTest());
 		runner.add(new ERegInstantiationCheckTest());
 		runner.add(new FileLengthCheckTest());


### PR DESCRIPTION
- LeftCurlyCheck checks placement of left curly braces - supports eol and newline 
- EmptyBlockCheck checks empty blocks - takes comments into account

Turns out it is not a simple task to get to all the places that can have a curly brace, I hope I have managed to get all of them. It supports two modes:
- `option=eol` – must have at least one non whitespace character before curly and only whitespace, } and/or // + comment after curly
- `option=nl` – must have only whitespace before curly
  There is no `nlow` (newline on wrap) option, because currently there is no wrap detection. 

I have added a @SuppressWarnings exception to CyclomaticComplexityCheck, because there are some one liner Lambda functions that would trigger a LeftCurly error.

Empty BlockCheck has two modes:
- `text` – empty blocks must have a comment inside
- `empty` – can have a comment inside, enforces {} notation when no comment is present

Both checks replace the simple checks in BlockFormatCheck, but offer more customisation options. A RigthCurlyCheck is missing, so it is not a full replacement of BlockFormatCheck.
