### PR TITLE
Fix checks without props not being added when running from config

### DIFF
--- a/checkstyle/Main.hx
+++ b/checkstyle/Main.hx
@@ -116,7 +116,7 @@ class Main {
 		var check:Check = cast info.build(checkConf.type);
 		if (check == null) return;
 		verifyAllowedFields(checkConf, ["type", "props"], check.getModuleName());
-		if (checkConf.props == null) return;
+		if (checkConf.props == null) checkConf.props = [];
 
 		var props = Reflect.fields(checkConf.props);
 		for (prop in props) {


### PR DESCRIPTION
Messed this up in #73... If `props` was null, it would never get to the `add()` call because of the early `return`. :/ Wasn't caught earlier because there are no unit tests for running from a `.json`.

This was a bit frustrating to debug - I was just trying to add a new check and very confused why it worked in checkstyle's own tests and not with Flixel's config...
