### PR TITLE
added support for nlow to LeftCurlyCheck

### DIFF
--- a/checkstyle/checks/LeftCurlyCheck.hx
+++ b/checkstyle/checks/LeftCurlyCheck.hx
@@ -26,6 +26,7 @@ class LeftCurlyCheck extends Check {
 
 	public static inline var EOL:String = "eol";
 	public static inline var NL:String = "nl";
+	public static inline var NLOW:String = "nlow";
 
 	public var tokens:Array<String>;
 	public var option:String;
@@ -101,7 +102,7 @@ class LeftCurlyCheck extends Check {
 			switch (field.kind) {
 				case FFun(f):
 					if (!hasToken(FUNCTION)) return;
-					checkBlocks(f.expr);
+					checkBlocks(f.expr, isFieldWrapped(field));
 				default:
 			}
 		}
@@ -140,14 +141,14 @@ class LeftCurlyCheck extends Check {
 					checkBlocks(f.expr);
 				case EFor(it, expr):
 					if (!hasToken(FOR)) return;
-					checkBlocks(expr);
+					checkBlocks(expr, isWrapped(it));
 				case EIf(econd, eif, eelse):
 					if (!hasToken(IF)) return;
-					checkBlocks(eif);
+					checkBlocks(eif, isWrapped(econd));
 					checkBlocks(eelse);
 				case EWhile(econd, expr, _):
 					if (!hasToken(WHILE)) return;
-					checkBlocks(expr);
+					checkBlocks(expr, isWrapped(econd));
 				case ESwitch(expr, cases, edef):
 					if (!hasToken(SWITCH)) return;
 					var firstCase:Expr = edef;
@@ -155,10 +156,10 @@ class LeftCurlyCheck extends Check {
 						firstCase = cases[0].values[0];
 					}
 					if (firstCase == null) {
-						checkLinesBetween(e.pos.min, e.pos.max, e.pos);
+						checkLinesBetween(e.pos.min, e.pos.max, isWrapped(expr), e.pos);
 						return;
 					}
-					checkLinesBetween(expr.pos.max, firstCase.pos.min, e.pos);
+					checkLinesBetween(expr.pos.max, firstCase.pos.min, isWrapped(expr), e.pos);
 				case ETry(expr, catches):
 					if (!hasToken(TRY)) return;
 					checkBlocks(expr);
@@ -170,30 +171,53 @@ class LeftCurlyCheck extends Check {
 		});
 	}
 
-	function checkBlocks(e:Expr) {
+	function isFieldWrapped(field:Field):Bool {
+		var pos1:Int = field.pos.min;
+		var pos2:Int = pos1;
+		switch (field.kind) {
+			case FFun(f):
+				if (f.expr == null) {
+					return false;
+				}
+				pos2 = f.expr.pos.min;
+			default:
+				return false;
+		}
+
+		var functionDef:String = checker.file.content.substring(pos1, pos2);
+		return (functionDef.indexOf('\n') >= 0) ||
+				(functionDef.indexOf('\r') >= 0);
+	}
+
+	function isWrapped(e:Expr):Bool {
+		if (e == null) return false;
+		return (checker.getLinePos(e.pos.min).line != checker.getLinePos(e.pos.max).line);
+	}
+
+	function checkBlocks(e:Expr, wrapped:Bool = false) {
 		if ((e == null) || (e.expr == null)) return;
 
 		switch(e.expr) {
 			case EBlock(_):
 				var linePos:LinePos = checker.getLinePos(e.pos.min);
 				var line:String = checker.lines[linePos.line];
-				checkLeftCurly(line, e.pos);
+				checkLeftCurly(line, wrapped, e.pos);
 			default:
 		}
 	}
 
-	function checkLinesBetween(min:Int, max:Int, pos:Position) {
+	function checkLinesBetween(min:Int, max:Int, wrapped:Bool = false, pos:Position) {
 		if (isPosSuppressed(pos)) return;
 		var bracePos:Int = checker.file.content.lastIndexOf("{", max);
 		if (bracePos < 0 || bracePos < min) return;
 
 		var lineNum:Int = checker.getLinePos(bracePos).line;
 		var line:String = checker.lines[lineNum];
-		checkLeftCurly(line, pos);
+		checkLeftCurly(line, wrapped, pos);
 	}
 
 	@SuppressWarnings("checkstyle:BlockFormat")
-	function checkLeftCurly(line:String, pos:Position) {
+	function checkLeftCurly(line:String, wrapped:Bool = false, pos:Position) {
 		var lineLength:Int = line.length;
 
 		// must have at least one non whitespace character before curly
@@ -205,12 +229,14 @@ class LeftCurlyCheck extends Check {
 		try {
 			if (curlyAtEOL) {
 				logErrorIf ((option == NL), 'Left curly should be on new line (only whitespace before curly)', pos);
-				logErrorIf ((option != EOL), 'Left curly unknown option ${option}', pos);
+				logErrorIf ((option == NLOW) && wrapped, 'Left curly should be on new line (previous expression is split over muliple lines)', pos);
+				logErrorIf ((option != EOL) && (option != NLOW), 'Left curly unknown option ${option}', pos);
 				return;
 			}
 			logErrorIf ((option == EOL), 'Left curly should be at EOL (only linebreak or comment after curly)', pos);
 			logErrorIf ((!curlyOnNL), 'Left curly should be on new line (only whitespace before curly)', pos);
-			logErrorIf ((option != NL), 'Left curly unknown option ${option}', pos);
+			logErrorIf ((option == NLOW) && !wrapped, 'Left curly should be at EOL (previous expression is not split over muliple lines)', pos);
+			logErrorIf ((option != NL) && (option != NLOW), 'Left curly unknown option ${option}', pos);
 		}
 		catch (e:String) {
 			// one of the error messages fired -> do nothing

--- a/test/LeftCurlyCheckTest.hx
+++ b/test/LeftCurlyCheckTest.hx
@@ -53,6 +53,17 @@ class LeftCurlyCheckTest extends CheckTestCase {
 		check.option = LeftCurlyCheck.NL;
 		assertMsg(check, LeftCurlyTests.TEST15, '');
 	}
+
+	public function testNLOW() {
+		var check = new LeftCurlyCheck();
+		check.option = LeftCurlyCheck.NLOW;
+		assertMsg(check, LeftCurlyTests.TEST, '');
+		assertMsg(check, LeftCurlyTests.TEST12, '');
+		assertMsg(check, LeftCurlyTests.TEST16, '');
+		assertMsg(check, LeftCurlyTests.TEST17, 'Left curly should be at EOL (previous expression is not split over muliple lines)');
+		assertMsg(check, LeftCurlyTests.TEST18, 'Left curly should be on new line (previous expression is split over muliple lines)');
+		assertMsg(check, LeftCurlyTests.TEST19, 'Left curly should be on new line (previous expression is split over muliple lines)');
+	}
 }
 
 class LeftCurlyTests {
@@ -241,6 +252,58 @@ class LeftCurlyTests {
 				case true: // do nothing
 				default:
 					return 'test abc ${val}';
+			}
+		}
+	}";
+
+	public static inline var TEST16:String = "
+	class Test {
+		public function test(val:Int,
+				val2:Int):String
+		{
+			switch(val * 10 -
+					val / 10)
+			{
+				case 0: // do nothing
+				default:
+			}
+		}
+	}";
+
+	public static inline var TEST17:String = "
+	class Test {
+		public function test(val:Int, val2:Int):String
+		{
+			switch(val * 10 - val / 10)
+			{
+				case 1: // do nothing
+				default:
+			}
+		}
+	}";
+
+	public static inline var TEST18:String = "
+	class Test {
+		public function test(val:Int,
+				val2:Int):String {
+			switch(val * 10 -
+					val / 10)
+			{
+				case 0: // do nothing
+				default:
+			}
+		}
+	}";
+
+	public static inline var TEST19:String = "
+	class Test {
+		public function test(val:Int,
+				val2:Int):String
+		{
+			switch(val * 10 -
+					val / 10) {
+				case 0: // do nothing
+				default:
 			}
 		}
 	}";


### PR DESCRIPTION
enforces EOL mode unless controlling expression is multi line in which case left curly must be placed on a new line

nlow support is probably not complete and might require more test cases
