### PR TITLE
Improved invalid config field detection

### DIFF
--- a/checkstyle/Main.hx
+++ b/checkstyle/Main.hx
@@ -111,6 +111,7 @@ class Main {
 		checker.process(toProcess);
 	}
 
+	@SuppressWarnings('checkstyle:Dynamic')
 	function createCheck(checkConf:Dynamic, defaultSeverity:String) {
 		var check:Check = cast info.build(checkConf.type);
 		if (check == null) return;
@@ -131,6 +132,7 @@ class Main {
 		checker.addCheck(check);
 	}
 
+	@SuppressWarnings('checkstyle:Dynamic')
 	function verifyAllowedFields(object:Dynamic, allowedFields:Array<String>, messagePrefix:String) {
 		for (field in Reflect.fields(object)) {
 			if (allowedFields.indexOf(field) < 0) {


### PR DESCRIPTION
#62 only detects unknown properties, but it doesn't error in cases like these:

(`"format"` not wrapped in `"props"` - I've done this more than once :/)

``` json
{
    "type": "TypeName",
    "format": "^[A-Z]+[a-zA-Z0-9]*$"
}
```

(typo in top-level field)

``` json
{
    "check": [

    ]
}
```

Now this doesn't fail silently anymore.
