### PR TITLE
Add a checkstyle.checks.literal package

### DIFF
--- a/src/checkstyle/checks/literal/ArrayInstantiationCheck.hx
+++ b/src/checkstyle/checks/literal/ArrayInstantiationCheck.hx
@@ -1,4 +1,4 @@
-package checkstyle.checks;
+package checkstyle.checks.literal;
 
 import checkstyle.utils.ExprUtils;
 import haxe.macro.Expr;

--- a/src/checkstyle/checks/literal/ERegInstantiationCheck.hx
+++ b/src/checkstyle/checks/literal/ERegInstantiationCheck.hx
@@ -1,4 +1,4 @@
-package checkstyle.checks;
+package checkstyle.checks.literal;
 
 import checkstyle.utils.ExprUtils;
 import haxe.macro.Expr;

--- a/src/checkstyle/checks/literal/HexadecimalLiteralsCheck.hx
+++ b/src/checkstyle/checks/literal/HexadecimalLiteralsCheck.hx
@@ -1,4 +1,4 @@
-package checkstyle.checks;
+package checkstyle.checks.literal;
 
 import checkstyle.utils.ExprUtils;
 import haxe.macro.Expr;

--- a/test/checks/literal/ArrayInstantiationCheckTest.hx
+++ b/test/checks/literal/ArrayInstantiationCheckTest.hx
@@ -1,6 +1,6 @@
-package checks;
+package checks.literal;
 
-import checkstyle.checks.ArrayInstantiationCheck;
+import checkstyle.checks.literal.ArrayInstantiationCheck;
 
 class ArrayInstantiationCheckTest extends CheckTestCase {
 

--- a/test/checks/literal/ERegInstantiationCheckTest.hx
+++ b/test/checks/literal/ERegInstantiationCheckTest.hx
@@ -1,6 +1,6 @@
-package checks;
+package checks.literal;
 
-import checkstyle.checks.ERegInstantiationCheck;
+import checkstyle.checks.literal.ERegInstantiationCheck;
 
 class ERegInstantiationCheckTest extends CheckTestCase {
 

--- a/test/checks/literal/HexadecimalLiteralsCheckTest.hx
+++ b/test/checks/literal/HexadecimalLiteralsCheckTest.hx
@@ -1,6 +1,6 @@
-package checks;
+package checks.literal;
 
-import checkstyle.checks.HexadecimalLiteralsCheck;
+import checkstyle.checks.literal.HexadecimalLiteralsCheck;
 
 class HexadecimalLiteralsCheckTest extends CheckTestCase {
 


### PR DESCRIPTION
This is a deviation from the package structure in Java, but these checks don't seem to exist there anywhere.

Not sure if `ArrayInstanation` and `ERegInstantiation` should become `ArrayLiterals` and `ERegLiterals`?
