### PR TITLE
Output FlashDevelop-compatible character ranges, closes #55

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .DS_Store
 *.n
 *.zip
+*.hxproj
+.haxelib/

--- a/checkstyle/Checker.hx
+++ b/checkstyle/Checker.hx
@@ -140,7 +140,8 @@ class Checker {
 					message: "Parsing failed: " + e + "\nStacktrace: " +
 								CallStack.toString(CallStack.exceptionStack()),
 					line:1,
-					column:1,
+					startColumn:0,
+					endColumn:0,
 					severity:ERROR,
 					moduleName:"Checker"
 				});
@@ -162,7 +163,8 @@ class Checker {
 						message:"Check " + check.getModuleName() + " failed: " +
 									e + "\nStacktrace: " + CallStack.toString(CallStack.exceptionStack()),
 						line:1,
-						column:1,
+						startColumn:0,
+						endColumn:0,
 						severity:ERROR,
 						moduleName:"Checker"
 					});

--- a/checkstyle/LintMessage.hx
+++ b/checkstyle/LintMessage.hx
@@ -12,7 +12,8 @@ typedef LintMessage = {
 	var fileName:String;
 	var message:String;
 	var line:Int;
-	var column:Int;
+	var startColumn:Int;
+	var endColumn:Int;
 	var severity:SeverityLevel;
 	var moduleName:String;
 }

--- a/checkstyle/checks/ArrayInstantiationCheck.hx
+++ b/checkstyle/checks/ArrayInstantiationCheck.hx
@@ -12,8 +12,7 @@ class ArrayInstantiationCheck extends Check {
 		ExprUtils.walkFile(checker.ast, function(e:Expr) {
 			switch(e.expr){
 				case ENew({pack:[], name:"Array"}, _):
-					var lp = checker.getLinePos(e.pos.min);
-					log('Bad array instantiation, use the array literal notation [] which is faster', lp.line + 1, lp.ofs + 1, Reflect.field(SeverityLevel, severity));
+					logPos('Bad array instantiation, use the array literal notation [] which is faster', e.pos, Reflect.field(SeverityLevel, severity));
 				default:
 			}
 		});

--- a/checkstyle/checks/Check.hx
+++ b/checkstyle/checks/Check.hx
@@ -29,15 +29,18 @@ class Check {
 
 	public function logPos(msg:String, pos:Position, sev:SeverityLevel) {
 		var lp = checker.getLinePos(pos.min);
-		log(msg, lp.line + 1, lp.ofs + 1, sev);
+		var length = pos.max - pos.min;
+		log(msg, lp.line + 1, lp.ofs, lp.ofs + length, sev);
 	}
 
-	public function log(msg:String, l:Int, c:Int, sev:SeverityLevel) {
+	public function log(msg:String, l:Int, startColumn:Int, ?endColumn:Int, sev:SeverityLevel) {
+		if (endColumn == null) endColumn = startColumn;
 		messages.push({
 			fileName:checker.file.name,
 			message:msg,
 			line:l,
-			column:c,
+			startColumn:startColumn,
+			endColumn:endColumn,
 			severity:sev,
 			moduleName:getModuleName()
 		});

--- a/checkstyle/checks/ERegInstantiationCheck.hx
+++ b/checkstyle/checks/ERegInstantiationCheck.hx
@@ -19,8 +19,7 @@ class ERegInstantiationCheck extends Check {
 					{pack:[], name:"EReg"},
 					[{expr:EConst(CString(re)), pos:_}, {expr:EConst(CString(opt)), pos:_}]
 				):
-					var lp = checker.getLinePos(e.pos.min);
-					log('Bad EReg instantiation, define expression between ~/ and /', lp.line + 1, lp.ofs + 1, Reflect.field(SeverityLevel, severity));
+					logPos('Bad EReg instantiation, define expression between ~/ and /', e.pos, Reflect.field(SeverityLevel, severity));
 				default:
 			}
 		});

--- a/checkstyle/checks/EmptyLinesCheck.hx
+++ b/checkstyle/checks/EmptyLinesCheck.hx
@@ -42,6 +42,6 @@ class EmptyLinesCheck extends Check {
 	}
 
 	function logInfo(pos) {
-		log('Too many consecutive empty lines (> ${max})', pos, 0, Reflect.field(SeverityLevel, severity));
+		log('Too many consecutive empty lines (> ${max})', pos, 0, null, Reflect.field(SeverityLevel, severity));
 	}
 }

--- a/checkstyle/checks/FileLengthCheck.hx
+++ b/checkstyle/checks/FileLengthCheck.hx
@@ -23,6 +23,6 @@ class FileLengthCheck extends Check {
 				default:
 			}
 		}
-		if (checker.lines.length > max) log('Too many lines in file (> ${max})', checker.lines.length, 1, Reflect.field(SeverityLevel, severity));
+		if (checker.lines.length > max) log('Too many lines in file (> ${max})', checker.lines.length, 0, null, Reflect.field(SeverityLevel, severity));
 	}
 }

--- a/checkstyle/checks/IndentationCharacterCheck.hx
+++ b/checkstyle/checks/IndentationCharacterCheck.hx
@@ -25,7 +25,7 @@ class IndentationCharacterCheck extends Check {
 		}
 		for (i in 0 ... checker.lines.length) {
 			var line = checker.lines[i];
-			if (line.length > 0 && !re.match(line)) log('Wrong indentation character (${character})', i + 1, 1, Reflect.field(SeverityLevel, severity));
+			if (line.length > 0 && !re.match(line)) log('Wrong indentation character (${character})', i + 1, 0, null, Reflect.field(SeverityLevel, severity));
 		}
 	}
 }

--- a/checkstyle/checks/LineLengthCheck.hx
+++ b/checkstyle/checks/LineLengthCheck.hx
@@ -20,7 +20,7 @@ class LineLengthCheck extends Check {
 			var line = checker.lines[i];
 			if (line.length > max) {
 				if (isLineSuppressed(i)) continue;
-				log('Too long line (> ${max})', i + 1, 1, Reflect.field(SeverityLevel, severity));
+				log('Too long line (> ${max})', i + 1, 0, line.length, Reflect.field(SeverityLevel, severity));
 			}
 		}
 	}

--- a/checkstyle/checks/ListenerNameCheck.hx
+++ b/checkstyle/checks/ListenerNameCheck.hx
@@ -51,15 +51,14 @@ class ListenerNameCheck extends Check {
 		var listener = p[1];
 		switch(listener.expr){
 			case EConst(CIdent(ident)):
-				var lp = checker.getLinePos(listener.pos.min);
-				checkListenerName(ident, lp.line, lp.ofs);
+				checkListenerName(ident, listener.pos);
 			default:
 		}
 	}
 
-	function checkListenerName(name:String, line:Int, col:Int) {
+	function checkListenerName(name:String, pos:Position) {
 		formatRE = new EReg (format, "");
 		var match = formatRE.match(name);
-		if (!match) log('Wrong listener name: ' + name + ' (should be ~/${format}/)', line, col, Reflect.field(SeverityLevel, severity));
+		if (!match) logPos('Wrong listener name: ' + name + ' (should be ~/${format}/)', pos, Reflect.field(SeverityLevel, severity));
 	}
 }

--- a/checkstyle/checks/MethodLengthCheck.hx
+++ b/checkstyle/checks/MethodLengthCheck.hx
@@ -57,7 +57,7 @@ class MethodLengthCheck extends Check {
 		var lp = checker.getLinePos(f.pos.min);
 		var lmin = lp.line;
 		var lmax = checker.getLinePos(f.pos.max).line;
-		if (lmax - lmin > max) warnFunctionLength(f.name, lp.line + 1, lp.ofs + 1);
+		if (lmax - lmin > max) warnFunctionLength(f.name, f.pos);
 	}
 
 	function checkFunction(f:Expr) {
@@ -71,10 +71,10 @@ class MethodLengthCheck extends Check {
 			default: throw "EFunction only";
 		}
 
-		if (lmax - lmin > max) warnFunctionLength(fname, lp.line + 1, lp.ofs + 1);
+		if (lmax - lmin > max) warnFunctionLength(fname, f.pos);
 	}
 
-	function warnFunctionLength(name:String, pos:Int, ofs:Int) {
-		log('Function is too long: ${name} (> ${max} lines, try splitting into multiple functions)', pos, ofs, Reflect.field(SeverityLevel, severity));
+	function warnFunctionLength(name:String, pos:Position) {
+		logPos('Function is too long: ${name} (> ${max} lines, try splitting into multiple functions)', pos, Reflect.field(SeverityLevel, severity));
 	}
 }

--- a/checkstyle/checks/TODOCommentCheck.hx
+++ b/checkstyle/checks/TODOCommentCheck.hx
@@ -12,8 +12,7 @@ class TODOCommentCheck extends Check {
 		for (tk in checker.tokens) {
 			switch(tk.tok) {
 				case Comment(s) | CommentLine(s):
-					var lp = checker.getLinePos(tk.pos.min);
-					if (re.match(s)) log('TODO comment:' + s, lp.line + 1, lp.ofs + 1, Reflect.field(SeverityLevel, severity));
+					if (re.match(s)) logPos('TODO comment:' + s, tk.pos, Reflect.field(SeverityLevel, severity));
 				default:
 			}
 		}

--- a/checkstyle/checks/TabForAligningCheck.hx
+++ b/checkstyle/checks/TabForAligningCheck.hx
@@ -11,7 +11,7 @@ class TabForAligningCheck extends Check {
 		for (i in 0 ... checker.lines.length) {
 			var line = checker.lines[i];
 			if (re.match(line) && line.indexOf("//") == -1) {
-				log("Tab after non-space character. Use space for aligning", i + 1, line.length, Reflect.field(SeverityLevel, severity));
+				log("Tab after non-space character. Use space for aligning", i + 1, line.length, null, Reflect.field(SeverityLevel, severity));
 			}
 		}
 	}

--- a/checkstyle/checks/TrailingWhitespaceCheck.hx
+++ b/checkstyle/checks/TrailingWhitespaceCheck.hx
@@ -11,7 +11,7 @@ class TrailingWhitespaceCheck extends Check {
 		var re = ~/\s+$/;
 		for (i in 0 ... checker.lines.length) {
 			var line = checker.lines[i];
-			if (re.match(line)) log('Trailing whitespace', i + 1, line.length, Reflect.field(SeverityLevel, severity));
+			if (re.match(line)) log('Trailing whitespace', i + 1, line.length, null, Reflect.field(SeverityLevel, severity));
 		}
 	}
 }

--- a/checkstyle/reporter/JSONReporter.hx
+++ b/checkstyle/reporter/JSONReporter.hx
@@ -35,7 +35,7 @@ class JSONReporter implements IReporter {
 	public function addMessage(m:LintMessage) {
 		var reportMessage:ReportMessage = {
 			line: m.line,
-			column: m.column,
+			column: m.startColumn,
 			severity: severityString(m.severity),
 			message: m.message
 		};

--- a/checkstyle/reporter/Reporter.hx
+++ b/checkstyle/reporter/Reporter.hx
@@ -8,10 +8,10 @@ class Reporter implements IReporter {
 
 	static function severityString(s:SeverityLevel):String {
 		return switch(s){
-			case INFO: return "info";
-			case WARNING: return "warning";
-			case ERROR: return "error";
-			case IGNORE: return "ignore";
+			case INFO: return "Info";
+			case WARNING: return "Warning";
+			case ERROR: return "Error";
+			case IGNORE: return "Ignore";
 		}
 	}
 
@@ -28,15 +28,23 @@ class Reporter implements IReporter {
 		sb.add(m.fileName);
 		sb.add(':');
 		sb.add(m.line);
-		if (m.column > 0) {
-			sb.add(':');
-			sb.add(m.column);
+		if (m.startColumn >= 0) {
+			var isRange = m.startColumn != m.endColumn;
+			sb.add(': character${isRange ? 's' : ''} ');
+			sb.add(m.startColumn);
+			if (isRange) {
+				sb.add('-');
+				sb.add(m.endColumn);
+			}
+			sb.add(' ');
 		}
 		sb.add(": ");
 		sb.add(severityString(m.severity));
 		sb.add(": ");
 		sb.add(m.message);
 		sb.add("\n");
-		Sys.stdout().writeString(sb.toString());
+		
+		var output = (m.severity == ERROR || m.severity == WARNING) ? Sys.stderr() : Sys.stdout();
+		output.writeString(sb.toString());
 	}
 }

--- a/checkstyle/reporter/XMLReporter.hx
+++ b/checkstyle/reporter/XMLReporter.hx
@@ -105,9 +105,9 @@ class XMLReporter implements IReporter {
 		sb.add("\t\t<error line=\"");
 		sb.add(m.line);
 		sb.add("\"");
-		if (m.column > 0) {
+		if (m.startColumn >= 0) {
 			sb.add(" column=\"");
-			sb.add(m.column);
+			sb.add(m.startColumn);
 			sb.add("\"");
 		}
 		sb.add(" severity=\"");


### PR DESCRIPTION
- capitalized the text reporter's severity levels and output to stderr for warnings and errors to be recognized correctly by FD
- output character ranges if `startColumn != endColumn`
- it seems like all column positions were off by one, they are now zero-indexed
- changed a lot of checks to use `logPos()`

All in all, this makes the error reporting much more similar to the comiler's error messages (which is what FD can handle). The xml reporter just ignores the `endColumn` for now.

Result:

![](http://i.imgur.com/17ealxN.png)
