### PR TITLE
added RightCurlyCheck

### DIFF
--- a/checkstyle/Checker.hx
+++ b/checkstyle/Checker.hx
@@ -52,6 +52,7 @@ class Checker {
 	}
 
 	public function getLinePos(off:Int):LinePos {
+		if (off == file.content.length) off--;
 		for (i in 0...linesIdx.length) {
 			if (linesIdx[i].l <= off && linesIdx[i].r >= off) {
 				return { line:i, ofs: off - linesIdx[i].l };

--- a/checkstyle/checks/LeftCurlyCheck.hx
+++ b/checkstyle/checks/LeftCurlyCheck.hx
@@ -155,6 +155,10 @@ class LeftCurlyCheck extends Check {
 					if (cases.length > 0) {
 						firstCase = cases[0].values[0];
 					}
+					for (c in cases) {
+						checkBlocks(c.expr, isListWrapped(c.values));
+					}
+					checkBlocks(edef);
 					if (firstCase == null) {
 						checkLinesBetween(e.pos.min, e.pos.max, isWrapped(expr), e.pos);
 						return;
@@ -189,6 +193,14 @@ class LeftCurlyCheck extends Check {
 				(functionDef.indexOf('\r') >= 0);
 	}
 
+	function isListWrapped(es:Array<Expr>):Bool {
+		if (es == null) return false;
+		if (es.length <= 0) return false;
+		var posMin:Int = es[0].pos.min;
+		var posMax:Int = es[es.length - 1].pos.max;
+		return (checker.getLinePos(posMin).line != checker.getLinePos(posMax).line);
+	}
+
 	function isWrapped(e:Expr):Bool {
 		if (e == null) return false;
 		return (checker.getLinePos(e.pos.min).line != checker.getLinePos(e.pos.max).line);
@@ -196,6 +208,7 @@ class LeftCurlyCheck extends Check {
 
 	function checkBlocks(e:Expr, wrapped:Bool = false) {
 		if ((e == null) || (e.expr == null)) return;
+		if (checker.file.content.charAt(e.pos.min) != "{") return;
 
 		switch(e.expr) {
 			case EBlock(_):

--- a/resources/config.json
+++ b/resources/config.json
@@ -236,6 +236,28 @@
 			}
 		},
 		{
+			"type": "RightCurly",
+			"props": {
+				"severity": "WARNING",
+				"option": "aloneorsingle",
+				"tokens": [
+					"CLASS_DEF",
+					"ENUM_DEF",
+					"ABSTRACT_DEF",
+					"TYPEDEF_DEF",
+					"CLASS_DEF",
+					"INTERFACE_DEF",
+					"FUNCTION",
+					"FOR",
+					"IF",
+					"WHILE",
+					"SWITCH",
+					"TRY",
+					"CATCH"
+				]
+			}
+		},
+		{
 			"type": "Spacing",
 			"props": {
 				"severity": "INFO",

--- a/resources/config.json
+++ b/resources/config.json
@@ -247,6 +247,7 @@
 					"TYPEDEF_DEF",
 					"CLASS_DEF",
 					"INTERFACE_DEF",
+					"OBJECT_DECL",
 					"FUNCTION",
 					"FOR",
 					"IF",

--- a/test/LeftCurlyCheckTest.hx
+++ b/test/LeftCurlyCheckTest.hx
@@ -12,6 +12,7 @@ class LeftCurlyCheckTest extends CheckTestCase {
 		assertMsg(check, LeftCurlyTests.TEST8, '');
 		assertMsg(check, LeftCurlyTests.TEST9, '');
 		assertMsg(check, LeftCurlyTests.TEST14, '');
+		assertMsg(check, LeftCurlyTests.EOL_CASEBLOCK, '');
 	}
 
 	public function testWrongBraces() {
@@ -23,6 +24,8 @@ class LeftCurlyCheckTest extends CheckTestCase {
 		assertMsg(check, LeftCurlyTests.TEST5, 'Left curly should be at EOL (only linebreak or comment after curly)');
 		assertMsg(check, LeftCurlyTests.TEST7, 'Left curly should be at EOL (only linebreak or comment after curly)');
 		assertMsg(check, LeftCurlyTests.TEST10, 'Left curly should be at EOL (only linebreak or comment after curly)');
+		assertMsg(check, LeftCurlyTests.NL_CASEBLOCK, 'Left curly should be at EOL (only linebreak or comment after curly)');
+		assertMsg(check, LeftCurlyTests.NLOW_CASEBLOCK, 'Left curly should be at EOL (only linebreak or comment after curly)');
 	}
 
 	public function testBraceOnNL() {
@@ -52,6 +55,9 @@ class LeftCurlyCheckTest extends CheckTestCase {
 		var check = new LeftCurlyCheck();
 		check.option = LeftCurlyCheck.NL;
 		assertMsg(check, LeftCurlyTests.TEST15, '');
+		assertMsg(check, LeftCurlyTests.NL_CASEBLOCK, '');
+		assertMsg(check, LeftCurlyTests.EOL_CASEBLOCK, 'Left curly should be on new line (only whitespace before curly)');
+		assertMsg(check, LeftCurlyTests.NLOW_CASEBLOCK, 'Left curly should be on new line (only whitespace before curly)');
 	}
 
 	public function testNLOW() {
@@ -60,6 +66,7 @@ class LeftCurlyCheckTest extends CheckTestCase {
 		assertMsg(check, LeftCurlyTests.TEST, '');
 		assertMsg(check, LeftCurlyTests.TEST12, '');
 		assertMsg(check, LeftCurlyTests.TEST16, '');
+		assertMsg(check, LeftCurlyTests.NLOW_CASEBLOCK, '');
 		assertMsg(check, LeftCurlyTests.TEST17, 'Left curly should be at EOL (previous expression is not split over muliple lines)');
 		assertMsg(check, LeftCurlyTests.TEST18, 'Left curly should be on new line (previous expression is split over muliple lines)');
 		assertMsg(check, LeftCurlyTests.TEST19, 'Left curly should be on new line (previous expression is split over muliple lines)');
@@ -303,6 +310,52 @@ class LeftCurlyTests {
 			switch(val * 10 -
 					val / 10) {
 				case 0: // do nothing
+				default:
+			}
+		}
+	}";
+
+	public static inline var NL_CASEBLOCK:String = "
+	class Test
+	{
+		public function test(val:Int,
+				val2:Int):String
+		{
+			switch(val)
+			{
+				case 0:
+				{
+					// do nothing
+				}
+				default:
+			}
+		}
+	}";
+
+	public static inline var EOL_CASEBLOCK:String = "
+	class Test {
+		public function test(val:Int,
+				val2:Int):String {
+			switch(val) {
+				case 0: {
+					// do nothing
+				}
+				default:
+			}
+		}
+	}";
+
+	public static inline var NLOW_CASEBLOCK:String = "
+	class Test {
+		public function test(val:Int,
+				val2:Int):String
+		{
+			switch(val) {
+				case (true ||
+					!false):
+				{
+					// do nothing
+				}
 				default:
 			}
 		}

--- a/test/RightCurlyCheckTest.hx
+++ b/test/RightCurlyCheckTest.hx
@@ -1,0 +1,420 @@
+package ;
+
+import checkstyle.checks.RightCurlyCheck;
+
+class RightCurlyCheckTest extends CheckTestCase {
+
+	public function testCorrectAloneOrSingleLine() {
+		var check = new RightCurlyCheck();
+		assertMsg(check, RightCurlyTests.ALONE_OR_SINGLELINE_CORRECT, '');
+
+		assertMsg(check, RightCurlyTests.SINGLELINE_IF, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_FUNCTION, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_FOR, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_WHILE, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_TRY_CATCH, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_INTERFACE, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_CLASS, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_TYPEDEF, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_SWITCH, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_CASE, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_OBJECT, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_ABSTRACT, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_ENUM, '');
+
+		assertMsg(check, RightCurlyTests.ALONE_IF, '');
+		assertMsg(check, RightCurlyTests.ALONE_FUNCTION, '');
+		assertMsg(check, RightCurlyTests.ALONE_FOR, '');
+		assertMsg(check, RightCurlyTests.ALONE_WHILE, '');
+		assertMsg(check, RightCurlyTests.ALONE_TRY_CATCH, '');
+		assertMsg(check, RightCurlyTests.ALONE_INTERFACE, '');
+		assertMsg(check, RightCurlyTests.ALONE_CLASS, '');
+		assertMsg(check, RightCurlyTests.ALONE_TYPEDEF, '');
+		assertMsg(check, RightCurlyTests.ALONE_SWITCH, '');
+		assertMsg(check, RightCurlyTests.ALONE_CASE, '');
+		assertMsg(check, RightCurlyTests.ALONE_OBJECT, '');
+		assertMsg(check, RightCurlyTests.ALONE_ABSTRACT, '');
+		assertMsg(check, RightCurlyTests.ALONE_ENUM, '');
+	}
+
+	public function testIncorrectAloneOrSingleLine() {
+		var check = new RightCurlyCheck();
+		assertMsg(check, RightCurlyTests.SAMELINE_IF, 'Right curly should be alone on a new line');
+		assertMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH, 'Right curly should be alone on a new line');
+	}
+
+	public function testCorrectSame() {
+		var check = new RightCurlyCheck();
+		check.option = RightCurlyCheck.SAME;
+		assertMsg(check, RightCurlyTests.SAMELINE_IF, '');
+		assertMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH, '');
+
+		assertMsg(check, RightCurlyTests.ALONE_FUNCTION, '');
+		assertMsg(check, RightCurlyTests.ALONE_FOR, '');
+		assertMsg(check, RightCurlyTests.ALONE_WHILE, '');
+		assertMsg(check, RightCurlyTests.ALONE_INTERFACE, '');
+		assertMsg(check, RightCurlyTests.ALONE_CLASS, '');
+		assertMsg(check, RightCurlyTests.ALONE_TYPEDEF, '');
+		assertMsg(check, RightCurlyTests.ALONE_SWITCH, '');
+		assertMsg(check, RightCurlyTests.ALONE_CASE, '');
+		assertMsg(check, RightCurlyTests.ALONE_OBJECT, '');
+		assertMsg(check, RightCurlyTests.ALONE_ABSTRACT, '');
+		assertMsg(check, RightCurlyTests.ALONE_ENUM, '');
+	}
+
+	public function testIncorrectSame() {
+		var check = new RightCurlyCheck();
+		check.option = RightCurlyCheck.SAME;
+		assertMsg(check, RightCurlyTests.SINGLELINE_IF, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_FOR, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_WHILE, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_TRY_CATCH, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_INTERFACE, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_CLASS, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_TYPEDEF, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_SWITCH, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_CASE, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_OBJECT, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_ABSTRACT, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_ENUM, 'Right curly should not be on same line as left curly');
+
+		assertMsg(check, RightCurlyTests.ALONE_IF, 'Right curly should be on same line as following block (e.g. "} else" or "} catch")');
+		assertMsg(check, RightCurlyTests.ALONE_TRY_CATCH, 'Right curly should be on same line as following block (e.g. "} else" or "} catch")');
+	}
+
+	public function testCorrectAlone() {
+		var check = new RightCurlyCheck();
+		check.option = RightCurlyCheck.ALONE;
+		assertMsg(check, RightCurlyTests.ALONE_IF, '');
+		assertMsg(check, RightCurlyTests.ALONE_FOR, '');
+		assertMsg(check, RightCurlyTests.ALONE_WHILE, '');
+		assertMsg(check, RightCurlyTests.ALONE_FUNCTION, '');
+		assertMsg(check, RightCurlyTests.ALONE_INTERFACE, '');
+		assertMsg(check, RightCurlyTests.ALONE_CLASS, '');
+		assertMsg(check, RightCurlyTests.ALONE_TYPEDEF, '');
+		assertMsg(check, RightCurlyTests.ALONE_SWITCH, '');
+		assertMsg(check, RightCurlyTests.ALONE_CASE, '');
+		assertMsg(check, RightCurlyTests.ALONE_OBJECT, '');
+		assertMsg(check, RightCurlyTests.ALONE_ABSTRACT, '');
+		assertMsg(check, RightCurlyTests.ALONE_ENUM, '');
+	}
+
+	public function testIncorrectAlone() {
+		var check = new RightCurlyCheck();
+		check.option = RightCurlyCheck.ALONE;
+		assertMsg(check, RightCurlyTests.SINGLELINE_IF, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_FUNCTION, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_FOR, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_WHILE, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_TRY_CATCH, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_INTERFACE, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_CLASS, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_TYPEDEF, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_SWITCH, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_CASE, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_OBJECT, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_ABSTRACT, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_ENUM, 'Right curly should not be on same line as left curly');
+
+		assertMsg(check, RightCurlyTests.SAMELINE_IF, 'Right curly should be alone on a new line');
+		assertMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH, 'Right curly should be alone on a new line');
+	}
+
+	public function testTokenIF() {
+		var check = new RightCurlyCheck();
+		check.tokens = [RightCurlyCheck.IF];
+		assertMsg(check, RightCurlyTests.SINGLELINE_IF, '');
+		assertMsg(check, RightCurlyTests.SINGLELINE_FOR, '');
+		assertMsg(check, RightCurlyTests.SAMELINE_IF, 'Right curly should be alone on a new line');
+		assertMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH, '');
+		assertMsg(check, RightCurlyTests.ALONE_IF, '');
+		assertMsg(check, RightCurlyTests.ALONE_FOR, '');
+
+		check.option = RightCurlyCheck.SAME;
+		assertMsg(check, RightCurlyTests.SINGLELINE_IF, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_FOR, '');
+		assertMsg(check, RightCurlyTests.SAMELINE_IF, '');
+		assertMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH, '');
+		assertMsg(check, RightCurlyTests.ALONE_IF, 'Right curly should be on same line as following block (e.g. "} else" or "} catch")');
+		assertMsg(check, RightCurlyTests.ALONE_FOR, '');
+
+		check.option = RightCurlyCheck.ALONE;
+		assertMsg(check, RightCurlyTests.SINGLELINE_IF, 'Right curly should not be on same line as left curly');
+		assertMsg(check, RightCurlyTests.SINGLELINE_FOR, '');
+		assertMsg(check, RightCurlyTests.SAMELINE_IF, 'Right curly should be alone on a new line');
+		assertMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH, '');
+		assertMsg(check, RightCurlyTests.ALONE_IF, '');
+		assertMsg(check, RightCurlyTests.ALONE_FOR, '');
+	}
+}
+
+class RightCurlyTests {
+	public static inline var ALONE_OR_SINGLELINE_CORRECT:String = "
+	class Test {
+		function test() {
+			if (true) { return; }
+
+			if (true) return;
+			else {
+				return;
+			}
+
+			if (true) { return; } else { trace ('test'); }
+
+			if (true) { // comment
+				return;
+			}
+			else if (false) {
+				return;
+			}
+
+			for (i in 0...10) {
+				return i;
+			}
+
+			for (i in 0...10) { return i; }
+
+			while (true) {
+				return;
+			}
+
+			var x = { x: 100, y: 100 };
+			var x = { x: 100, y: 100
+			};
+
+			while (true) { return; }
+		}
+		@SuppressWarnings('checkstyle:RightCurly')
+		function test1()
+		{
+			if (true)
+			{
+				return;
+			} else trace ('test1');
+
+			for (i in 0...10)
+			{ return i; }
+
+			while (true)
+			{ return; }
+		}
+	}";
+
+	public static inline var SINGLELINE_IF:String = "
+	class Test {
+		function test() {
+			if (true) { return; } else { return; }
+		}
+	}";
+
+	public static inline var SAMELINE_IF:String = "
+	class Test {
+		function test() {
+			if (true) {
+				return;
+			} else {
+				return;
+			}
+		}
+	}";
+
+	public static inline var ALONE_IF:String = "
+	class Test {
+		function test() {
+			if (true) {
+				return;
+			}
+			else {
+				return;
+			}
+		}
+	}";
+
+	public static inline var SINGLELINE_FUNCTION:String = "
+	class Test {
+		function test() { trace ('test'); }
+	}";
+
+	public static inline var ALONE_FUNCTION:String = "
+	class Test {
+		function test() {
+			trace ('test');
+		}
+	}";
+
+	public static inline var SINGLELINE_FOR:String = "
+	class Test {
+		function test() {
+			for (i in 0...100) { trace ('$i'); }
+		}
+	}";
+
+	public static inline var ALONE_FOR:String = "
+	class Test {
+		function test() {
+			for (i in 0...100) {
+				trace ('$i');
+			}
+		}
+	}";
+
+	public static inline var SINGLELINE_WHILE:String = "
+	class Test {
+		function test() {
+			while (true) { trace ('test'); }
+		}
+	}";
+
+	public static inline var ALONE_WHILE:String = "
+	class Test {
+		function test() {
+			while (true) {
+				trace ('test');
+			}
+		}
+	}";
+
+	public static inline var SINGLELINE_TRY_CATCH:String = "
+	class Test {
+		function test() {
+			try { trace ('test'); } catch (e:Dynamic) {}
+		}
+	}";
+
+	public static inline var SAMELINE_TRY_CATCH:String = "
+	class Test {
+		function test() {
+			try {
+				trace ('test');
+			} catch (e:Dynamic) {
+			}
+		}
+	}";
+
+	public static inline var ALONE_TRY_CATCH:String = "
+	class Test {
+		function test() {
+			try {
+				trace ('test');
+			}
+			catch (e:Dynamic) {
+			}
+		}
+	}";
+
+	public static inline var SINGLELINE_INTERFACE:String = "
+	interface Test { function test(); }";
+
+	public static inline var ALONE_INTERFACE:String = "
+	interface Test {
+		function test();
+	}";
+
+	public static inline var SINGLELINE_CLASS:String = "
+	class Test { function test() {}; }";
+
+	public static inline var ALONE_CLASS:String = "
+	class Test {
+		function test() {
+		};
+	}";
+
+	public static inline var SINGLELINE_TYPEDEF:String = "
+	typedef Test = { x:Int, y:Int, z:Int };";
+
+	public static inline var ALONE_TYPEDEF:String = "
+	typedef Test = {
+		x:Int,
+		y:Int,
+		z:Int
+	};";
+
+	public static inline var SINGLELINE_SWITCH:String = "
+	class Test {
+		function test(val:Bool) {
+			switch (val) { case true: return; default: trace(val); }
+		}
+	}";
+
+	public static inline var ALONE_SWITCH:String = "
+	class Test {
+		function test() {
+			switch (val) {
+				case true:
+					return;
+				default:
+					trace(val);
+			}
+		}
+	}";
+
+	public static inline var SINGLELINE_CASE:String = "
+	class Test {
+		function test(val:Bool) {
+			switch (val) {
+				case true: return;
+				case false: { trace(val); return; }
+				default: { trace('unreachable'); return; }
+			}
+		}
+	}";
+
+	public static inline var ALONE_CASE:String = "
+	class Test {
+		function test() {
+			switch (val) {
+				case true: return;
+				case false: {
+					trace(val);
+					return;
+				}
+				default: {
+					trace('unreachable');
+					return;
+				}
+			}
+		}
+	}";
+
+	public static inline var SINGLELINE_OBJECT:String = "
+	class Test {
+		function test(val:Bool) {
+			var p = { x:100, y: 10, z: 2 };
+		}
+	}";
+
+	public static inline var ALONE_OBJECT:String = "
+	class Test {
+		function test() {
+			var p = {
+				x:100,
+				y: 10,
+				z: 2
+			};
+		}
+	}";
+
+	public static inline var SINGLELINE_ABSTRACT:String = "
+	abstract Test(String) { @:from public static function fromString(value:String) { return new Test('Hello $value'); } }";
+
+	public static inline var ALONE_ABSTRACT:String = "
+	abstract Test(String) {
+		@:from
+		public static function fromString(value:String) {
+			return new Test('Hello $value');
+		}
+	}";
+
+	public static inline var SINGLELINE_ENUM:String = "
+	enum Test { Monday; Tuesday; Wednesday; Thursday; Friday; Weekend(day:String); }";
+
+	public static inline var ALONE_ENUM:String = "
+	enum Test {
+		Monday;
+		Tuesday;
+		Wednesday;
+		Thursday;
+		Friday;
+		Weekend(day:String);
+	}";
+}

--- a/test/TestMain.hx
+++ b/test/TestMain.hx
@@ -30,6 +30,7 @@ class TestMain {
 		runner.add(new ParameterNumberCheckTest());
 		runner.add(new PublicPrivateCheckTest());
 		runner.add(new ReturnCheckTest());
+		runner.add(new RightCurlyCheckTest());
 		runner.add(new SpacingCheckTest());
 		runner.add(new TabForAligningCheckTest());
 		runner.add(new TODOCommentCheckTest());


### PR DESCRIPTION
RightCurlyCheck supports three modes (see also: https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyOption.java):
alone - right curly must be alone on a new line
same - right curly must be alone on a new line, except for "} else" and "} catch" 
aloneorsingle - right curly can occur on same line as left curly or must be alone on a new line
