### PR TITLE
IndentationCharacterCheck: less misleading error message

### DIFF
--- a/checkstyle/checks/IndentationCharacterCheck.hx
+++ b/checkstyle/checks/IndentationCharacterCheck.hx
@@ -25,7 +25,7 @@ class IndentationCharacterCheck extends Check {
 		}
 		for (i in 0 ... checker.lines.length) {
 			var line = checker.lines[i];
-			if (line.length > 0 && !re.match(line)) log('Wrong indentation character (${character})', i + 1, 0, null, Reflect.field(SeverityLevel, severity));
+			if (line.length > 0 && !re.match(line)) log('Wrong indentation character (should be ${character})', i + 1, 0, null, Reflect.field(SeverityLevel, severity));
 		}
 	}
 }

--- a/test/IndentationCharacterCheckTest.hx
+++ b/test/IndentationCharacterCheckTest.hx
@@ -6,7 +6,7 @@ class IndentationCharacterCheckTest extends CheckTestCase {
 
 	public function testWrongIndentation() {
 		var msg = checkMessage(IndentationTests.TEST1, new IndentationCharacterCheck());
-		assertEquals(msg, 'Wrong indentation character (tab)');
+		assertEquals(msg, 'Wrong indentation character (should be tab)');
 	}
 
 	public function testCorrectIndentation() {
@@ -19,7 +19,7 @@ class IndentationCharacterCheckTest extends CheckTestCase {
 		check.character = "space";
 
 		var msg = checkMessage(IndentationTests.TEST3, check);
-		assertEquals(msg, 'Wrong indentation character (space)');
+		assertEquals(msg, 'Wrong indentation character (should be space)');
 	}
 
 	public function testMultilineIfIndentation() {


### PR DESCRIPTION
It sounded like the current indent char was tab / space, when it's really the other way around (_should_ be tab / space).
