### PR TITLE
Use enum abstract for test case strings instead of classes

### DIFF
--- a/test/TestMain.hx
+++ b/test/TestMain.hx
@@ -9,7 +9,7 @@ class TestMain {
 		var runner = new haxe.unit.TestRunner();
 		runner.add(new TokenTreeBuilderTest());
 
-		var tests:List<Class<CheckTestCase>> = CompileTime.getAllClasses(CheckTestCase);
+		var tests = CompileTime.getAllClasses(CheckTestCase);
 		for (testClass in tests) runner.add(Type.createInstance(testClass, []));
 
 		var success = runner.run();

--- a/test/checks/AvoidStarImportCheckTest.hx
+++ b/test/checks/AvoidStarImportCheckTest.hx
@@ -2,21 +2,22 @@ package checks;
 
 import checkstyle.checks.AvoidStarImportCheck;
 
-class AvoidStarImportCheckTest extends CheckTestCase {
+class AvoidStarImportCheckTest extends CheckTestCase<AvoidStarImportCheckTests> {
 
 	public function testNoStarImport() {
 		var check = new AvoidStarImportCheck();
-		assertNoMsg(check, AvoidStarImportCheckTests.IMPORT);
+		assertNoMsg(check, IMPORT);
 	}
 
 	public function testStarImport() {
 		var check = new AvoidStarImportCheck();
-		assertMsg(check, AvoidStarImportCheckTests.STAR_IMPORT, 'Import line uses a star (.*) import - consider using full type names');
+		assertMsg(check, STAR_IMPORT, 'Import line uses a star (.*) import - consider using full type names');
 	}
 }
 
-class AvoidStarImportCheckTests {
-	public static inline var IMPORT:String = "
+@:enum
+abstract AvoidStarImportCheckTests(String) to String {
+	var IMPORT = "
 	package haxe.checkstyle;
 
 	import haxe.checkstyle.Check;
@@ -29,7 +30,7 @@ class AvoidStarImportCheckTests {
 		public function new() {}
 	}";
 
-	public static inline var STAR_IMPORT:String = "
+	var STAR_IMPORT = "
 	package haxe.checkstyle;
 
 	import haxe.checkstyle.*;

--- a/test/checks/CheckTestCase.hx
+++ b/test/checks/CheckTestCase.hx
@@ -8,7 +8,7 @@ import checkstyle.reporter.IReporter;
 import checkstyle.Checker;
 import checkstyle.checks.Check;
 
-class CheckTestCase extends haxe.unit.TestCase {
+class CheckTestCase<T:String> extends haxe.unit.TestCase {
 
 	static inline var FILE_NAME:String = "Test.hx";
 
@@ -17,7 +17,7 @@ class CheckTestCase extends haxe.unit.TestCase {
 
 	override public function setup() {}
 
-	function assertMsg(check:Check, testCase:String, expected:String, ?defines:Array<Array<String>>, ?pos:PosInfos) {
+	function assertMsg(check:Check, testCase:T, expected:String, ?defines:Array<Array<String>>, ?pos:PosInfos) {
 		var re = ~/abstractAndClass ([a-zA-Z0-9]*)/g;
 		if (re.match(testCase)) {
 			actualAssertMsg(check, re.replace(testCase, "class $1"), expected, pos);
@@ -26,7 +26,7 @@ class CheckTestCase extends haxe.unit.TestCase {
 		else actualAssertMsg(check, testCase, expected, defines, pos);
 	}
 
-	function assertNoMsg(check:Check, testCase:String, ?pos:PosInfos) {
+	function assertNoMsg(check:Check, testCase:T, ?pos:PosInfos) {
 		assertMsg(check, testCase, '', null, pos);
 	}
 

--- a/test/checks/CyclomaticComplexityCheckTest.hx
+++ b/test/checks/CyclomaticComplexityCheckTest.hx
@@ -2,7 +2,7 @@ package checks;
 
 import checkstyle.checks.CyclomaticComplexityCheck;
 
-class CyclomaticComplexityCheckTest extends CheckTestCase {
+class CyclomaticComplexityCheckTest extends CheckTestCase<CyclomaticComplexityCheckTests> {
 
 	public function testCorrectNaming() {
 		var check = new CyclomaticComplexityCheck();
@@ -10,13 +10,14 @@ class CyclomaticComplexityCheckTest extends CheckTestCase {
 			{ severity : "WARNING", complexity : 1 },
 			{ severity : "ERROR", complexity : 2 }
 		];
-		assertMsg(check, CyclomaticComplexityTests.TEST, 'Function "test" is too complex (score: 2).');
+		assertMsg(check, TEST, 'Function "test" is too complex (score: 2).');
 	}
 
 }
 
-class CyclomaticComplexityTests {
-	public static inline var TEST:String = "
+@:enum
+abstract CyclomaticComplexityCheckTests(String) to String {
+	var TEST = "
 	class Test {
 		function test() {
 			var a:Array<Int> = [0, 5, 20];

--- a/test/checks/EmptyPackageCheckTest.hx
+++ b/test/checks/EmptyPackageCheckTest.hx
@@ -2,26 +2,27 @@ package checks;
 
 import checkstyle.checks.EmptyPackageCheck;
 
-class EmptyPackageCheckTest extends CheckTestCase {
+class EmptyPackageCheckTest extends CheckTestCase<EmptyPackageCheckTests> {
 
 	public function testEmptyPackage() {
-		assertMsg(new EmptyPackageCheck(), EmptyPackageCheckTests.TEST1, "Found empty package");
+		assertMsg(new EmptyPackageCheck(), TEST1, "Found empty package");
 	}
 
 	public function testCorrectPackage() {
-		assertNoMsg(new EmptyPackageCheck(), EmptyPackageCheckTests.TEST2);
+		assertNoMsg(new EmptyPackageCheck(), TEST2);
 	}
 }
 
-class EmptyPackageCheckTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract EmptyPackageCheckTests(String) to String {
+	var TEST1 = "
 	package;
 
 	class Test {
 		public function new() {}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	package checks.test;
 
 	class Test {

--- a/test/checks/TODOCommentCheckTest.hx
+++ b/test/checks/TODOCommentCheckTest.hx
@@ -2,15 +2,16 @@ package checks;
 
 import checkstyle.checks.TODOCommentCheck;
 
-class TODOCommentCheckTest extends CheckTestCase {
+class TODOCommentCheckTest extends CheckTestCase<TODOCommentCheckTests> {
 
 	public function testTODO() {
-		assertMsg(new TODOCommentCheck(), TODOTests.TEST1, 'TODO comment: TODO: remove test');
+		assertMsg(new TODOCommentCheck(), TEST1, 'TODO comment: TODO: remove test');
 	}
 }
 
-class TODOTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract TODOCommentCheckTests(String) to String {
+	var TEST1 = "
 	class Test {
 		// TODO: remove test
 		public override function test() {}

--- a/test/checks/block/EmptyBlockCheckTest.hx
+++ b/test/checks/block/EmptyBlockCheckTest.hx
@@ -2,7 +2,7 @@ package checks.block;
 
 import checkstyle.checks.block.EmptyBlockCheck;
 
-class EmptyBlockCheckTest extends CheckTestCase {
+class EmptyBlockCheckTest extends CheckTestCase<EmptyBlockCheckTests> {
 
 	static inline var MSG_EMPTY_BLOCK:String = 'Empty block should be written as {}';
 	static inline var MSG_EMPTY_BLOCK_SHOULD_CONTAIN:String = 'Empty block should contain a comment or a statement';
@@ -11,48 +11,48 @@ class EmptyBlockCheckTest extends CheckTestCase {
 
 	public function testCorrectEmptyBlock() {
 		var check:EmptyBlockCheck = new EmptyBlockCheck();
-		assertNoMsg(check, EmptyBlockTests.EMPTY_BLOCK);
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_STATEMENT);
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_STATEMENT2);
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_COMMENT);
-		assertNoMsg(check, EmptyBlockTests.EMPTY_OBJECT_DECL);
-		assertNoMsg(check, EmptyBlockTests.OBJECT_DECL_WITH_COMMENT);
+		assertNoMsg(check, EMPTY_BLOCK);
+		assertNoMsg(check, BLOCK_WITH_STATEMENT);
+		assertNoMsg(check, BLOCK_WITH_STATEMENT2);
+		assertNoMsg(check, BLOCK_WITH_COMMENT);
+		assertNoMsg(check, EMPTY_OBJECT_DECL);
+		assertNoMsg(check, OBJECT_DECL_WITH_COMMENT);
 	}
 
 	public function testWrongEmptyBlock() {
 		var check:EmptyBlockCheck = new EmptyBlockCheck();
-		assertMsg(check, EmptyBlockTests.EMPTY_BLOCK_WHITESPACE, MSG_EMPTY_BLOCK);
-		assertMsg(check, EmptyBlockTests.EMPTY_OBJECT_DECL_WHITESPACE, MSG_EMPTY_BLOCK);
+		assertMsg(check, EMPTY_BLOCK_WHITESPACE, MSG_EMPTY_BLOCK);
+		assertMsg(check, EMPTY_OBJECT_DECL_WHITESPACE, MSG_EMPTY_BLOCK);
 	}
 
 	public function testEmptyBlockComment() {
 		var check:EmptyBlockCheck = new EmptyBlockCheck();
 		check.option = TEXT;
 
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_STATEMENT);
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_STATEMENT2);
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_COMMENT);
-		assertNoMsg(check, EmptyBlockTests.OBJECT_DECL_WITH_COMMENT);
+		assertNoMsg(check, BLOCK_WITH_STATEMENT);
+		assertNoMsg(check, BLOCK_WITH_STATEMENT2);
+		assertNoMsg(check, BLOCK_WITH_COMMENT);
+		assertNoMsg(check, OBJECT_DECL_WITH_COMMENT);
 
-		assertMsg(check, EmptyBlockTests.EMPTY_BLOCK, MSG_EMPTY_BLOCK_SHOULD_CONTAIN);
-		assertMsg(check, EmptyBlockTests.EMPTY_OBJECT_DECL, MSG_EMPTY_BLOCK_SHOULD_CONTAIN);
-		assertMsg(check, EmptyBlockTests.EMPTY_BLOCK_WHITESPACE, MSG_EMPTY_BLOCK_SHOULD_CONTAIN);
-		assertMsg(check, EmptyBlockTests.EMPTY_OBJECT_DECL_WHITESPACE, MSG_EMPTY_BLOCK_SHOULD_CONTAIN);
+		assertMsg(check, EMPTY_BLOCK, MSG_EMPTY_BLOCK_SHOULD_CONTAIN);
+		assertMsg(check, EMPTY_OBJECT_DECL, MSG_EMPTY_BLOCK_SHOULD_CONTAIN);
+		assertMsg(check, EMPTY_BLOCK_WHITESPACE, MSG_EMPTY_BLOCK_SHOULD_CONTAIN);
+		assertMsg(check, EMPTY_OBJECT_DECL_WHITESPACE, MSG_EMPTY_BLOCK_SHOULD_CONTAIN);
 	}
 
 	public function testEmptyBlockStatement() {
 		var check:EmptyBlockCheck = new EmptyBlockCheck();
 		check.option = STATEMENT;
 
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_STATEMENT);
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_STATEMENT2);
+		assertNoMsg(check, BLOCK_WITH_STATEMENT);
+		assertNoMsg(check, BLOCK_WITH_STATEMENT2);
 
-		assertMsg(check, EmptyBlockTests.BLOCK_WITH_COMMENT, MSG_BLOCK_SHOULD_CONTAIN);
-		assertMsg(check, EmptyBlockTests.OBJECT_DECL_WITH_COMMENT, MSG_BLOCK_SHOULD_CONTAIN);
-		assertMsg(check, EmptyBlockTests.EMPTY_BLOCK, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
-		assertMsg(check, EmptyBlockTests.EMPTY_OBJECT_DECL, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
-		assertMsg(check, EmptyBlockTests.EMPTY_BLOCK_WHITESPACE, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
-		assertMsg(check, EmptyBlockTests.EMPTY_OBJECT_DECL_WHITESPACE, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
+		assertMsg(check, BLOCK_WITH_COMMENT, MSG_BLOCK_SHOULD_CONTAIN);
+		assertMsg(check, OBJECT_DECL_WITH_COMMENT, MSG_BLOCK_SHOULD_CONTAIN);
+		assertMsg(check, EMPTY_BLOCK, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
+		assertMsg(check, EMPTY_OBJECT_DECL, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
+		assertMsg(check, EMPTY_BLOCK_WHITESPACE, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
+		assertMsg(check, EMPTY_OBJECT_DECL_WHITESPACE, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
 	}
 
 	public function testEmptyBlockStatementObjectDecl() {
@@ -60,20 +60,21 @@ class EmptyBlockCheckTest extends CheckTestCase {
 		check.option = STATEMENT;
 		check.tokens = [OBJECT_DECL];
 
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_STATEMENT);
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_STATEMENT2);
-		assertNoMsg(check, EmptyBlockTests.BLOCK_WITH_COMMENT);
-		assertNoMsg(check, EmptyBlockTests.EMPTY_BLOCK);
-		assertNoMsg(check, EmptyBlockTests.EMPTY_BLOCK_WHITESPACE);
+		assertNoMsg(check, BLOCK_WITH_STATEMENT);
+		assertNoMsg(check, BLOCK_WITH_STATEMENT2);
+		assertNoMsg(check, BLOCK_WITH_COMMENT);
+		assertNoMsg(check, EMPTY_BLOCK);
+		assertNoMsg(check, EMPTY_BLOCK_WHITESPACE);
 
-		assertMsg(check, EmptyBlockTests.OBJECT_DECL_WITH_COMMENT, MSG_BLOCK_SHOULD_CONTAIN);
-		assertMsg(check, EmptyBlockTests.EMPTY_OBJECT_DECL, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
-		assertMsg(check, EmptyBlockTests.EMPTY_OBJECT_DECL_WHITESPACE, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
+		assertMsg(check, OBJECT_DECL_WITH_COMMENT, MSG_BLOCK_SHOULD_CONTAIN);
+		assertMsg(check, EMPTY_OBJECT_DECL, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
+		assertMsg(check, EMPTY_OBJECT_DECL_WHITESPACE, MSG_EMPTY_BLOCK_CONTAIN_STATEMENT);
 	}
 }
 
-class EmptyBlockTests {
-	public static inline var EMPTY_BLOCK:String = "
+@:enum
+abstract EmptyBlockCheckTests(String) to String {
+	var EMPTY_BLOCK = "
 	class Test {
 		public function new() {}
 		@SuppressWarnings('checkstyle:EmptyBlock')
@@ -81,41 +82,41 @@ class EmptyBlockTests {
 		}
 	}";
 
-	public static inline var EMPTY_BLOCK_WHITESPACE:String = "
+	var EMPTY_BLOCK_WHITESPACE = "
 	class Test {
 		public function new(){
 
 		}
 	}";
 
-	public static inline var BLOCK_WITH_STATEMENT:String =
+	var BLOCK_WITH_STATEMENT =
 	"class Test {
 		public function new() { var a:Int;
 
 		}
 	}";
 
-	public static inline var BLOCK_WITH_STATEMENT2:String =
+	var BLOCK_WITH_STATEMENT2 =
 	"class Test {
 		public function new() {
 			var a:Int; }
 	}";
 
-	public static inline var BLOCK_WITH_COMMENT:String =
+	var BLOCK_WITH_COMMENT =
 	"class Test {
 		public function new() {
 			// comment
 		}
 	}";
 
-	public static inline var EMPTY_OBJECT_DECL:String =
+	var EMPTY_OBJECT_DECL =
 	"class Test {
 		public function new() {
 			var a = {};
 		}
 	}";
 
-	public static inline var EMPTY_OBJECT_DECL_WHITESPACE:String = "
+	var EMPTY_OBJECT_DECL_WHITESPACE = "
 	class Test {
 		public function new() {
 			var a = {
@@ -123,7 +124,7 @@ class EmptyBlockTests {
 		}
 	}";
 
-	public static inline var OBJECT_DECL_WITH_COMMENT:String = "
+	var OBJECT_DECL_WITH_COMMENT = "
 	class Test {
 		public function new() {
 			var a = {
@@ -132,7 +133,7 @@ class EmptyBlockTests {
 		}
 	}";
 
-	public static inline var OBJECT_DECL_WITH_COMMENT2:String = "
+	var OBJECT_DECL_WITH_COMMENT2 = "
 	class Test {
 		public function new() { /* comment
 								 */

--- a/test/checks/block/LeftCurlyCheckTest.hx
+++ b/test/checks/block/LeftCurlyCheckTest.hx
@@ -2,7 +2,7 @@ package checks.block;
 
 import checkstyle.checks.block.LeftCurlyCheck;
 
-class LeftCurlyCheckTest extends CheckTestCase {
+class LeftCurlyCheckTest extends CheckTestCase<LeftCurlyCheckTests> {
 
 	static inline var MSG_EOL:String = 'Left curly should be at EOL (only linebreak or comment after curly)';
 	static inline var MSG_NL:String = 'Left curly should be on new line (only whitespace before curly)';
@@ -11,112 +11,113 @@ class LeftCurlyCheckTest extends CheckTestCase {
 
 	public function testCorrectBraces() {
 		var check = new LeftCurlyCheck();
-		assertNoMsg(check, LeftCurlyTests.TEST);
-		assertNoMsg(check, LeftCurlyTests.TEST4);
-		assertNoMsg(check, LeftCurlyTests.TEST6);
-		assertNoMsg(check, LeftCurlyTests.TEST8);
-		assertNoMsg(check, LeftCurlyTests.TEST9);
-		assertNoMsg(check, LeftCurlyTests.TEST14);
-		assertNoMsg(check, LeftCurlyTests.EOL_CASEBLOCK);
-		assertNoMsg(check, LeftCurlyTests.MACRO_REIFICATION);
-		assertNoMsg(check, LeftCurlyTests.ISSUE_97);
-		assertNoMsg(check, LeftCurlyTests.ARRAY_COMPREHENSION_ISSUE_114);
-		assertNoMsg(check, LeftCurlyTests.ARRAY_COMPREHENSION_2_ISSUE_114);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST6);
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+		assertNoMsg(check, TEST14);
+		assertNoMsg(check, EOL_CASEBLOCK);
+		assertNoMsg(check, MACRO_REIFICATION);
+		assertNoMsg(check, ISSUE_97);
+		assertNoMsg(check, ARRAY_COMPREHENSION_ISSUE_114);
+		assertNoMsg(check, ARRAY_COMPREHENSION_2_ISSUE_114);
 	}
 
 	public function testWrongBraces() {
 		var check = new LeftCurlyCheck();
-		assertMsg(check, LeftCurlyTests.TEST1, MSG_EOL);
-		assertMsg(check, LeftCurlyTests.TEST2, MSG_EOL);
-		assertMsg(check, LeftCurlyTests.TEST3, MSG_EOL);
-		assertMsg(check, LeftCurlyTests.TEST3, MSG_EOL);
-		assertMsg(check, LeftCurlyTests.TEST5, MSG_EOL);
-		assertMsg(check, LeftCurlyTests.TEST7, MSG_EOL);
-		assertMsg(check, LeftCurlyTests.TEST10, MSG_EOL);
-		assertMsg(check, LeftCurlyTests.NL_CASEBLOCK, MSG_EOL);
-		assertMsg(check, LeftCurlyTests.NLOW_CASEBLOCK, MSG_EOL);
+		assertMsg(check, TEST1, MSG_EOL);
+		assertMsg(check, TEST2, MSG_EOL);
+		assertMsg(check, TEST3, MSG_EOL);
+		assertMsg(check, TEST3, MSG_EOL);
+		assertMsg(check, TEST5, MSG_EOL);
+		assertMsg(check, TEST7, MSG_EOL);
+		assertMsg(check, TEST10, MSG_EOL);
+		assertMsg(check, NL_CASEBLOCK, MSG_EOL);
+		assertMsg(check, NLOW_CASEBLOCK, MSG_EOL);
 	}
 
 	public function testBraceOnNL() {
 		var check = new LeftCurlyCheck();
 		check.option = NL;
 
-		assertMsg(check, LeftCurlyTests.TEST, MSG_NL);
-		assertNoMsg(check, LeftCurlyTests.TEST13);
+		assertMsg(check, TEST, MSG_NL);
+		assertNoMsg(check, TEST13);
 
 		check.tokens = [OBJECT_DECL];
-		assertMsg(check, LeftCurlyTests.TEST4, MSG_NL);
-		assertMsg(check, LeftCurlyTests.TEST14, MSG_NL);
+		assertMsg(check, TEST4, MSG_NL);
+		assertMsg(check, TEST14, MSG_NL);
 
 		check.tokens = [IF];
-		assertNoMsg(check, LeftCurlyTests.TEST1);
-		assertNoMsg(check, LeftCurlyTests.TEST13);
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST13);
 
 		check.tokens = [FOR];
-		assertNoMsg(check, LeftCurlyTests.TEST5);
-		assertNoMsg(check, LeftCurlyTests.TEST13);
+		assertNoMsg(check, TEST5);
+		assertNoMsg(check, TEST13);
 
 		check.tokens = [FUNCTION];
-		assertNoMsg(check, LeftCurlyTests.TEST13);
+		assertNoMsg(check, TEST13);
 	}
 
 	public function testSwitch() {
 		var check = new LeftCurlyCheck();
 		check.option = NL;
-		assertNoMsg(check, LeftCurlyTests.TEST15);
-		assertNoMsg(check, LeftCurlyTests.NL_CASEBLOCK);
-		assertMsg(check, LeftCurlyTests.EOL_CASEBLOCK, MSG_NL);
-		assertMsg(check, LeftCurlyTests.NLOW_CASEBLOCK, MSG_NL);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, NL_CASEBLOCK);
+		assertMsg(check, EOL_CASEBLOCK, MSG_NL);
+		assertMsg(check, NLOW_CASEBLOCK, MSG_NL);
 	}
 
 	public function testNLOW() {
 		var check = new LeftCurlyCheck();
 		check.option = NLOW;
-		assertNoMsg(check, LeftCurlyTests.TEST);
-		assertNoMsg(check, LeftCurlyTests.TEST12);
-		assertNoMsg(check, LeftCurlyTests.TEST16);
-		assertNoMsg(check, LeftCurlyTests.NLOW_CASEBLOCK);
-		assertMsg(check, LeftCurlyTests.TEST17, MSG_NLOW);
-		assertMsg(check, LeftCurlyTests.TEST18, MSG_NL_SPLIT);
-		assertMsg(check, LeftCurlyTests.TEST19, MSG_NL_SPLIT);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST12);
+		assertNoMsg(check, TEST16);
+		assertNoMsg(check, NLOW_CASEBLOCK);
+		assertMsg(check, TEST17, MSG_NLOW);
+		assertMsg(check, TEST18, MSG_NL_SPLIT);
+		assertMsg(check, TEST19, MSG_NL_SPLIT);
 	}
 
 	public function testReification() {
 		var check = new LeftCurlyCheck();
 		check.tokens = [REIFICATION];
-		assertMsg(check, LeftCurlyTests.MACRO_REIFICATION, MSG_EOL);
+		assertMsg(check, MACRO_REIFICATION, MSG_EOL);
 	}
 
 	public function testIgnoreEmptySingleline() {
 		var check = new LeftCurlyCheck();
 		check.ignoreEmptySingleline = false;
-		assertMsg(check, LeftCurlyTests.NO_FIELDS_CLASS, MSG_EOL);
-		assertMsg(check, LeftCurlyTests.NO_FIELDS_MACRO, MSG_EOL);
+		assertMsg(check, NO_FIELDS_CLASS, MSG_EOL);
+		assertMsg(check, NO_FIELDS_MACRO, MSG_EOL);
 
 		check.ignoreEmptySingleline = true;
-		assertNoMsg(check, LeftCurlyTests.NO_FIELDS_CLASS);
-		assertNoMsg(check, LeftCurlyTests.NO_FIELDS_MACRO);
+		assertNoMsg(check, NO_FIELDS_CLASS);
+		assertNoMsg(check, NO_FIELDS_MACRO);
 	}
 
 	public function testArrayComprehension() {
 		var check = new LeftCurlyCheck();
 		check.tokens = [ARRAY_COMPREHENSION];
-		assertNoMsg(check, LeftCurlyTests.ARRAY_COMPREHENSION_2_ISSUE_114);
-		assertMsg(check, LeftCurlyTests.ARRAY_COMPREHENSION_ISSUE_114, MSG_EOL);
+		assertNoMsg(check, ARRAY_COMPREHENSION_2_ISSUE_114);
+		assertMsg(check, ARRAY_COMPREHENSION_ISSUE_114, MSG_EOL);
 
 		check.option = NLOW;
-		assertNoMsg(check, LeftCurlyTests.ARRAY_COMPREHENSION_2_ISSUE_114);
-		assertNoMsg(check, LeftCurlyTests.ARRAY_COMPREHENSION_NLOW_ISSUE_114);
-		assertMsg(check, LeftCurlyTests.ARRAY_COMPREHENSION_ISSUE_114, MSG_NL);
+		assertNoMsg(check, ARRAY_COMPREHENSION_2_ISSUE_114);
+		assertNoMsg(check, ARRAY_COMPREHENSION_NLOW_ISSUE_114);
+		assertMsg(check, ARRAY_COMPREHENSION_ISSUE_114, MSG_NL);
 
 		check.option = NL;
-		assertMsg(check, LeftCurlyTests.ARRAY_COMPREHENSION_2_ISSUE_114, MSG_NL);
-		assertMsg(check, LeftCurlyTests.ARRAY_COMPREHENSION_ISSUE_114, MSG_NL);
+		assertMsg(check, ARRAY_COMPREHENSION_2_ISSUE_114, MSG_NL);
+		assertMsg(check, ARRAY_COMPREHENSION_ISSUE_114, MSG_NL);
 	}
 }
 
-class LeftCurlyTests {
-	public static inline var TEST:String = "
+@:enum
+abstract LeftCurlyCheckTests(String) to String {
+	var TEST = "
 	class Test {
 		function test() {
 			if (true) {
@@ -163,7 +164,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	class Test {
 		function test() {
 			if (true)
@@ -173,7 +174,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	class Test {
 		function test() {
 			if (true)
@@ -185,7 +186,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST3:String = "
+	var TEST3 = "
 	class Test {
 		function test()
 		{
@@ -198,7 +199,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST4:String = "
+	var TEST4 = "
 	class Test {
 		function test() {
 			if (true) return { x:1,
@@ -207,7 +208,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST5:String = "
+	var TEST5 = "
 	class Test {
 		function test() {
 			for (i in 0...10)
@@ -217,7 +218,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST6:String = "
+	var TEST6 = "
 	class Test {
 		function test() {
 			for (i in 0...10) if (i < 5) {
@@ -226,14 +227,14 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST7:String = "
+	var TEST7 = "
 	class Test {
 		function test() {
 			while (true) { return i; }
 		}
 	}";
 
-	public static inline var TEST8:String = "
+	var TEST8 = "
 	class Test {
 		function test() {
 			while (true) {
@@ -242,14 +243,14 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST9:String = "
+	var TEST9 = "
 	class Test {
 		function test() {
 			for (i in 0....10) return i;
 		}
 	}";
 
-	public static inline var TEST10:String = "
+	var TEST10 = "
 	class Test
 	{
 		function test() {
@@ -257,14 +258,14 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST12:String = "
+	var TEST12 = "
 	class Test {
 		function test() {
 			var struct = {x:10, y:10, z:20};
 		}
 	}";
 
-	public static inline var TEST13:String = "
+	var TEST13 = "
 	class Test
 	{
 		function test()
@@ -283,7 +284,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST14:String = "
+	var TEST14 = "
 	typedef Test = {
 		x:Int,
 		y:Int,
@@ -291,7 +292,7 @@ class LeftCurlyTests {
 		point:{x:Int, y:Int, z:Int}
 	}";
 
-	public static inline var TEST15:String = "
+	var TEST15 = "
 	class Test
 	{
 		public function test(val:Bool):String
@@ -305,7 +306,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST16:String = "
+	var TEST16 = "
 	class Test {
 		public function test(val:Int,
 				val2:Int):String
@@ -319,7 +320,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST17:String = "
+	var TEST17 = "
 	class Test {
 		public function test(val:Int, val2:Int):String
 		{
@@ -331,7 +332,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST18:String = "
+	var TEST18 = "
 	class Test {
 		public function test(val:Int,
 				val2:Int):String {
@@ -344,7 +345,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var TEST19:String = "
+	var TEST19 = "
 	class Test {
 		public function test(val:Int,
 				val2:Int):String
@@ -357,7 +358,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var NL_CASEBLOCK:String = "
+	var NL_CASEBLOCK = "
 	class Test
 	{
 		public function test(val:Int,
@@ -374,7 +375,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var EOL_CASEBLOCK:String = "
+	var EOL_CASEBLOCK = "
 	class Test {
 		public function test(val:Int,
 				val2:Int):String {
@@ -387,7 +388,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var NLOW_CASEBLOCK:String = "
+	var NLOW_CASEBLOCK = "
 	class Test {
 		public function test(val:Int,
 				val2:Int):String
@@ -403,7 +404,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var MACRO_REIFICATION:String = "
+	var MACRO_REIFICATION = "
 	class Test {
 		public function test(val:Int) {
 			var str = 'Hello, world';
@@ -412,16 +413,16 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var NO_FIELDS_CLASS:String = "
+	var NO_FIELDS_CLASS = "
 	class Test {}
 	";
 
-	public static inline var NO_FIELDS_MACRO:String = "
+	var NO_FIELDS_MACRO = "
 	class Test {
 		var definition = macro class Font extends flash.text.Font {};
 	}";
 
-	public static inline var ISSUE_97:String = "
+	var ISSUE_97 = "
 	class Test {
 		function foo() {
 			switch (expr) {
@@ -448,7 +449,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var ARRAY_COMPREHENSION_ISSUE_114:String = "
+	var ARRAY_COMPREHENSION_ISSUE_114 = "
 	class Test {
 		public function foo() {
 			[for (i in 0...10) {index:i}];
@@ -456,7 +457,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var ARRAY_COMPREHENSION_2_ISSUE_114:String = "
+	var ARRAY_COMPREHENSION_2_ISSUE_114 = "
 	class Test {
 		public function foo() {
 			[for (i in 0...10) {
@@ -470,7 +471,7 @@ class LeftCurlyTests {
 		}
 	}";
 
-	public static inline var ARRAY_COMPREHENSION_NLOW_ISSUE_114:String = "
+	var ARRAY_COMPREHENSION_NLOW_ISSUE_114 = "
 	class Test {
 		public function foo() {
 			[for (x in 0...10)

--- a/test/checks/block/NeedBracesCheckTest.hx
+++ b/test/checks/block/NeedBracesCheckTest.hx
@@ -2,7 +2,7 @@ package checks.block;
 
 import checkstyle.checks.block.NeedBracesCheck;
 
-class NeedBracesCheckTest extends CheckTestCase {
+class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 
 	static inline var PREFIX:String = 'No braces used for body of ';
 	static inline var MSG_IF:String = PREFIX + '"if"';
@@ -17,159 +17,160 @@ class NeedBracesCheckTest extends CheckTestCase {
 
 	public function testCorrectBraces() {
 		var check = new NeedBracesCheck ();
-		assertNoMsg(check, NeedBracesTests.TEST);
-		assertNoMsg(check, NeedBracesTests.TEST3);
-		assertNoMsg(check, NeedBracesTests.TEST5);
-		assertNoMsg(check, NeedBracesTests.TEST8);
-		assertNoMsg(check, NeedBracesTests.TEST9);
-		assertNoMsg(check, NeedBracesTests.TEST10);
-		assertNoMsg(check, NeedBracesTests.TEST12);
-		assertNoMsg(check, NeedBracesTests.TEST13);
-		assertNoMsg(check, NeedBracesTests.TEST14);
-		assertNoMsg(check, NeedBracesTests.INTERFACE_DEF);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST5);
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+		assertNoMsg(check, TEST10);
+		assertNoMsg(check, TEST12);
+		assertNoMsg(check, TEST13);
+		assertNoMsg(check, TEST14);
+		assertNoMsg(check, INTERFACE_DEF);
 	}
 
 	public function testWrongBraces() {
 		var check = new NeedBracesCheck ();
-		assertMsg(check, NeedBracesTests.TEST1, MSG_IF);
-		assertMsg(check, NeedBracesTests.TEST2, MSG_ELSE);
-		assertMsg(check, NeedBracesTests.TEST4, MSG_IF);
-		assertMsg(check, NeedBracesTests.TEST6, MSG_FOR);
-		assertMsg(check, NeedBracesTests.TEST7, MSG_WHILE);
-		assertMsg(check, NeedBracesTests.TEST11, MSG_IF);
+		assertMsg(check, TEST1, MSG_IF);
+		assertMsg(check, TEST2, MSG_ELSE);
+		assertMsg(check, TEST4, MSG_IF);
+		assertMsg(check, TEST6, MSG_FOR);
+		assertMsg(check, TEST7, MSG_WHILE);
+		assertMsg(check, TEST11, MSG_IF);
 	}
 
 	public function testNoAllowSingleLine() {
 		var check = new NeedBracesCheck ();
 		check.allowSingleLineStatement = false;
 
-		assertMsg(check, NeedBracesTests.TEST, MSG_SAME_LINE_WHILE);
-		assertMsg(check, NeedBracesTests.TEST1, MSG_IF);
-		assertMsg(check, NeedBracesTests.TEST2, MSG_ELSE);
-		assertNoMsg(check, NeedBracesTests.TEST3);
-		assertMsg(check, NeedBracesTests.TEST4, MSG_IF);
-		assertNoMsg(check, NeedBracesTests.TEST5);
-		assertMsg(check, NeedBracesTests.TEST6, MSG_FOR);
-		assertMsg(check, NeedBracesTests.TEST7, MSG_WHILE);
-		assertNoMsg(check, NeedBracesTests.TEST8);
-		assertMsg(check, NeedBracesTests.TEST9, MSG_SAME_LINE_FOR);
-		assertMsg(check, NeedBracesTests.TEST10, MSG_SAME_LINE_IF);
-		assertMsg(check, NeedBracesTests.TEST11, MSG_SAME_LINE_ELSE);
-		assertMsg(check, NeedBracesTests.TEST12, MSG_ELSE);
-		assertMsg(check, NeedBracesTests.TEST13, MSG_SAME_LINE_ELSE);
-		assertMsg(check, NeedBracesTests.TEST14, MSG_ELSE);
-		assertNoMsg(check, NeedBracesTests.INTERFACE_DEF);
+		assertMsg(check, TEST, MSG_SAME_LINE_WHILE);
+		assertMsg(check, TEST1, MSG_IF);
+		assertMsg(check, TEST2, MSG_ELSE);
+		assertNoMsg(check, TEST3);
+		assertMsg(check, TEST4, MSG_IF);
+		assertNoMsg(check, TEST5);
+		assertMsg(check, TEST6, MSG_FOR);
+		assertMsg(check, TEST7, MSG_WHILE);
+		assertNoMsg(check, TEST8);
+		assertMsg(check, TEST9, MSG_SAME_LINE_FOR);
+		assertMsg(check, TEST10, MSG_SAME_LINE_IF);
+		assertMsg(check, TEST11, MSG_SAME_LINE_ELSE);
+		assertMsg(check, TEST12, MSG_ELSE);
+		assertMsg(check, TEST13, MSG_SAME_LINE_ELSE);
+		assertMsg(check, TEST14, MSG_ELSE);
+		assertNoMsg(check, INTERFACE_DEF);
 	}
 
 	public function testTokenFor() {
 		var check = new NeedBracesCheck ();
 		check.tokens = [FOR];
 
-		assertNoMsg(check, NeedBracesTests.TEST);
-		assertNoMsg(check, NeedBracesTests.TEST1);
-		assertNoMsg(check, NeedBracesTests.TEST2);
-		assertNoMsg(check, NeedBracesTests.TEST3);
-		assertNoMsg(check, NeedBracesTests.TEST4);
-		assertNoMsg(check, NeedBracesTests.TEST5);
-		assertMsg(check, NeedBracesTests.TEST6, MSG_FOR);
-		assertNoMsg(check, NeedBracesTests.TEST7);
-		assertNoMsg(check, NeedBracesTests.TEST8);
-		assertNoMsg(check, NeedBracesTests.TEST9);
-		assertNoMsg(check, NeedBracesTests.TEST10);
-		assertNoMsg(check, NeedBracesTests.TEST11);
-		assertNoMsg(check, NeedBracesTests.TEST12);
-		assertNoMsg(check, NeedBracesTests.TEST13);
-		assertNoMsg(check, NeedBracesTests.TEST14);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
+		assertMsg(check, TEST6, MSG_FOR);
+		assertNoMsg(check, TEST7);
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+		assertNoMsg(check, TEST10);
+		assertNoMsg(check, TEST11);
+		assertNoMsg(check, TEST12);
+		assertNoMsg(check, TEST13);
+		assertNoMsg(check, TEST14);
 
 		check.allowSingleLineStatement = false;
-		assertMsg(check, NeedBracesTests.TEST, MSG_SAME_LINE_FOR);
-		assertMsg(check, NeedBracesTests.TEST9, MSG_SAME_LINE_FOR);
+		assertMsg(check, TEST, MSG_SAME_LINE_FOR);
+		assertMsg(check, TEST9, MSG_SAME_LINE_FOR);
 	}
 
 	public function testTokenIf() {
 		var check = new NeedBracesCheck ();
 		check.tokens = [IF];
 
-		assertNoMsg(check, NeedBracesTests.TEST);
-		assertMsg(check, NeedBracesTests.TEST1, MSG_IF);
-		assertMsg(check, NeedBracesTests.TEST2, MSG_ELSE);
-		assertNoMsg(check, NeedBracesTests.TEST3);
-		assertMsg(check, NeedBracesTests.TEST4, MSG_IF);
-		assertNoMsg(check, NeedBracesTests.TEST5);
-		assertNoMsg(check, NeedBracesTests.TEST6);
-		assertNoMsg(check, NeedBracesTests.TEST7);
-		assertNoMsg(check, NeedBracesTests.TEST8);
-		assertNoMsg(check, NeedBracesTests.TEST9);
-		assertNoMsg(check, NeedBracesTests.TEST10);
-		assertMsg(check, NeedBracesTests.TEST11, MSG_IF);
-		assertMsg(check, NeedBracesTests.TEST12, MSG_ELSE);
-		assertNoMsg(check, NeedBracesTests.TEST13);
-		assertMsg(check, NeedBracesTests.TEST14, MSG_ELSE);
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, MSG_IF);
+		assertMsg(check, TEST2, MSG_ELSE);
+		assertNoMsg(check, TEST3);
+		assertMsg(check, TEST4, MSG_IF);
+		assertNoMsg(check, TEST5);
+		assertNoMsg(check, TEST6);
+		assertNoMsg(check, TEST7);
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+		assertNoMsg(check, TEST10);
+		assertMsg(check, TEST11, MSG_IF);
+		assertMsg(check, TEST12, MSG_ELSE);
+		assertNoMsg(check, TEST13);
+		assertMsg(check, TEST14, MSG_ELSE);
 
 		check.allowSingleLineStatement = false;
-		assertMsg(check, NeedBracesTests.TEST, MSG_SAME_LINE_IF);
-		assertMsg(check, NeedBracesTests.TEST10, MSG_SAME_LINE_IF);
-		assertMsg(check, NeedBracesTests.TEST11, MSG_SAME_LINE_ELSE);
-		assertMsg(check, NeedBracesTests.TEST13, MSG_SAME_LINE_ELSE);
-		assertMsg(check, NeedBracesTests.TEST14, MSG_ELSE);
+		assertMsg(check, TEST, MSG_SAME_LINE_IF);
+		assertMsg(check, TEST10, MSG_SAME_LINE_IF);
+		assertMsg(check, TEST11, MSG_SAME_LINE_ELSE);
+		assertMsg(check, TEST13, MSG_SAME_LINE_ELSE);
+		assertMsg(check, TEST14, MSG_ELSE);
 	}
 
 	public function testTokenElseIf() {
 		var check = new NeedBracesCheck ();
 		check.tokens = [IF, ELSE_IF];
 
-		assertNoMsg(check, NeedBracesTests.TEST);
-		assertMsg(check, NeedBracesTests.TEST1, MSG_IF);
-		assertMsg(check, NeedBracesTests.TEST2, MSG_ELSE);
-		assertNoMsg(check, NeedBracesTests.TEST3);
-		assertMsg(check, NeedBracesTests.TEST4, MSG_IF);
-		assertNoMsg(check, NeedBracesTests.TEST5);
-		assertNoMsg(check, NeedBracesTests.TEST6);
-		assertNoMsg(check, NeedBracesTests.TEST7);
-		assertNoMsg(check, NeedBracesTests.TEST8);
-		assertNoMsg(check, NeedBracesTests.TEST9);
-		assertNoMsg(check, NeedBracesTests.TEST10);
-		assertMsg(check, NeedBracesTests.TEST11, MSG_IF);
-		assertNoMsg(check, NeedBracesTests.TEST12);
-		assertNoMsg(check, NeedBracesTests.TEST13);
-		assertNoMsg(check, NeedBracesTests.TEST14);
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, MSG_IF);
+		assertMsg(check, TEST2, MSG_ELSE);
+		assertNoMsg(check, TEST3);
+		assertMsg(check, TEST4, MSG_IF);
+		assertNoMsg(check, TEST5);
+		assertNoMsg(check, TEST6);
+		assertNoMsg(check, TEST7);
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+		assertNoMsg(check, TEST10);
+		assertMsg(check, TEST11, MSG_IF);
+		assertNoMsg(check, TEST12);
+		assertNoMsg(check, TEST13);
+		assertNoMsg(check, TEST14);
 
 		check.allowSingleLineStatement = false;
-		assertMsg(check, NeedBracesTests.TEST, MSG_SAME_LINE_IF);
-		assertMsg(check, NeedBracesTests.TEST10, MSG_SAME_LINE_IF);
-		assertMsg(check, NeedBracesTests.TEST11, MSG_SAME_LINE_ELSE);
-		assertMsg(check, NeedBracesTests.TEST12, MSG_ELSE);
-		assertMsg(check, NeedBracesTests.TEST13, MSG_SAME_LINE_ELSE);
-		assertMsg(check, NeedBracesTests.TEST14, MSG_ELSE);
+		assertMsg(check, TEST, MSG_SAME_LINE_IF);
+		assertMsg(check, TEST10, MSG_SAME_LINE_IF);
+		assertMsg(check, TEST11, MSG_SAME_LINE_ELSE);
+		assertMsg(check, TEST12, MSG_ELSE);
+		assertMsg(check, TEST13, MSG_SAME_LINE_ELSE);
+		assertMsg(check, TEST14, MSG_ELSE);
 	}
 
 	public function testTokenWhile() {
 		var check = new NeedBracesCheck ();
 		check.tokens = [WHILE];
 
-		assertNoMsg(check, NeedBracesTests.TEST);
-		assertNoMsg(check, NeedBracesTests.TEST1);
-		assertNoMsg(check, NeedBracesTests.TEST2);
-		assertNoMsg(check, NeedBracesTests.TEST3);
-		assertNoMsg(check, NeedBracesTests.TEST4);
-		assertNoMsg(check, NeedBracesTests.TEST5);
-		assertNoMsg(check, NeedBracesTests.TEST6);
-		assertMsg(check, NeedBracesTests.TEST7, MSG_WHILE);
-		assertNoMsg(check, NeedBracesTests.TEST8);
-		assertNoMsg(check, NeedBracesTests.TEST9);
-		assertNoMsg(check, NeedBracesTests.TEST10);
-		assertNoMsg(check, NeedBracesTests.TEST11);
-		assertNoMsg(check, NeedBracesTests.TEST12);
-		assertNoMsg(check, NeedBracesTests.TEST13);
-		assertNoMsg(check, NeedBracesTests.TEST14);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
+		assertNoMsg(check, TEST6);
+		assertMsg(check, TEST7, MSG_WHILE);
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+		assertNoMsg(check, TEST10);
+		assertNoMsg(check, TEST11);
+		assertNoMsg(check, TEST12);
+		assertNoMsg(check, TEST13);
+		assertNoMsg(check, TEST14);
 
 		check.allowSingleLineStatement = false;
-		assertMsg(check, NeedBracesTests.TEST, MSG_SAME_LINE_WHILE);
+		assertMsg(check, TEST, MSG_SAME_LINE_WHILE);
 	}
 }
 
-class NeedBracesTests {
-	public static inline var TEST:String = "
+@:enum
+abstract NeedBracesCheckTests(String) to String {
+	var TEST = "
 	class Test {
 		function test() {
 			if (true) return;
@@ -206,7 +207,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	class Test {
 		function test() {
 			if (true)
@@ -214,7 +215,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	class Test {
 		function test() {
 			if (true) return;
@@ -223,7 +224,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST3:String = "
+	var TEST3 = "
 	class Test {
 		function test() {
 			if (true) {
@@ -235,7 +236,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST4:String = "
+	var TEST4 = "
 	class Test {
 		function test() {
 			if (true) return { x:1,
@@ -244,7 +245,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST5:String = "
+	var TEST5 = "
 	class Test {
 		function test() {
 			for (i in 0...10) {
@@ -253,7 +254,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST6:String = "
+	var TEST6 = "
 	class Test {
 		function test() {
 			for (i in 0...10) if (i < 5) {
@@ -262,7 +263,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST7:String = "
+	var TEST7 = "
 	class Test {
 		function test() {
 			while (true)
@@ -270,7 +271,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST8:String = "
+	var TEST8 = "
 	class Test {
 		function test() {
 			while (true) {
@@ -279,21 +280,21 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST9:String = "
+	var TEST9 = "
 	class Test {
 		function test() {
 			for (i in 0....10) return i;
 		}
 	}";
 
-	public static inline var TEST10:String = "
+	var TEST10 = "
 	class Test {
 		function test() {
 			if (true) return;
 		}
 	}";
 
-	public static inline var TEST11:String = "
+	var TEST11 = "
 	class Test {
 		function test() {
 			if (true)
@@ -302,7 +303,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST12:String = "
+	var TEST12 = "
 	class Test {
 		function test() {
 			if (true) return;
@@ -312,7 +313,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST13:String = "
+	var TEST13 = "
 	class Test {
 		function test() {
 			if (true) return;
@@ -320,7 +321,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var TEST14:String = "
+	var TEST14 = "
 	class Test {
 		function test() {
 			if (condition) {
@@ -331,7 +332,7 @@ class NeedBracesTests {
 		}
 	}";
 
-	public static inline var INTERFACE_DEF:String = "
+	var INTERFACE_DEF = "
 	interface Test {
 		function test();
 	}";

--- a/test/checks/block/RightCurlyCheckTest.hx
+++ b/test/checks/block/RightCurlyCheckTest.hx
@@ -2,7 +2,7 @@ package checks.block;
 
 import checkstyle.checks.block.RightCurlyCheck;
 
-class RightCurlyCheckTest extends CheckTestCase {
+class RightCurlyCheckTest extends CheckTestCase<RightCurlyCheckTests> {
 
 	static inline var MSG_ALONE:String = 'Right curly should be alone on a new line';
 	static inline var MSG_NOT_SAME_LINE:String = 'Right curly should not be on same line as left curly';
@@ -10,195 +10,196 @@ class RightCurlyCheckTest extends CheckTestCase {
 
 	public function testCorrectAloneOrSingleLine() {
 		var check = new RightCurlyCheck();
-		assertNoMsg(check, RightCurlyTests.ALONE_OR_SINGLELINE_CORRECT);
+		assertNoMsg(check, ALONE_OR_SINGLELINE_CORRECT);
 
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_IF);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_FUNCTION);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_FOR);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_WHILE);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_TRY_CATCH);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_INTERFACE);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_CLASS);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_TYPEDEF);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_SWITCH);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_CASE);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_OBJECT);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_ABSTRACT);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_ENUM);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_NESTED_OBJECT);
+		assertNoMsg(check, SINGLELINE_IF);
+		assertNoMsg(check, SINGLELINE_FUNCTION);
+		assertNoMsg(check, SINGLELINE_FOR);
+		assertNoMsg(check, SINGLELINE_WHILE);
+		assertNoMsg(check, SINGLELINE_TRY_CATCH);
+		assertNoMsg(check, SINGLELINE_INTERFACE);
+		assertNoMsg(check, SINGLELINE_CLASS);
+		assertNoMsg(check, SINGLELINE_TYPEDEF);
+		assertNoMsg(check, SINGLELINE_SWITCH);
+		assertNoMsg(check, SINGLELINE_CASE);
+		assertNoMsg(check, SINGLELINE_OBJECT);
+		assertNoMsg(check, SINGLELINE_ABSTRACT);
+		assertNoMsg(check, SINGLELINE_ENUM);
+		assertNoMsg(check, SINGLELINE_NESTED_OBJECT);
 
-		assertNoMsg(check, RightCurlyTests.MACRO_REIFICATION);
+		assertNoMsg(check, MACRO_REIFICATION);
 
-		assertNoMsg(check, RightCurlyTests.ALONE_IF);
-		assertNoMsg(check, RightCurlyTests.ALONE_FUNCTION);
-		assertNoMsg(check, RightCurlyTests.ALONE_FOR);
-		assertNoMsg(check, RightCurlyTests.ALONE_WHILE);
-		assertNoMsg(check, RightCurlyTests.ALONE_TRY_CATCH);
-		assertNoMsg(check, RightCurlyTests.ALONE_INTERFACE);
-		assertNoMsg(check, RightCurlyTests.ALONE_CLASS);
-		assertNoMsg(check, RightCurlyTests.ALONE_TYPEDEF);
-		assertNoMsg(check, RightCurlyTests.ALONE_SWITCH);
-		assertNoMsg(check, RightCurlyTests.ALONE_CASE);
-		assertNoMsg(check, RightCurlyTests.ALONE_OBJECT);
-		assertNoMsg(check, RightCurlyTests.ALONE_ABSTRACT);
-		assertNoMsg(check, RightCurlyTests.ALONE_ENUM);
-		assertNoMsg(check, RightCurlyTests.ALONE_NESTED_OBJECT);
+		assertNoMsg(check, ALONE_IF);
+		assertNoMsg(check, ALONE_FUNCTION);
+		assertNoMsg(check, ALONE_FOR);
+		assertNoMsg(check, ALONE_WHILE);
+		assertNoMsg(check, ALONE_TRY_CATCH);
+		assertNoMsg(check, ALONE_INTERFACE);
+		assertNoMsg(check, ALONE_CLASS);
+		assertNoMsg(check, ALONE_TYPEDEF);
+		assertNoMsg(check, ALONE_SWITCH);
+		assertNoMsg(check, ALONE_CASE);
+		assertNoMsg(check, ALONE_OBJECT);
+		assertNoMsg(check, ALONE_ABSTRACT);
+		assertNoMsg(check, ALONE_ENUM);
+		assertNoMsg(check, ALONE_NESTED_OBJECT);
 
-		assertNoMsg(check, RightCurlyTests.ARRAY_COMPREHENSION_ISSUE_114);
-		assertNoMsg(check, RightCurlyTests.ARRAY_COMPREHENSION_2_ISSUE_114);
+		assertNoMsg(check, ARRAY_COMPREHENSION_ISSUE_114);
+		assertNoMsg(check, ARRAY_COMPREHENSION_2_ISSUE_114);
 	}
 
 	public function testIncorrectAloneOrSingleLine() {
 		var check = new RightCurlyCheck();
-		assertMsg(check, RightCurlyTests.SAMELINE_IF, MSG_ALONE);
-		assertMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH, MSG_ALONE);
-		assertMsg(check, RightCurlyTests.SAMELINE_NESTED_OBJECT, MSG_ALONE);
+		assertMsg(check, SAMELINE_IF, MSG_ALONE);
+		assertMsg(check, SAMELINE_TRY_CATCH, MSG_ALONE);
+		assertMsg(check, SAMELINE_NESTED_OBJECT, MSG_ALONE);
 	}
 
 	public function testCorrectSame() {
 		var check = new RightCurlyCheck();
 		check.option = SAME;
-		assertNoMsg(check, RightCurlyTests.SAMELINE_IF);
-		assertNoMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH);
-		assertNoMsg(check, RightCurlyTests.SAMELINE_NESTED_OBJECT);
+		assertNoMsg(check, SAMELINE_IF);
+		assertNoMsg(check, SAMELINE_TRY_CATCH);
+		assertNoMsg(check, SAMELINE_NESTED_OBJECT);
 
-		assertNoMsg(check, RightCurlyTests.ALONE_FUNCTION);
-		assertNoMsg(check, RightCurlyTests.ALONE_FOR);
-		assertNoMsg(check, RightCurlyTests.ALONE_WHILE);
-		assertNoMsg(check, RightCurlyTests.ALONE_INTERFACE);
-		assertNoMsg(check, RightCurlyTests.ALONE_CLASS);
-		assertNoMsg(check, RightCurlyTests.ALONE_TYPEDEF);
-		assertNoMsg(check, RightCurlyTests.ALONE_SWITCH);
-		assertNoMsg(check, RightCurlyTests.ALONE_CASE);
-		assertNoMsg(check, RightCurlyTests.ALONE_OBJECT);
-		assertNoMsg(check, RightCurlyTests.ALONE_ABSTRACT);
-		assertNoMsg(check, RightCurlyTests.ALONE_ENUM);
-		assertNoMsg(check, RightCurlyTests.ALONE_NESTED_OBJECT);
+		assertNoMsg(check, ALONE_FUNCTION);
+		assertNoMsg(check, ALONE_FOR);
+		assertNoMsg(check, ALONE_WHILE);
+		assertNoMsg(check, ALONE_INTERFACE);
+		assertNoMsg(check, ALONE_CLASS);
+		assertNoMsg(check, ALONE_TYPEDEF);
+		assertNoMsg(check, ALONE_SWITCH);
+		assertNoMsg(check, ALONE_CASE);
+		assertNoMsg(check, ALONE_OBJECT);
+		assertNoMsg(check, ALONE_ABSTRACT);
+		assertNoMsg(check, ALONE_ENUM);
+		assertNoMsg(check, ALONE_NESTED_OBJECT);
 
-		assertNoMsg(check, RightCurlyTests.MACRO_REIFICATION);
+		assertNoMsg(check, MACRO_REIFICATION);
 	}
 
 	public function testIncorrectSame() {
 		var check = new RightCurlyCheck();
 		check.option = SAME;
-		assertMsg(check, RightCurlyTests.SINGLELINE_IF, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_FOR, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_WHILE, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_TRY_CATCH, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_INTERFACE, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_CLASS, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_TYPEDEF, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_SWITCH, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_CASE, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_OBJECT, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_ABSTRACT, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_ENUM, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_NESTED_OBJECT, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_IF, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_FOR, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_WHILE, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_TRY_CATCH, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_INTERFACE, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_CLASS, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_TYPEDEF, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_SWITCH, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_CASE, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_OBJECT, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_ABSTRACT, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_ENUM, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_NESTED_OBJECT, MSG_NOT_SAME_LINE);
 
-		assertMsg(check, RightCurlyTests.ALONE_IF, MSG_SAME_LINE);
-		assertMsg(check, RightCurlyTests.ALONE_TRY_CATCH, MSG_SAME_LINE);
+		assertMsg(check, ALONE_IF, MSG_SAME_LINE);
+		assertMsg(check, ALONE_TRY_CATCH, MSG_SAME_LINE);
 	}
 
 	public function testCorrectAlone() {
 		var check = new RightCurlyCheck();
 		check.option = ALONE;
-		assertNoMsg(check, RightCurlyTests.ALONE_IF);
-		assertNoMsg(check, RightCurlyTests.ALONE_FOR);
-		assertNoMsg(check, RightCurlyTests.ALONE_WHILE);
-		assertNoMsg(check, RightCurlyTests.ALONE_FUNCTION);
-		assertNoMsg(check, RightCurlyTests.ALONE_INTERFACE);
-		assertNoMsg(check, RightCurlyTests.ALONE_CLASS);
-		assertNoMsg(check, RightCurlyTests.ALONE_TYPEDEF);
-		assertNoMsg(check, RightCurlyTests.ALONE_SWITCH);
-		assertNoMsg(check, RightCurlyTests.ALONE_CASE);
-		assertNoMsg(check, RightCurlyTests.ALONE_OBJECT);
-		assertNoMsg(check, RightCurlyTests.ALONE_ABSTRACT);
-		assertNoMsg(check, RightCurlyTests.ALONE_ENUM);
-		assertNoMsg(check, RightCurlyTests.ALONE_NESTED_OBJECT);
+		assertNoMsg(check, ALONE_IF);
+		assertNoMsg(check, ALONE_FOR);
+		assertNoMsg(check, ALONE_WHILE);
+		assertNoMsg(check, ALONE_FUNCTION);
+		assertNoMsg(check, ALONE_INTERFACE);
+		assertNoMsg(check, ALONE_CLASS);
+		assertNoMsg(check, ALONE_TYPEDEF);
+		assertNoMsg(check, ALONE_SWITCH);
+		assertNoMsg(check, ALONE_CASE);
+		assertNoMsg(check, ALONE_OBJECT);
+		assertNoMsg(check, ALONE_ABSTRACT);
+		assertNoMsg(check, ALONE_ENUM);
+		assertNoMsg(check, ALONE_NESTED_OBJECT);
 
-		assertNoMsg(check, RightCurlyTests.MACRO_REIFICATION);
+		assertNoMsg(check, MACRO_REIFICATION);
 	}
 
 	public function testIncorrectAlone() {
 		var check = new RightCurlyCheck();
 		check.option = ALONE;
-		assertMsg(check, RightCurlyTests.SINGLELINE_IF, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_FUNCTION, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_FOR, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_WHILE, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_TRY_CATCH, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_INTERFACE, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_CLASS, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_TYPEDEF, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_SWITCH, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_CASE, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_OBJECT, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_ABSTRACT, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_ENUM, MSG_NOT_SAME_LINE);
-		assertMsg(check, RightCurlyTests.SINGLELINE_NESTED_OBJECT, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_IF, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_FUNCTION, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_FOR, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_WHILE, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_TRY_CATCH, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_INTERFACE, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_CLASS, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_TYPEDEF, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_SWITCH, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_CASE, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_OBJECT, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_ABSTRACT, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_ENUM, MSG_NOT_SAME_LINE);
+		assertMsg(check, SINGLELINE_NESTED_OBJECT, MSG_NOT_SAME_LINE);
 
-		assertMsg(check, RightCurlyTests.SAMELINE_IF, MSG_ALONE);
-		assertMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH, MSG_ALONE);
-		assertMsg(check, RightCurlyTests.SAMELINE_NESTED_OBJECT, MSG_ALONE);
+		assertMsg(check, SAMELINE_IF, MSG_ALONE);
+		assertMsg(check, SAMELINE_TRY_CATCH, MSG_ALONE);
+		assertMsg(check, SAMELINE_NESTED_OBJECT, MSG_ALONE);
 	}
 
 	public function testTokenIF() {
 		var check = new RightCurlyCheck();
 		check.tokens = [IF];
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_IF);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_FOR);
-		assertMsg(check, RightCurlyTests.SAMELINE_IF, MSG_ALONE);
-		assertNoMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH);
-		assertNoMsg(check, RightCurlyTests.ALONE_IF);
-		assertNoMsg(check, RightCurlyTests.ALONE_FOR);
+		assertNoMsg(check, SINGLELINE_IF);
+		assertNoMsg(check, SINGLELINE_FOR);
+		assertMsg(check, SAMELINE_IF, MSG_ALONE);
+		assertNoMsg(check, SAMELINE_TRY_CATCH);
+		assertNoMsg(check, ALONE_IF);
+		assertNoMsg(check, ALONE_FOR);
 
 		check.option = SAME;
-		assertMsg(check, RightCurlyTests.SINGLELINE_IF, MSG_NOT_SAME_LINE);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_FOR);
-		assertNoMsg(check, RightCurlyTests.SAMELINE_IF);
-		assertNoMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH);
-		assertMsg(check, RightCurlyTests.ALONE_IF, MSG_SAME_LINE);
-		assertNoMsg(check, RightCurlyTests.ALONE_FOR);
+		assertMsg(check, SINGLELINE_IF, MSG_NOT_SAME_LINE);
+		assertNoMsg(check, SINGLELINE_FOR);
+		assertNoMsg(check, SAMELINE_IF);
+		assertNoMsg(check, SAMELINE_TRY_CATCH);
+		assertMsg(check, ALONE_IF, MSG_SAME_LINE);
+		assertNoMsg(check, ALONE_FOR);
 
 		check.option = ALONE;
-		assertMsg(check, RightCurlyTests.SINGLELINE_IF, MSG_NOT_SAME_LINE);
-		assertNoMsg(check, RightCurlyTests.SINGLELINE_FOR);
-		assertMsg(check, RightCurlyTests.SAMELINE_IF, MSG_ALONE);
-		assertNoMsg(check, RightCurlyTests.SAMELINE_TRY_CATCH);
-		assertNoMsg(check, RightCurlyTests.ALONE_IF);
-		assertNoMsg(check, RightCurlyTests.ALONE_FOR);
+		assertMsg(check, SINGLELINE_IF, MSG_NOT_SAME_LINE);
+		assertNoMsg(check, SINGLELINE_FOR);
+		assertMsg(check, SAMELINE_IF, MSG_ALONE);
+		assertNoMsg(check, SAMELINE_TRY_CATCH);
+		assertNoMsg(check, ALONE_IF);
+		assertNoMsg(check, ALONE_FOR);
 	}
 
 	public function testTokenMacroReification() {
 		var check = new RightCurlyCheck();
 		check.tokens = [REIFICATION];
-		assertNoMsg(check, RightCurlyTests.MACRO_REIFICATION);
+		assertNoMsg(check, MACRO_REIFICATION);
 
 		check.option = SAME;
-		assertMsg(check, RightCurlyTests.MACRO_REIFICATION, MSG_NOT_SAME_LINE);
+		assertMsg(check, MACRO_REIFICATION, MSG_NOT_SAME_LINE);
 
 		check.option = ALONE;
-		assertMsg(check, RightCurlyTests.MACRO_REIFICATION, MSG_NOT_SAME_LINE);
+		assertMsg(check, MACRO_REIFICATION, MSG_NOT_SAME_LINE);
 	}
 
 	public function testArrayComprehension() {
 		var check = new RightCurlyCheck();
 		check.tokens = [ARRAY_COMPREHENSION];
-		assertNoMsg(check, RightCurlyTests.ARRAY_COMPREHENSION_ISSUE_114);
-		assertNoMsg(check, RightCurlyTests.ARRAY_COMPREHENSION_2_ISSUE_114);
+		assertNoMsg(check, ARRAY_COMPREHENSION_ISSUE_114);
+		assertNoMsg(check, ARRAY_COMPREHENSION_2_ISSUE_114);
 
 		check.option = SAME;
-		assertMsg(check, RightCurlyTests.ARRAY_COMPREHENSION_ISSUE_114, MSG_NOT_SAME_LINE);
-		assertNoMsg(check, RightCurlyTests.ARRAY_COMPREHENSION_2_ISSUE_114);
+		assertMsg(check, ARRAY_COMPREHENSION_ISSUE_114, MSG_NOT_SAME_LINE);
+		assertNoMsg(check, ARRAY_COMPREHENSION_2_ISSUE_114);
 
 		check.option = ALONE;
-		assertMsg(check, RightCurlyTests.ARRAY_COMPREHENSION_ISSUE_114, MSG_NOT_SAME_LINE);
-		assertNoMsg(check, RightCurlyTests.ARRAY_COMPREHENSION_2_ISSUE_114);
+		assertMsg(check, ARRAY_COMPREHENSION_ISSUE_114, MSG_NOT_SAME_LINE);
+		assertNoMsg(check, ARRAY_COMPREHENSION_2_ISSUE_114);
 	}
 }
 
-class RightCurlyTests {
-	public static inline var ALONE_OR_SINGLELINE_CORRECT:String = "
+@:enum
+abstract RightCurlyCheckTests(String) to String {
+	var ALONE_OR_SINGLELINE_CORRECT = "
 	class Test {
 		function test() {
 			if (true) { return; }
@@ -249,14 +250,14 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var SINGLELINE_IF:String = "
+	var SINGLELINE_IF = "
 	class Test {
 		function test() {
 			if (true) { return; } else { return; }
 		}
 	}";
 
-	public static inline var SAMELINE_IF:String = "
+	var SAMELINE_IF = "
 	class Test {
 		function test() {
 			if (true) {
@@ -267,7 +268,7 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var ALONE_IF:String = "
+	var ALONE_IF = "
 	class Test {
 		function test() {
 			if (true) {
@@ -279,26 +280,26 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var SINGLELINE_FUNCTION:String = "
+	var SINGLELINE_FUNCTION = "
 	class Test {
 		function test() { trace ('test'); }
 	}";
 
-	public static inline var ALONE_FUNCTION:String = "
+	var ALONE_FUNCTION = "
 	class Test {
 		function test() {
 			trace ('test');
 		}
 	}";
 
-	public static inline var SINGLELINE_FOR:String = "
+	var SINGLELINE_FOR = "
 	class Test {
 		function test() {
 			for (i in 0...100) { trace ('$i'); }
 		}
 	}";
 
-	public static inline var ALONE_FOR:String = "
+	var ALONE_FOR = "
 	class Test {
 		function test() {
 			for (i in 0...100) {
@@ -307,14 +308,14 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var SINGLELINE_WHILE:String = "
+	var SINGLELINE_WHILE = "
 	class Test {
 		function test() {
 			while (true) { trace ('test'); }
 		}
 	}";
 
-	public static inline var ALONE_WHILE:String = "
+	var ALONE_WHILE = "
 	class Test {
 		function test() {
 			while (true) {
@@ -323,14 +324,14 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var SINGLELINE_TRY_CATCH:String = "
+	var SINGLELINE_TRY_CATCH = "
 	class Test {
 		function test() {
 			try { trace ('test'); } catch (e:Dynamic) {}
 		}
 	}";
 
-	public static inline var SAMELINE_TRY_CATCH:String = "
+	var SAMELINE_TRY_CATCH = "
 	class Test {
 		function test() {
 			try {
@@ -340,7 +341,7 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var ALONE_TRY_CATCH:String = "
+	var ALONE_TRY_CATCH = "
 	class Test {
 		function test() {
 			try {
@@ -351,41 +352,41 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var SINGLELINE_INTERFACE:String = "
+	var SINGLELINE_INTERFACE = "
 	interface Test { function test(); }";
 
-	public static inline var ALONE_INTERFACE:String = "
+	var ALONE_INTERFACE = "
 	interface Test {
 		function test();
 	}";
 
-	public static inline var SINGLELINE_CLASS:String = "
+	var SINGLELINE_CLASS = "
 	class Test { function test() {}; }";
 
-	public static inline var ALONE_CLASS:String = "
+	var ALONE_CLASS = "
 	class Test {
 		function test() {
 		};
 	}";
 
-	public static inline var SINGLELINE_TYPEDEF:String = "
+	var SINGLELINE_TYPEDEF = "
 	typedef Test = { x:Int, y:Int, z:Int }";
 
-	public static inline var ALONE_TYPEDEF:String = "
+	var ALONE_TYPEDEF = "
 	typedef Test = {
 		x:Int,
 		y:Int,
 		z:Int
 	}";
 
-	public static inline var SINGLELINE_SWITCH:String = "
+	var SINGLELINE_SWITCH = "
 	class Test {
 		function test(val:Bool) {
 			switch (val) { case true: return; default: trace(val); }
 		}
 	}";
 
-	public static inline var ALONE_SWITCH:String = "
+	var ALONE_SWITCH = "
 	class Test {
 		function test() {
 			switch (val) {
@@ -397,7 +398,7 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var SINGLELINE_CASE:String = "
+	var SINGLELINE_CASE = "
 	class Test {
 		function test(val:Bool) {
 			switch (val) {
@@ -408,7 +409,7 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var ALONE_CASE:String = "
+	var ALONE_CASE = "
 	class Test {
 		function test() {
 			switch (val) {
@@ -425,14 +426,14 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var SINGLELINE_OBJECT:String = "
+	var SINGLELINE_OBJECT = "
 	class Test {
 		function test(val:Bool) {
 			var p = { x:100, y: 10, z: 2 };
 		}
 	}";
 
-	public static inline var ALONE_OBJECT:String = "
+	var ALONE_OBJECT = "
 	class Test {
 		function test() {
 			var p = {
@@ -443,10 +444,10 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var SINGLELINE_ABSTRACT:String = "
+	var SINGLELINE_ABSTRACT = "
 	abstract Test(String) { @:from public static function fromString(value:String) { return new Test('Hello $value'); } }";
 
-	public static inline var ALONE_ABSTRACT:String = "
+	var ALONE_ABSTRACT = "
 	abstract Test(String) {
 		@:from
 		public static function fromString(value:String) {
@@ -454,10 +455,10 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var SINGLELINE_ENUM:String = "
+	var SINGLELINE_ENUM = "
 	enum Test { Monday; Tuesday; Wednesday; Thursday; Friday; Weekend(day:String); }";
 
-	public static inline var ALONE_ENUM:String = "
+	var ALONE_ENUM = "
 	enum Test {
 		Monday;
 		Tuesday;
@@ -467,7 +468,7 @@ class RightCurlyTests {
 		Weekend(day:String);
 	}";
 
-	public static inline var SINGLELINE_NESTED_OBJECT:String = "
+	var SINGLELINE_NESTED_OBJECT = "
 	class Test {
 		public function test() {
 			var l = {
@@ -480,7 +481,7 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var SAMELINE_NESTED_OBJECT:String = "
+	var SAMELINE_NESTED_OBJECT = "
 	class Test {
 		public function test() {
 			var l = {
@@ -508,7 +509,7 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var ALONE_NESTED_OBJECT:String = "
+	var ALONE_NESTED_OBJECT = "
 	class Test {
 		public function test() {
 			var l = {
@@ -538,7 +539,7 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var MACRO_REIFICATION:String = "
+	var MACRO_REIFICATION = "
 	class Test {
 		public function test(val:Int) {
 			var str = 'Hello, world';
@@ -547,7 +548,7 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var ARRAY_COMPREHENSION_ISSUE_114:String = "
+	var ARRAY_COMPREHENSION_ISSUE_114 = "
 	class Test {
 		public function foo() {
 			[for (i in 0...10) {index:i}];
@@ -555,7 +556,7 @@ class RightCurlyTests {
 		}
 	}";
 
-	public static inline var ARRAY_COMPREHENSION_2_ISSUE_114:String = "
+	var ARRAY_COMPREHENSION_2_ISSUE_114 = "
 	class Test {
 		public function foo() {
 			[for (i in 0...10) {

--- a/test/checks/coding/AvoidInlineConditionalsCheckTest.hx
+++ b/test/checks/coding/AvoidInlineConditionalsCheckTest.hx
@@ -2,15 +2,16 @@ package checks.coding;
 
 import checkstyle.checks.coding.AvoidInlineConditionalsCheck;
 
-class AvoidInlineConditionalsCheckTest extends CheckTestCase {
+class AvoidInlineConditionalsCheckTest extends CheckTestCase<AvoidInlineConditionalsTests> {
 
 	public function testInlineCondition() {
-		assertMsg(new AvoidInlineConditionalsCheck(), AvoidInlineConditionalsTests.TEST1, 'Avoid inline conditionals');
+		assertMsg(new AvoidInlineConditionalsCheck(), TEST1, 'Avoid inline conditionals');
 	}
 }
 
-class AvoidInlineConditionalsTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract AvoidInlineConditionalsTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		var a:Array<Int> = [];
 		var x = (a == null || a.length < 1) ? null : a[0];

--- a/test/checks/coding/HiddenFieldCheckTest.hx
+++ b/test/checks/coding/HiddenFieldCheckTest.hx
@@ -3,59 +3,60 @@ package checks.coding;
 import checkstyle.checks.coding.HiddenFieldCheck;
 
 @SuppressWarnings('checkstyle:MultipleStringLiterals')
-class HiddenFieldCheckTest extends CheckTestCase {
+class HiddenFieldCheckTest extends CheckTestCase<HiddenFieldCheckTests> {
 
 	public function testCorrectHidden() {
 		var check = new HiddenFieldCheck();
-		assertNoMsg(check, HiddenFieldCheckTests.NO_HIDDEN_FIELDS);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_CONSTRUCTOR);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_CONSTRUCTOR_VAR);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_SETTER);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_MAIN);
+		assertNoMsg(check, NO_HIDDEN_FIELDS);
+		assertNoMsg(check, HIDDEN_FIELDS_CONSTRUCTOR);
+		assertNoMsg(check, HIDDEN_FIELDS_CONSTRUCTOR_VAR);
+		assertNoMsg(check, HIDDEN_FIELDS_SETTER);
+		assertNoMsg(check, HIDDEN_FIELDS_MAIN);
 	}
 
 	public function testDetectHiddenFields() {
 		var check = new HiddenFieldCheck();
-		assertMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_FUNC, 'Parameter definition of "field1" masks member of same name');
-		assertMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_FOR, 'For loop definition of "field1" masks member of same name');
+		assertMsg(check, HIDDEN_FIELDS_FUNC, 'Parameter definition of "field1" masks member of same name');
+		assertMsg(check, HIDDEN_FIELDS_FOR, 'For loop definition of "field1" masks member of same name');
 	}
 
 	public function testDetectHiddenFieldsInConstructor() {
 		var check = new HiddenFieldCheck();
 		check.ignoreConstructorParameter = false;
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_SETTER);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_MAIN);
-		assertNoMsg(check, HiddenFieldCheckTests.NO_HIDDEN_FIELDS);
-		assertMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_CONSTRUCTOR, 'Parameter definition of "field1" masks member of same name');
-		assertMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_CONSTRUCTOR_VAR, 'Variable definition of "field2" masks member of same name');
-		assertMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_FUNC, 'Parameter definition of "field1" masks member of same name');
+		assertNoMsg(check, HIDDEN_FIELDS_SETTER);
+		assertNoMsg(check, HIDDEN_FIELDS_MAIN);
+		assertNoMsg(check, NO_HIDDEN_FIELDS);
+		assertMsg(check, HIDDEN_FIELDS_CONSTRUCTOR, 'Parameter definition of "field1" masks member of same name');
+		assertMsg(check, HIDDEN_FIELDS_CONSTRUCTOR_VAR, 'Variable definition of "field2" masks member of same name');
+		assertMsg(check, HIDDEN_FIELDS_FUNC, 'Parameter definition of "field1" masks member of same name');
 	}
 
 	public function testDetectHiddenFieldsInSetter() {
 		var check = new HiddenFieldCheck();
 		check.ignoreSetter = false;
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_MAIN);
-		assertNoMsg(check, HiddenFieldCheckTests.NO_HIDDEN_FIELDS);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_CONSTRUCTOR);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_CONSTRUCTOR_VAR);
-		assertMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_SETTER, 'Parameter definition of "field2" masks member of same name');
-		assertMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_FUNC, 'Parameter definition of "field1" masks member of same name');
+		assertNoMsg(check, HIDDEN_FIELDS_MAIN);
+		assertNoMsg(check, NO_HIDDEN_FIELDS);
+		assertNoMsg(check, HIDDEN_FIELDS_CONSTRUCTOR);
+		assertNoMsg(check, HIDDEN_FIELDS_CONSTRUCTOR_VAR);
+		assertMsg(check, HIDDEN_FIELDS_SETTER, 'Parameter definition of "field2" masks member of same name');
+		assertMsg(check, HIDDEN_FIELDS_FUNC, 'Parameter definition of "field1" masks member of same name');
 	}
 
 	public function testDetectHiddenFieldsiRegEx() {
 		var check = new HiddenFieldCheck();
 		check.ignoreFormat = "^test$";
-		assertNoMsg(check, HiddenFieldCheckTests.NO_HIDDEN_FIELDS);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_CONSTRUCTOR);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_CONSTRUCTOR_VAR);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_SETTER);
-		assertNoMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_FUNC);
-		assertMsg(check, HiddenFieldCheckTests.HIDDEN_FIELDS_MAIN, 'Variable definition of "field2" masks member of same name');
+		assertNoMsg(check, NO_HIDDEN_FIELDS);
+		assertNoMsg(check, HIDDEN_FIELDS_CONSTRUCTOR);
+		assertNoMsg(check, HIDDEN_FIELDS_CONSTRUCTOR_VAR);
+		assertNoMsg(check, HIDDEN_FIELDS_SETTER);
+		assertNoMsg(check, HIDDEN_FIELDS_FUNC);
+		assertMsg(check, HIDDEN_FIELDS_MAIN, 'Variable definition of "field2" masks member of same name');
 	}
 }
 
-class HiddenFieldCheckTests {
-	public static inline var NO_HIDDEN_FIELDS:String = "
+@:enum
+abstract HiddenFieldCheckTests(String) to String {
+	var NO_HIDDEN_FIELDS = "
 	class Test {
 		var field1:Int;
 		var field2:Int = 1;
@@ -77,7 +78,7 @@ class HiddenFieldCheckTests {
 		}
 	}";
 
-	public static inline var HIDDEN_FIELDS_CONSTRUCTOR:String = "
+	var HIDDEN_FIELDS_CONSTRUCTOR = "
 	class Test {
 		var field1:Int;
 		var field2:Int = 1;
@@ -86,7 +87,7 @@ class HiddenFieldCheckTests {
 		}
 	}";
 
-	public static inline var HIDDEN_FIELDS_CONSTRUCTOR_VAR:String = "
+	var HIDDEN_FIELDS_CONSTRUCTOR_VAR = "
 	class Test {
 		var field1:Int;
 		var field2:Int = 1;
@@ -96,7 +97,7 @@ class HiddenFieldCheckTests {
 		}
 	}";
 
-	public static inline var HIDDEN_FIELDS_SETTER:String = "
+	var HIDDEN_FIELDS_SETTER = "
 	class Test {
 		var field1:Int;
 		var field2:Int = 1;
@@ -108,7 +109,7 @@ class HiddenFieldCheckTests {
 		}
 	}";
 
-	public static inline var HIDDEN_FIELDS_FUNC:String = "
+	var HIDDEN_FIELDS_FUNC = "
 	class Test {
 		var field1:Int;
 		var field2:Int = 1;
@@ -117,7 +118,7 @@ class HiddenFieldCheckTests {
 		}
 	}";
 
-	public static inline var HIDDEN_FIELDS_MAIN:String = "
+	var HIDDEN_FIELDS_MAIN = "
 	class Test {
 		var field1:Int;
 		var field2:Int = 1;
@@ -126,7 +127,7 @@ class HiddenFieldCheckTests {
 		}
 	}";
 
-	public static inline var HIDDEN_FIELDS_FOR:String = "
+	var HIDDEN_FIELDS_FOR = "
 	class Test {
 		var field1:Int;
 		var field2:Int = 1;

--- a/test/checks/coding/InnerAssignmentCheckTest.hx
+++ b/test/checks/coding/InnerAssignmentCheckTest.hx
@@ -2,50 +2,51 @@ package checks.coding;
 
 import checkstyle.checks.coding.InnerAssignmentCheck;
 
-class InnerAssignmentCheckTest extends CheckTestCase {
+class InnerAssignmentCheckTest extends CheckTestCase<InnerAssignmentCheckTests> {
 
 	static inline var MSG_INNER_ASSIGNMENT:String = 'Inner assignment detected';
 
 	public function testCorrectAssignment() {
 		var check = new InnerAssignmentCheck();
-		assertNoMsg(check, InnerAssignmentCheckTests.IF_EXPR);
-		assertNoMsg(check, InnerAssignmentCheckTests.WHILE_COND);
-		assertNoMsg(check, InnerAssignmentCheckTests.MEMBER_DEF);
-		assertNoMsg(check, InnerAssignmentCheckTests.METHOD_DEF);
+		assertNoMsg(check, IF_EXPR);
+		assertNoMsg(check, WHILE_COND);
+		assertNoMsg(check, MEMBER_DEF);
+		assertNoMsg(check, METHOD_DEF);
 	}
 
 	public function testIncorrectInnerAssignment() {
 		var check = new InnerAssignmentCheck();
-		assertMsg(check, InnerAssignmentCheckTests.IF_COND, MSG_INNER_ASSIGNMENT);
-		assertMsg(check, InnerAssignmentCheckTests.IF_RETURN_EXPR, MSG_INNER_ASSIGNMENT);
-		assertMsg(check, InnerAssignmentCheckTests.WHILE_COND_RETURN, MSG_INNER_ASSIGNMENT);
-		assertMsg(check, InnerAssignmentCheckTests.SWITCH, MSG_INNER_ASSIGNMENT);
+		assertMsg(check, IF_COND, MSG_INNER_ASSIGNMENT);
+		assertMsg(check, IF_RETURN_EXPR, MSG_INNER_ASSIGNMENT);
+		assertMsg(check, WHILE_COND_RETURN, MSG_INNER_ASSIGNMENT);
+		assertMsg(check, SWITCH, MSG_INNER_ASSIGNMENT);
 	}
 }
 
-class InnerAssignmentCheckTests {
-	public static inline var IF_COND:String = "
+@:enum
+abstract InnerAssignmentCheckTests(String) to String {
+	var IF_COND = "
 	abstractAndClass Test {
 		public function new() {
 			if ((a=b) > 0) return;
 		}
 	}";
 
-	public static inline var IF_EXPR:String = "
+	var IF_EXPR = "
 	abstractAndClass Test {
 		public function new() {
 			if (a==b) a=b;
 		}
 	}";
 
-	public static inline var IF_RETURN_EXPR:String = "
+	var IF_RETURN_EXPR = "
 	abstractAndClass Test {
 		public function new() {
 			if (a==b) return a=b;
 		}
 	}";
 
-	public static inline var WHILE_COND:String = "
+	var WHILE_COND = "
 	abstractAndClass Test {
 		public function new() {
 			while ((a=b) > 0) {
@@ -54,7 +55,7 @@ class InnerAssignmentCheckTests {
 		}
 	}";
 
-	public static inline var WHILE_COND_RETURN:String = "
+	var WHILE_COND_RETURN = "
 	abstractAndClass Test {
 		public function new() {
 			while ((a=b) > 0) {
@@ -63,13 +64,13 @@ class InnerAssignmentCheckTests {
 		}
 	}";
 
-	public static inline var METHOD_DEF:String = "
+	var METHOD_DEF = "
 	abstractAndClass Test {
 		public function new(a:Null<Int> = 1, b:String = 'test', c = []) {
 		}
 	}";
 
-	public static inline var MEMBER_DEF:String = "
+	var MEMBER_DEF = "
 	abstractAndClass Test {
 		var a:Null<Int> = 1;
 		var a(default, null):Null<Int> = 1;
@@ -79,7 +80,7 @@ class InnerAssignmentCheckTests {
 		}
 	}";
 
-	public static inline var SWITCH:String = "
+	var SWITCH = "
 	class Test {
 		public function new() {
 			var p = 1;

--- a/test/checks/coding/MagicNumberCheckTest.hx
+++ b/test/checks/coding/MagicNumberCheckTest.hx
@@ -2,49 +2,50 @@ package checks.coding;
 
 import checkstyle.checks.coding.MagicNumberCheck;
 
-class MagicNumberCheckTest extends CheckTestCase {
+class MagicNumberCheckTest extends CheckTestCase<MagicNumberCheckTests> {
 
 	public function testNoMagicNumber() {
 		var check = new MagicNumberCheck();
-		assertNoMsg(check, MagicNumberCheckTests.STANDARD_MAGIC_NUMBERS);
-		assertNoMsg(check, MagicNumberCheckTests.ALLOWED_MAGIC_NUMBER);
+		assertNoMsg(check, STANDARD_MAGIC_NUMBERS);
+		assertNoMsg(check, ALLOWED_MAGIC_NUMBER);
 	}
 
 	public function testMagicNumber() {
 		var check = new MagicNumberCheck();
-		assertMsg(check, MagicNumberCheckTests.INT_NUMBER_ASSIGN, 'Magic number "5" detected - consider using a constant');
-		assertMsg(check, MagicNumberCheckTests.NEGATIVE_INT_NUMBER_ASSIGN, 'Magic number "-2" detected - consider using a constant');
-		assertMsg(check, MagicNumberCheckTests.FLOAT_NUMBER_ASSIGN, 'Magic number "5.0" detected - consider using a constant');
-		assertMsg(check, MagicNumberCheckTests.INT_NUMBER_IF, 'Magic number "5" detected - consider using a constant');
-		assertMsg(check, MagicNumberCheckTests.INT_NUMBER_FUNCTION, 'Magic number "10" detected - consider using a constant');
+		assertMsg(check, INT_NUMBER_ASSIGN, 'Magic number "5" detected - consider using a constant');
+		assertMsg(check, NEGATIVE_INT_NUMBER_ASSIGN, 'Magic number "-2" detected - consider using a constant');
+		assertMsg(check, FLOAT_NUMBER_ASSIGN, 'Magic number "5.0" detected - consider using a constant');
+		assertMsg(check, INT_NUMBER_IF, 'Magic number "5" detected - consider using a constant');
+		assertMsg(check, INT_NUMBER_FUNCTION, 'Magic number "10" detected - consider using a constant');
 	}
 
 	@SuppressWarnings('checkstyle:MagicNumber')
 	public function testIgnoreNumbers() {
 		var check = new MagicNumberCheck();
 		check.ignoreNumbers = [-1, 0, 2];
-		assertMsg(check, MagicNumberCheckTests.STANDARD_MAGIC_NUMBERS, 'Magic number "1" detected - consider using a constant');
+		assertMsg(check, STANDARD_MAGIC_NUMBERS, 'Magic number "1" detected - consider using a constant');
 
 		check.ignoreNumbers = [1, 0, 2];
-		assertMsg(check, MagicNumberCheckTests.STANDARD_MAGIC_NUMBERS, 'Magic number "-1" detected - consider using a constant');
+		assertMsg(check, STANDARD_MAGIC_NUMBERS, 'Magic number "-1" detected - consider using a constant');
 
 		check.ignoreNumbers = [-1, 0, 1, 2, 5];
-		assertNoMsg(check, MagicNumberCheckTests.STANDARD_MAGIC_NUMBERS);
-		assertNoMsg(check, MagicNumberCheckTests.ALLOWED_MAGIC_NUMBER);
-		assertNoMsg(check, MagicNumberCheckTests.INT_NUMBER_ASSIGN);
-		assertNoMsg(check, MagicNumberCheckTests.FLOAT_NUMBER_ASSIGN);
-		assertNoMsg(check, MagicNumberCheckTests.INT_NUMBER_IF);
-		assertMsg(check, MagicNumberCheckTests.INT_NUMBER_FUNCTION, 'Magic number "10" detected - consider using a constant');
+		assertNoMsg(check, STANDARD_MAGIC_NUMBERS);
+		assertNoMsg(check, ALLOWED_MAGIC_NUMBER);
+		assertNoMsg(check, INT_NUMBER_ASSIGN);
+		assertNoMsg(check, FLOAT_NUMBER_ASSIGN);
+		assertNoMsg(check, INT_NUMBER_IF);
+		assertMsg(check, INT_NUMBER_FUNCTION, 'Magic number "10" detected - consider using a constant');
 	}
 
 	public function testEnumAbstract() {
 		var check = new MagicNumberCheck();
-		assertNoMsg(check, MagicNumberCheckTests.ENUM_ABSTRACT);
+		assertNoMsg(check, ENUM_ABSTRACT);
 	}
 }
 
-class MagicNumberCheckTests {
-	public static inline var STANDARD_MAGIC_NUMBERS:String = "
+@:enum
+abstract MagicNumberCheckTests(String) to String {
+	var STANDARD_MAGIC_NUMBERS = "
 	abstractAndClass Test {
 		public function new() {
 			a = -1;
@@ -54,41 +55,41 @@ class MagicNumberCheckTests {
 		}
 	}";
 
-	public static inline var INT_NUMBER_ASSIGN:String = "
+	var INT_NUMBER_ASSIGN = "
 	abstractAndClass Test {
 		public function new() {
 			a = 5;
 		}
 	}";
 
-	public static inline var NEGATIVE_INT_NUMBER_ASSIGN:String = "
+	var NEGATIVE_INT_NUMBER_ASSIGN = "
 	abstractAndClass Test {
 		public function new() {
 			a = -2;
 		}
 	}";
 
-	public static inline var FLOAT_NUMBER_ASSIGN:String = "
+	var FLOAT_NUMBER_ASSIGN = "
 	abstractAndClass Test {
 		public function new() {
 			a = 5.0;
 		}
 	}";
 
-	public static inline var INT_NUMBER_IF:String = "
+	var INT_NUMBER_IF = "
 	abstractAndClass Test {
 		public function new() {
 			if (a > 5) return;
 		}
 	}";
 
-	public static inline var INT_NUMBER_FUNCTION:String = "
+	var INT_NUMBER_FUNCTION = "
 	abstractAndClass Test {
 		public function new(a:Int = 10) {
 		}
 	}";
 
-	public static inline var ALLOWED_MAGIC_NUMBER:String = "
+	var ALLOWED_MAGIC_NUMBER = "
 	abstractAndClass Test {
 		static inline var VAL = 5;
 		public function new() {
@@ -96,7 +97,7 @@ class MagicNumberCheckTests {
 		}
 	}";
 
-	public static inline var ENUM_ABSTRACT:String = "
+	var ENUM_ABSTRACT = "
 	@:enum abstract Style(Int) {
 		var BOLD = 1;
 		var RED = 91;

--- a/test/checks/coding/MultipleVariableDeclarationsCheckTest.hx
+++ b/test/checks/coding/MultipleVariableDeclarationsCheckTest.hx
@@ -2,50 +2,51 @@ package checks.coding;
 
 import checkstyle.checks.coding.MultipleVariableDeclarationsCheck;
 
-class MultipleVariableDeclarationsCheckTest extends CheckTestCase {
+class MultipleVariableDeclarationsCheckTest extends CheckTestCase<MultipleVariableDeclarationsCheckTests> {
 
 	public function testMulitiVarsStatement() {
-		assertMsg(new MultipleVariableDeclarationsCheck(), MultipleVariableDeclarationsCheckTests.TEST1, 'Each variable declaration must be in its own statement');
-		assertMsg(new MultipleVariableDeclarationsCheck(), MultipleVariableDeclarationsCheckTests.TEST2, 'Each variable declaration must be in its own statement');
+		assertMsg(new MultipleVariableDeclarationsCheck(), TEST1, 'Each variable declaration must be in its own statement');
+		assertMsg(new MultipleVariableDeclarationsCheck(), TEST2, 'Each variable declaration must be in its own statement');
 	}
 
 	public function testMulitiVarsInOneLine() {
-		assertMsg(new MultipleVariableDeclarationsCheck(), MultipleVariableDeclarationsCheckTests.TEST3, 'Only one variable definition per line allowed');
+		assertMsg(new MultipleVariableDeclarationsCheck(), TEST3, 'Only one variable definition per line allowed');
 	}
 
 	public function testCorrectVariables() {
-		assertNoMsg(new MultipleVariableDeclarationsCheck(), MultipleVariableDeclarationsCheckTests.TEST4);
+		assertNoMsg(new MultipleVariableDeclarationsCheck(), TEST4);
 	}
 
 	public function testSuppressWarnings() {
-		assertNoMsg(new MultipleVariableDeclarationsCheck(), MultipleVariableDeclarationsCheckTests.TEST5);
-		assertNoMsg(new MultipleVariableDeclarationsCheck(), MultipleVariableDeclarationsCheckTests.TEST6);
+		assertNoMsg(new MultipleVariableDeclarationsCheck(), TEST5);
+		assertNoMsg(new MultipleVariableDeclarationsCheck(), TEST6);
 	}
 }
 
-class MultipleVariableDeclarationsCheckTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract MultipleVariableDeclarationsCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		function a() {
 			var d,e = 2;
 		}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	abstractAndClass Test {
 		function a() {
 			var d,e,f;
 		}
 	}";
 
-	public static inline var TEST3:String = "
+	var TEST3 = "
 	abstractAndClass Test {
 		function a() {
 			var d; var e;
 		}
 	}";
 
-	public static inline var TEST4:String = "
+	var TEST4 = "
 	abstractAndClass Test {
 		function a() {
 			var d;
@@ -53,7 +54,7 @@ class MultipleVariableDeclarationsCheckTests {
 		}
 	}";
 
-	public static inline var TEST5:String = "
+	var TEST5 = "
 	abstractAndClass Test {
 		@SuppressWarnings('checkstyle:MultipleVariableDeclarations')
 		function a() {
@@ -61,7 +62,7 @@ class MultipleVariableDeclarationsCheckTests {
 		}
 	}";
 
-	public static inline var TEST6:String = "
+	var TEST6 = "
 	abstractAndClass Test {
 		@SuppressWarnings('checkstyle:MultipleVariableDeclarations')
 		function a() {

--- a/test/checks/coding/NestedForDepthCheckTest.hx
+++ b/test/checks/coding/NestedForDepthCheckTest.hx
@@ -2,33 +2,34 @@ package checks.coding;
 
 import checkstyle.checks.coding.NestedForDepthCheck;
 
-class NestedForDepthCheckTest extends CheckTestCase {
+class NestedForDepthCheckTest extends CheckTestCase<NestedForDepthCheckTests> {
 
 	public function testDefault() {
 		var check = new NestedForDepthCheck();
-		assertNoMsg(check, NestedForDepthTests.TEST1);
+		assertNoMsg(check, TEST1);
 	}
 
 	public function testDefaultTooMany() {
 		var check = new NestedForDepthCheck();
-		assertMsg(check, NestedForDepthTests.TEST2, 'Nested for depth is 2 (max allowed is 1)');
+		assertMsg(check, TEST2, 'Nested for depth is 2 (max allowed is 1)');
 	}
 
 	public function testMaxParameter() {
 		var check = new NestedForDepthCheck();
 		check.max = 2;
 
-		assertNoMsg(check, NestedForDepthTests.TEST1);
-		assertNoMsg(check, NestedForDepthTests.TEST2);
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
 
 		check.max = 0;
-		assertNoMsg(check, NestedForDepthTests.TEST1);
-		assertMsg(check, NestedForDepthTests.TEST2, 'Nested for depth is 1 (max allowed is 0)');
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, 'Nested for depth is 1 (max allowed is 0)');
 	}
 }
 
-class NestedForDepthTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract NestedForDepthCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		public function test(params:Array<Int>):Void {
 			for (param in params) trace(param);               // level 0
@@ -66,7 +67,7 @@ class NestedForDepthTests {
 		}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		public function test1(param:Array<Int>) {
 			for (outerParam in params) {                      // level 0

--- a/test/checks/coding/NestedIfDepthCheckTest.hx
+++ b/test/checks/coding/NestedIfDepthCheckTest.hx
@@ -2,33 +2,34 @@ package checks.coding;
 
 import checkstyle.checks.coding.NestedIfDepthCheck;
 
-class NestedIfDepthCheckTest extends CheckTestCase {
+class NestedIfDepthCheckTest extends CheckTestCase<NestedIfDepthCheckTests> {
 
 	public function testDefault() {
 		var check = new NestedIfDepthCheck();
-		assertNoMsg(check, NestedIfDepthTests.TEST1);
+		assertNoMsg(check, TEST1);
 	}
 
 	public function testDefaultTooMany() {
 		var check = new NestedIfDepthCheck();
-		assertMsg(check, NestedIfDepthTests.TEST2, 'Nested if-else depth is 2 (max allowed is 1)');
+		assertMsg(check, TEST2, 'Nested if-else depth is 2 (max allowed is 1)');
 	}
 
 	public function testMaxParameter() {
 		var check = new NestedIfDepthCheck();
 		check.max = 2;
 
-		assertNoMsg(check, NestedIfDepthTests.TEST1);
-		assertNoMsg(check, NestedIfDepthTests.TEST2);
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
 
 		check.max = 0;
-		assertNoMsg(check, NestedIfDepthTests.TEST1);
-		assertMsg(check, NestedIfDepthTests.TEST2, 'Nested if-else depth is 1 (max allowed is 0)');
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, 'Nested if-else depth is 1 (max allowed is 0)');
 	}
 }
 
-class NestedIfDepthTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract NestedIfDepthCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		public function test(param:Int):Void {
 			if (param == 0) return 0;                   // level 0
@@ -55,7 +56,7 @@ class NestedIfDepthTests {
 		}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		public function test1(param:Int) {
 			if (param == 1) {                           // level 0

--- a/test/checks/coding/NestedTryDepthCheckTest.hx
+++ b/test/checks/coding/NestedTryDepthCheckTest.hx
@@ -2,33 +2,34 @@ package checks.coding;
 
 import checkstyle.checks.coding.NestedTryDepthCheck;
 
-class NestedTryDepthCheckTest extends CheckTestCase {
+class NestedTryDepthCheckTest extends CheckTestCase<NestedTryDepthCheckTests> {
 
 	public function testDefault() {
 		var check = new NestedTryDepthCheck();
-		assertNoMsg(check, NestedTryDepthTests.TEST1);
+		assertNoMsg(check, TEST1);
 	}
 
 	public function testDefaultTooMany() {
 		var check = new NestedTryDepthCheck();
-		assertMsg(check, NestedTryDepthTests.TEST2, 'Nested try depth is 2 (max allowed is 1)');
+		assertMsg(check, TEST2, 'Nested try depth is 2 (max allowed is 1)');
 	}
 
 	public function testMaxParameter() {
 		var check = new NestedTryDepthCheck();
 		check.max = 2;
 
-		assertNoMsg(check, NestedTryDepthTests.TEST1);
-		assertNoMsg(check, NestedTryDepthTests.TEST2);
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
 
 		check.max = 0;
-		assertNoMsg(check, NestedTryDepthTests.TEST1);
-		assertMsg(check, NestedTryDepthTests.TEST2, 'Nested try depth is 1 (max allowed is 0)');
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, 'Nested try depth is 1 (max allowed is 0)');
 	}
 }
 
-class NestedTryDepthTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract NestedTryDepthCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		public function test() {
 			try { } catch(e:String) { }    // level 0
@@ -61,7 +62,7 @@ class NestedTryDepthTests {
 		}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		public function test1() {
 			try {                           // level 0

--- a/test/checks/coding/ReturnCountCheckTest.hx
+++ b/test/checks/coding/ReturnCountCheckTest.hx
@@ -2,35 +2,36 @@ package checks.coding;
 
 import checkstyle.checks.coding.ReturnCountCheck;
 
-class ReturnCountCheckTest extends CheckTestCase {
+class ReturnCountCheckTest extends CheckTestCase<ReturnCountCheckTests> {
 
 	public function testReturnCount() {
-		assertMsg(new ReturnCountCheck(), ReturnCountCheckTests.TEST1, 'Return count is 3 (max allowed is 2)');
+		assertMsg(new ReturnCountCheck(), TEST1, 'Return count is 3 (max allowed is 2)');
 	}
 
 	public function testCorrectReturnCount() {
-		assertNoMsg(new ReturnCountCheck(), ReturnCountCheckTests.TEST2);
+		assertNoMsg(new ReturnCountCheck(), TEST2);
 	}
 
 	public function testSuppressedReturnCount() {
-		assertNoMsg(new ReturnCountCheck(), ReturnCountCheckTests.TEST3);
+		assertNoMsg(new ReturnCountCheck(), TEST3);
 	}
 
 	public function testCustomReturnCount() {
 		var chk = new ReturnCountCheck();
 		chk.max = 1;
-		assertMsg(chk, ReturnCountCheckTests.TEST4, 'Return count is 2 (max allowed is 1)');
+		assertMsg(chk, TEST4, 'Return count is 2 (max allowed is 1)');
 	}
 
 	public function testIgnoreRE() {
 		var chk = new ReturnCountCheck();
 		chk.ignoreFormat = "^equals$";
-		assertMsg(chk, ReturnCountCheckTests.TEST5, '');
+		assertMsg(chk, TEST5, '');
 	}
 }
 
-class ReturnCountCheckTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract ReturnCountCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		function a() {
 			return 1;
@@ -39,7 +40,7 @@ class ReturnCountCheckTests {
 		}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	abstractAndClass Test {
 		function a() {
 			return 1;
@@ -49,7 +50,7 @@ class ReturnCountCheckTests {
 		}
 	}";
 
-	public static inline var TEST3:String = "
+	var TEST3 = "
 	abstractAndClass Test {
 		@SuppressWarnings('checkstyle:ReturnCount')
 		function a() {
@@ -61,7 +62,7 @@ class ReturnCountCheckTests {
 		}
 	}";
 
-	public static inline var TEST4:String = "
+	var TEST4 = "
 	abstractAndClass Test {
 		function a() {
 			return 1;
@@ -71,7 +72,7 @@ class ReturnCountCheckTests {
 		}
 	}";
 
-	public static inline var TEST5:String = "
+	var TEST5 = "
 	abstractAndClass Test {
 		function equals() {
 			return 1;

--- a/test/checks/coding/SimplifyBooleanExpressionCheckTest.hx
+++ b/test/checks/coding/SimplifyBooleanExpressionCheckTest.hx
@@ -2,25 +2,26 @@ package checks.coding;
 
 import checkstyle.checks.coding.SimplifyBooleanExpressionCheck;
 
-class SimplifyBooleanExpressionCheckTest extends CheckTestCase {
+class SimplifyBooleanExpressionCheckTest extends CheckTestCase<SimplifyBooleanExpressionCheckTests> {
 
 	static inline var MSG_SIMPLIFY:String = 'Boolean expression can be simplified';
 
 	public function testWrongExpression() {
-		assertMsg(new SimplifyBooleanExpressionCheck(), SimplifyBooleanExpressionCheckTests.TEST1, MSG_SIMPLIFY);
-		assertMsg(new SimplifyBooleanExpressionCheck(), SimplifyBooleanExpressionCheckTests.TEST2, MSG_SIMPLIFY);
-		assertMsg(new SimplifyBooleanExpressionCheck(), SimplifyBooleanExpressionCheckTests.TEST3, MSG_SIMPLIFY);
-		assertMsg(new SimplifyBooleanExpressionCheck(), SimplifyBooleanExpressionCheckTests.TEST4, MSG_SIMPLIFY);
+		assertMsg(new SimplifyBooleanExpressionCheck(), TEST1, MSG_SIMPLIFY);
+		assertMsg(new SimplifyBooleanExpressionCheck(), TEST2, MSG_SIMPLIFY);
+		assertMsg(new SimplifyBooleanExpressionCheck(), TEST3, MSG_SIMPLIFY);
+		assertMsg(new SimplifyBooleanExpressionCheck(), TEST4, MSG_SIMPLIFY);
 	}
 
 	public function testCorrectExpression() {
-		assertNoMsg(new SimplifyBooleanExpressionCheck(), SimplifyBooleanExpressionCheckTests.TEST5);
-		assertNoMsg(new SimplifyBooleanExpressionCheck(), SimplifyBooleanExpressionCheckTests.TEST6);
+		assertNoMsg(new SimplifyBooleanExpressionCheck(), TEST5);
+		assertNoMsg(new SimplifyBooleanExpressionCheck(), TEST6);
 	}
 }
 
-class SimplifyBooleanExpressionCheckTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract SimplifyBooleanExpressionCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		function test() {
 			var bvar:Bool;
@@ -28,7 +29,7 @@ class SimplifyBooleanExpressionCheckTests {
 		}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	abstractAndClass Test {
 		function test() {
 			var bvar:Bool;
@@ -36,7 +37,7 @@ class SimplifyBooleanExpressionCheckTests {
 		}
 	}";
 
-	public static inline var TEST3:String = "
+	var TEST3 = "
 	abstractAndClass Test {
 		function test() {
 			var bvar:Bool;
@@ -44,7 +45,7 @@ class SimplifyBooleanExpressionCheckTests {
 		}
 	}";
 
-	public static inline var TEST4:String = "
+	var TEST4 = "
 	abstractAndClass Test {
 		function test() {
 			var bvar:Bool;
@@ -52,7 +53,7 @@ class SimplifyBooleanExpressionCheckTests {
 		}
 	}";
 
-	public static inline var TEST5:String = "
+	var TEST5 = "
 	abstractAndClass Test {
 		function test() {
 			var bvar:Bool;
@@ -60,7 +61,7 @@ class SimplifyBooleanExpressionCheckTests {
 		}
 	}";
 
-	public static inline var TEST6:String = "
+	var TEST6 = "
 	abstractAndClass Test {
 		function test() {
 			var bvar:Bool;

--- a/test/checks/coding/SimplifyBooleanReturnCheckTest.hx
+++ b/test/checks/coding/SimplifyBooleanReturnCheckTest.hx
@@ -2,25 +2,26 @@ package checks.coding;
 
 import checkstyle.checks.coding.SimplifyBooleanReturnCheck;
 
-class SimplifyBooleanReturnCheckTest extends CheckTestCase {
+class SimplifyBooleanReturnCheckTest extends CheckTestCase<SimplifyBooleanReturnCheckTests> {
 
 	static inline var MSG_SIMPLIFY:String = "Conditional logic can be removed";
 
 	public function testWrongExpression() {
-		assertMsg(new SimplifyBooleanReturnCheck(), SimplifyBooleanReturnCheckTests.TEST1, MSG_SIMPLIFY);
+		assertMsg(new SimplifyBooleanReturnCheck(), TEST1, MSG_SIMPLIFY);
 	}
 
 	public function testCorrectExpression() {
-		assertNoMsg(new SimplifyBooleanReturnCheck(), SimplifyBooleanReturnCheckTests.TEST2);
+		assertNoMsg(new SimplifyBooleanReturnCheck(), TEST2);
 	}
 
 	public function testOnlyIfExpression() {
-		assertNoMsg(new SimplifyBooleanReturnCheck(), SimplifyBooleanReturnCheckTests.TEST3);
+		assertNoMsg(new SimplifyBooleanReturnCheck(), TEST3);
 	}
 }
 
-class SimplifyBooleanReturnCheckTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract SimplifyBooleanReturnCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		function test() {
 			var a = (10 / 5 == 2);
@@ -29,7 +30,7 @@ class SimplifyBooleanReturnCheckTests {
 		}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	abstractAndClass Test {
 		function test() {
 			var a = (10 / 5 == 2);
@@ -37,7 +38,7 @@ class SimplifyBooleanReturnCheckTests {
 		}
 	}";
 
-	public static inline var TEST3:String = "
+	var TEST3 = "
 	abstractAndClass Test {
 		function test() {
 			var a = (10 / 5 == 2);

--- a/test/checks/coding/VariableInitialisationCheckTest.hx
+++ b/test/checks/coding/VariableInitialisationCheckTest.hx
@@ -2,24 +2,25 @@ package checks.coding;
 
 import checkstyle.checks.coding.VariableInitialisationCheck;
 
-class VariableInitialisationCheckTest extends CheckTestCase {
+class VariableInitialisationCheckTest extends CheckTestCase<VariableInitialisationCheckTests> {
 
 	public function testVar() {
-		assertMsg(new VariableInitialisationCheck(), VariableInitialisationTests.TEST1,
+		assertMsg(new VariableInitialisationCheck(), TEST1,
 			'Invalid variable initialisation: _a (move initialisation to constructor or function)');
 	}
 
 	public function testStatic() {
-		assertNoMsg(new VariableInitialisationCheck(), VariableInitialisationTests.TEST2);
+		assertNoMsg(new VariableInitialisationCheck(), TEST2);
 	}
 
 	public function testEnumAbstract() {
-		assertNoMsg(new VariableInitialisationCheck(), VariableInitialisationTests.TEST3);
+		assertNoMsg(new VariableInitialisationCheck(), TEST3);
 	}
 }
 
-class VariableInitialisationTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract VariableInitialisationCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		var _a:Int = 1;
 
@@ -29,14 +30,14 @@ class VariableInitialisationTests {
 		public function new() {}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		static inline var TEST:Int = 1;
 
 		public function new() {}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"@:enum
 	abstract Test(Int) {
 		var VALUE = 0;

--- a/test/checks/design/UnnecessaryConstructorCheckTest.hx
+++ b/test/checks/design/UnnecessaryConstructorCheckTest.hx
@@ -2,35 +2,36 @@ package checks.design;
 
 import checkstyle.checks.design.UnnecessaryConstructorCheck;
 
-class UnnecessaryConstructorCheckTest extends CheckTestCase {
+class UnnecessaryConstructorCheckTest extends CheckTestCase<UnnecessaryConstructorCheckTests> {
 
 	public function testWithConstructor() {
-		assertMsg(new UnnecessaryConstructorCheck(), UnnecessaryConstructorCheckTests.TEST1, "Unnecessary constructor found");
+		assertMsg(new UnnecessaryConstructorCheck(), TEST1, "Unnecessary constructor found");
 	}
 
 	public function testWithoutConstructor() {
-		assertNoMsg(new UnnecessaryConstructorCheck(), UnnecessaryConstructorCheckTests.TEST2);
+		assertNoMsg(new UnnecessaryConstructorCheck(), TEST2);
 	}
 
 	public function testWithConstructorAndInstanceVar() {
-		assertNoMsg(new UnnecessaryConstructorCheck(), UnnecessaryConstructorCheckTests.TEST3);
+		assertNoMsg(new UnnecessaryConstructorCheck(), TEST3);
 	}
 
 	public function testWithConstructorAndInstanceFunction() {
-		assertNoMsg(new UnnecessaryConstructorCheck(), UnnecessaryConstructorCheckTests.TEST4);
+		assertNoMsg(new UnnecessaryConstructorCheck(), TEST4);
 	}
 
 	public function testJustVarsWithConstructor() {
-		assertMsg(new UnnecessaryConstructorCheck(), UnnecessaryConstructorCheckTests.TEST5, "Unnecessary constructor found");
+		assertMsg(new UnnecessaryConstructorCheck(), TEST5, "Unnecessary constructor found");
 	}
 
 	public function testJustWithConstructor() {
-		assertNoMsg(new UnnecessaryConstructorCheck(), UnnecessaryConstructorCheckTests.TEST6);
+		assertNoMsg(new UnnecessaryConstructorCheck(), TEST6);
 	}
 }
 
-class UnnecessaryConstructorCheckTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract UnnecessaryConstructorCheckTests(String) to String {
+	var TEST1 = "
 	class Test {
 		public function new() {}
 
@@ -40,7 +41,7 @@ class UnnecessaryConstructorCheckTests {
 		static function test() {}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	class Test {
 		static var a:Int = 1;
 		static inline var b:Int = 1;
@@ -48,7 +49,7 @@ class UnnecessaryConstructorCheckTests {
 		static function test() {}
 	}";
 
-	public static inline var TEST3:String = "
+	var TEST3 = "
 	class Test {
 		var loc:Float;
 		static var a:Int = 1;
@@ -61,7 +62,7 @@ class UnnecessaryConstructorCheckTests {
 		static function test() {}
 	}";
 
-	public static inline var TEST4:String = "
+	var TEST4 = "
 	class Test {
 		var loc:Float;
 		static var a:Int = 1;
@@ -76,7 +77,7 @@ class UnnecessaryConstructorCheckTests {
 		public function test2(){}
 	}";
 
-	public static inline var TEST5:String = "
+	var TEST5 = "
 	class Test {
 		public function new() {}
 
@@ -84,7 +85,7 @@ class UnnecessaryConstructorCheckTests {
 		static inline var b:Int = 1;
 	}";
 
-	public static inline var TEST6:String = "
+	var TEST6 = "
 	class Test {
 		public function new() {}
 	}";

--- a/test/checks/literal/ArrayLiteralCheckTest.hx
+++ b/test/checks/literal/ArrayLiteralCheckTest.hx
@@ -2,24 +2,25 @@ package checks.literal;
 
 import checkstyle.checks.literal.ArrayLiteralCheck;
 
-class ArrayLiteralCheckTest extends CheckTestCase {
+class ArrayLiteralCheckTest extends CheckTestCase<ArrayLiteralCheckTests> {
 
 	public function testWrongArrayInstantiation() {
-		assertMsg(new ArrayLiteralCheck(), ArrayLiteralTests.TEST1, 'Bad array instantiation, use the array literal notation [] which is shorter and cleaner');
+		assertMsg(new ArrayLiteralCheck(), TEST1, 'Bad array instantiation, use the array literal notation [] which is shorter and cleaner');
 	}
 
 	public function testCorrectArrayInstantiation() {
-		assertNoMsg(new ArrayLiteralCheck(), ArrayLiteralTests.TEST2);
+		assertNoMsg(new ArrayLiteralCheck(), TEST2);
 	}
 }
 
-class ArrayLiteralTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract ArrayLiteralCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		var _arr:Array<Int> = new Array<Int>();
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	abstractAndClass Test {
 		var _arr:Array<Int> = [];
 	}";

--- a/test/checks/literal/ERegLiteralCheckTest.hx
+++ b/test/checks/literal/ERegLiteralCheckTest.hx
@@ -2,44 +2,45 @@ package checks.literal;
 
 import checkstyle.checks.literal.ERegLiteralCheck;
 
-class ERegLiteralCheckTest extends CheckTestCase {
+class ERegLiteralCheckTest extends CheckTestCase<ERegLiteralCheckTests> {
 
 	public function testCorrectEReg() {
-		assertNoMsg(new ERegLiteralCheck(), ERegLiteralTests.TEST2);
+		assertNoMsg(new ERegLiteralCheck(), TEST2);
 	}
 
 	public function testWrongEReg() {
-		assertMsg(new ERegLiteralCheck(), ERegLiteralTests.TEST1, 'Bad EReg instantiation, define expression between ~/ and /');
+		assertMsg(new ERegLiteralCheck(), TEST1, 'Bad EReg instantiation, define expression between ~/ and /');
 	}
 
 	public function testIssue43() {
-		assertNoMsg(new ERegLiteralCheck(), ERegLiteralTests.ISSUE_43);
+		assertNoMsg(new ERegLiteralCheck(), ISSUE_43);
 	}
 
 	public function testIssue99() {
-		assertNoMsg(new ERegLiteralCheck(), ERegLiteralTests.REGEX_WITH_STRING_INTERPOLATION);
+		assertNoMsg(new ERegLiteralCheck(), REGEX_WITH_STRING_INTERPOLATION);
 	}
 }
 
-class ERegLiteralTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract ERegLiteralCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		var _reg:EReg = new EReg('test', 'i');
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		var _reg:EReg = ~/test/i;
 	}";
 
-	public static inline var ISSUE_43:String =
+	var ISSUE_43 =
 	"abstractAndClass Test {
 		function test() {
 			cast (Type.createInstance(Array, []));
 		}
 	}";
 
-	public static inline var REGEX_WITH_STRING_INTERPOLATION:String =
+	var REGEX_WITH_STRING_INTERPOLATION =
 	"abstractAndClass Test {
 		var regex = new EReg('^${pattern}$', 'ig');
 	}";

--- a/test/checks/literal/HexadecimalLiteralCheckTest.hx
+++ b/test/checks/literal/HexadecimalLiteralCheckTest.hx
@@ -2,35 +2,36 @@ package checks.literal;
 
 import checkstyle.checks.literal.HexadecimalLiteralCheck;
 
-class HexadecimalLiteralCheckTest extends CheckTestCase {
+class HexadecimalLiteralCheckTest extends CheckTestCase<HexadecimalLiteralCheckTests> {
 
 	public function test1() {
-		assertMsg(new HexadecimalLiteralCheck(), HexadecimalLiteralTests.TEST1, 'Bad hexademical literal, use upperCase');
+		assertMsg(new HexadecimalLiteralCheck(), TEST1, 'Bad hexademical literal, use upperCase');
 	}
 
 	public function test2() {
-		assertNoMsg(new HexadecimalLiteralCheck(), HexadecimalLiteralTests.TEST2);
+		assertNoMsg(new HexadecimalLiteralCheck(), TEST2);
 	}
 
 	public function test3() {
 		var check = new HexadecimalLiteralCheck();
 		check.option = "lowerCase";
-		assertMsg(check, HexadecimalLiteralTests.TEST3, 'Bad hexademical literal, use lowerCase');
+		assertMsg(check, TEST3, 'Bad hexademical literal, use lowerCase');
 	}
 }
 
-class HexadecimalLiteralTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract HexadecimalLiteralCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		var clr = 0xffffff;
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		var clr = 0x0033FF;
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"abstractAndClass Test {
 		var clr = 0x0033FF;
 	}";

--- a/test/checks/literal/MultipleStringLiteralsCheckTest.hx
+++ b/test/checks/literal/MultipleStringLiteralsCheckTest.hx
@@ -2,34 +2,35 @@ package checks.literal;
 
 import checkstyle.checks.literal.MultipleStringLiteralsCheck;
 
-class MultipleStringLiteralsCheckTest extends CheckTestCase {
+class MultipleStringLiteralsCheckTest extends CheckTestCase<MultipleStringLiteralsCheckTests> {
 
 	public function testAllowedMultipleStringLiterals() {
 		var check = new MultipleStringLiteralsCheck();
-		assertNoMsg(check, MultipleStringLiteralsCheckTests.LESS_THAN_THREE);
-		assertNoMsg(check, MultipleStringLiteralsCheckTests.CONSTANT_NOT_COUNTED);
-		assertNoMsg(check, MultipleStringLiteralsCheckTests.SINGLE_CHARS);
-		assertNoMsg(check, MultipleStringLiteralsCheckTests.THREE_SPACE);
-		assertNoMsg(check, MultipleStringLiteralsCheckTests.OBJECT_FIELD_KEYS_ISSUE_116);
+		assertNoMsg(check, LESS_THAN_THREE);
+		assertNoMsg(check, CONSTANT_NOT_COUNTED);
+		assertNoMsg(check, SINGLE_CHARS);
+		assertNoMsg(check, THREE_SPACE);
+		assertNoMsg(check, OBJECT_FIELD_KEYS_ISSUE_116);
 	}
 
 	public function testMultipleStringLiterals() {
 		var check = new MultipleStringLiteralsCheck();
-		assertMsg(check, MultipleStringLiteralsCheckTests.THREE_XML, 'Multiple string literal "xml" detected - consider using a constant');
-		assertMsg(check, MultipleStringLiteralsCheckTests.THREE_XML_SWITCH, 'Multiple string literal "xml" detected - consider using a constant');
-		assertMsg(check, MultipleStringLiteralsCheckTests.OBJECT_FIELD_VALUES_ISSUE_116, 'Multiple string literal "duplicate" detected - consider using a constant');
+		assertMsg(check, THREE_XML, 'Multiple string literal "xml" detected - consider using a constant');
+		assertMsg(check, THREE_XML_SWITCH, 'Multiple string literal "xml" detected - consider using a constant');
+		assertMsg(check, OBJECT_FIELD_VALUES_ISSUE_116, 'Multiple string literal "duplicate" detected - consider using a constant');
 	}
 
 	public function testIgnoreRegEx() {
 		var check = new MultipleStringLiteralsCheck();
 		check.ignore = "^(\\s+|xml)$";
-		assertNoMsg(check, MultipleStringLiteralsCheckTests.THREE_XML);
-		assertNoMsg(check, MultipleStringLiteralsCheckTests.THREE_XML_SWITCH);
+		assertNoMsg(check, THREE_XML);
+		assertNoMsg(check, THREE_XML_SWITCH);
 	}
 }
 
-class MultipleStringLiteralsCheckTests {
-	public static inline var LESS_THAN_THREE:String = "
+@:enum
+abstract MultipleStringLiteralsCheckTests(String) to String {
+	var LESS_THAN_THREE = "
 	class Test {
 		static var a:String = 'check';
 		public function new(f:String = 'test') {
@@ -39,7 +40,7 @@ class MultipleStringLiteralsCheckTests {
 		}
 	}";
 
-	public static inline var CONSTANT_NOT_COUNTED:String = "
+	var CONSTANT_NOT_COUNTED = "
 	class Test {
 		static var a:String = 'xml';
 		public function new(f:String = 'test') {
@@ -48,7 +49,7 @@ class MultipleStringLiteralsCheckTests {
 		}
 	}";
 
-	public static inline var THREE_XML:String = "
+	var THREE_XML = "
 	class Test {
 		var a:String = 'xml';
 		public function new(f:String = 'xml') {
@@ -56,7 +57,7 @@ class MultipleStringLiteralsCheckTests {
 		}
 	}";
 
-	public static inline var THREE_SPACE:String = "
+	var THREE_SPACE = "
 	class Test {
 		var a:String = '   ';
 		public function new(f:String = '   ') {
@@ -64,7 +65,7 @@ class MultipleStringLiteralsCheckTests {
 		}
 	}";
 
-	public static inline var THREE_XML_SWITCH:String = "
+	var THREE_XML_SWITCH = "
 	class Test {
 		var a:String = 'xml';
 		public function new(f:String = 'xml') {
@@ -75,7 +76,7 @@ class MultipleStringLiteralsCheckTests {
 		}
 	}";
 
-	public static inline var SINGLE_CHARS:String = "
+	var SINGLE_CHARS = "
 	class Test {
 		public function new() {
 			a = 'a' + 'a' + 'a' + 'a' + 'a';
@@ -83,7 +84,7 @@ class MultipleStringLiteralsCheckTests {
 		}
 	}";
 
-	public static inline var OBJECT_FIELD_KEYS_ISSUE_116:String = "
+	var OBJECT_FIELD_KEYS_ISSUE_116 = "
 	class Test {
 		function foo() {
 			var array = [
@@ -100,7 +101,7 @@ class MultipleStringLiteralsCheckTests {
 		}
 	}";
 
-	public static inline var OBJECT_FIELD_VALUES_ISSUE_116:String = "
+	var OBJECT_FIELD_VALUES_ISSUE_116 = "
 	class Test {
 		function foo() {
 			var array = [

--- a/test/checks/modifier/ModifierOrderCheckTest.hx
+++ b/test/checks/modifier/ModifierOrderCheckTest.hx
@@ -2,41 +2,41 @@ package checks.modifier;
 
 import checkstyle.checks.modifier.ModifierOrderCheck;
 
-class ModifierOrderCheckTest extends CheckTestCase {
+class ModifierOrderCheckTest extends CheckTestCase<ModifierOrderCheckTests> {
 
 	public function testCorrectOrder() {
 		var check = new ModifierOrderCheck();
-		assertNoMsg(check, ModifierOrderTests.TEST1);
+		assertNoMsg(check, TEST1);
 	}
 
 	public function testWrongOrder() {
 		var check = new ModifierOrderCheck();
-		assertMsg(check, ModifierOrderTests.TEST2, 'Invalid modifier order: test (modifier: OVERRIDE)');
-		assertMsg(check, ModifierOrderTests.TEST3, 'Invalid modifier order: test (modifier: STATIC)');
-		assertMsg(check, ModifierOrderTests.TEST4, 'Invalid modifier order: test (modifier: MACRO)');
-		assertMsg(check, ModifierOrderTests.TEST5, 'Invalid modifier order: test (modifier: PUBLIC_PRIVATE)');
+		assertMsg(check, TEST2, 'Invalid modifier order: test (modifier: OVERRIDE)');
+		assertMsg(check, TEST3, 'Invalid modifier order: test (modifier: STATIC)');
+		assertMsg(check, TEST4, 'Invalid modifier order: test (modifier: MACRO)');
+		assertMsg(check, TEST5, 'Invalid modifier order: test (modifier: PUBLIC_PRIVATE)');
 	}
 
 	public function testModifiers() {
 		var check = new ModifierOrderCheck();
 		check.modifiers = [DYNAMIC, PUBLIC_PRIVATE, OVERRIDE, INLINE, STATIC, MACRO];
-		assertMsg(check, ModifierOrderTests.TEST1, 'Invalid modifier order: test6 (modifier: INLINE)');
-		assertNoMsg(check, ModifierOrderTests.TEST2);
-		assertNoMsg(check, ModifierOrderTests.TEST3);
-		assertNoMsg(check, ModifierOrderTests.TEST4);
-		assertNoMsg(check, ModifierOrderTests.TEST5);
+		assertMsg(check, TEST1, 'Invalid modifier order: test6 (modifier: INLINE)');
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 	}
 
 	public function testIgnore() {
 		var check = new ModifierOrderCheck();
 		check.severity = "ignore";
-		assertNoMsg(check, ModifierOrderTests.TEST1);
+		assertNoMsg(check, TEST1);
 	}
-
 }
 
-class ModifierOrderTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract ModifierOrderCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		override public function test1() {}
 		override private function test2() {}
@@ -46,22 +46,22 @@ class ModifierOrderTests {
 		public static inline function test6() {}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		public override function test() {}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"abstractAndClass Test {
 		public inline static function test() {}
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"abstractAndClass Test {
 		public macro function test() {}
 	}";
 
-	public static inline var TEST5:String =
+	var TEST5 =
 	"abstractAndClass Test {
 		dynamic public function test() {}
 	}";

--- a/test/checks/modifier/RedundantModifierCheckTest.hx
+++ b/test/checks/modifier/RedundantModifierCheckTest.hx
@@ -2,87 +2,88 @@ package checks.modifier;
 
 import checkstyle.checks.modifier.RedundantModifierCheck;
 
-class RedundantModifierCheckTest extends CheckTestCase {
+class RedundantModifierCheckTest extends CheckTestCase<RedundantModifierCheckTests> {
 
 	public function testCorrectUsage() {
-		assertNoMsg(new RedundantModifierCheck(), RedundantModifierTests.TEST);
-		assertNoMsg(new RedundantModifierCheck(), RedundantModifierTests.TEST3);
+		assertNoMsg(new RedundantModifierCheck(), TEST);
+		assertNoMsg(new RedundantModifierCheck(), TEST3);
 	}
 
 	public function testNormalClass() {
-		assertMsg(new RedundantModifierCheck(), RedundantModifierTests.TEST1, 'No need of private keyword: a');
+		assertMsg(new RedundantModifierCheck(), TEST1, 'No need of private keyword: a');
 	}
 
 	public function testInterface() {
-		assertMsg(new RedundantModifierCheck(), RedundantModifierTests.TEST2, 'No need of public keyword: a');
+		assertMsg(new RedundantModifierCheck(), TEST2, 'No need of public keyword: a');
 	}
 
 	public function testClassWithEnforce() {
 		var check = new RedundantModifierCheck();
 		check.enforcePublicPrivate = true;
-		assertNoMsg(check, RedundantModifierTests.TEST1);
+		assertNoMsg(check, TEST1);
 	}
 
 	public function testClassWithEnforceMissing() {
 		var check = new RedundantModifierCheck();
 		check.enforcePublicPrivate = true;
-		assertMsg(check, RedundantModifierTests.TEST, 'Missing private keyword: _onUpdate');
+		assertMsg(check, TEST, 'Missing private keyword: _onUpdate');
 	}
 
 	public function testInterfaceWithEnforce() {
 		var check = new RedundantModifierCheck();
 		check.enforcePublicPrivate = true;
-		assertNoMsg(check, RedundantModifierTests.TEST2);
+		assertNoMsg(check, TEST2);
 	}
 
 	public function testInterfaceWithEnforceMissing() {
 		var check = new RedundantModifierCheck();
 		check.enforcePublicPrivate = true;
-		assertMsg(check, RedundantModifierTests.TEST3, 'Missing public keyword: a');
+		assertMsg(check, TEST3, 'Missing public keyword: a');
 	}
 
 	public function testClassWithPublicFields() {
 		var check = new RedundantModifierCheck();
-		assertNoMsg(check, RedundantModifierTests.TEST4);
-		assertMsg(check, RedundantModifierTests.TEST5, 'No need of public keyword: foo');
+		assertNoMsg(check, TEST4);
+		assertMsg(check, TEST5, 'No need of public keyword: foo');
 
 		check.enforcePublicPrivate = true;
-		assertMsg(check, RedundantModifierTests.TEST6, 'Missing public keyword: foo');
+		assertMsg(check, TEST6, 'Missing public keyword: foo');
 	}
 
 	public function testEnumAbstract() {
 		var check = new RedundantModifierCheck();
-		assertMsg(check, RedundantModifierTests.TEST7, 'No need of public keyword: value');
-		assertNoMsg(check, RedundantModifierTests.TEST8);
-		assertMsg(check, RedundantModifierTests.TEST9, 'No need of private keyword: CONSTANT');
-		assertNoMsg(check, RedundantModifierTests.TEST10);
-		assertMsg(check, RedundantModifierTests.TEST11, 'No need of private keyword: foo');
-		assertNoMsg(check, RedundantModifierTests.TEST12);
+		assertMsg(check, TEST7, 'No need of public keyword: value');
+		assertNoMsg(check, TEST8);
+		assertMsg(check, TEST9, 'No need of private keyword: CONSTANT');
+		assertNoMsg(check, TEST10);
+		assertMsg(check, TEST11, 'No need of private keyword: foo');
+		assertNoMsg(check, TEST12);
 
 		check.enforcePublicPrivate = true;
-		assertNoMsg(check, RedundantModifierTests.TEST7);
-		assertMsg(check, RedundantModifierTests.TEST8, 'Missing public keyword: value');
-		assertNoMsg(check, RedundantModifierTests.TEST9);
-		assertMsg(check, RedundantModifierTests.TEST10, 'Missing private keyword: CONSTANT');
-		assertNoMsg(check, RedundantModifierTests.TEST11);
-		assertMsg(check, RedundantModifierTests.TEST12, 'Missing private keyword: foo');
+		assertNoMsg(check, TEST7);
+		assertMsg(check, TEST8, 'Missing public keyword: value');
+		assertNoMsg(check, TEST9);
+		assertMsg(check, TEST10, 'Missing private keyword: CONSTANT');
+		assertNoMsg(check, TEST11);
+		assertMsg(check, TEST12, 'Missing private keyword: foo');
 	}
 
 	public function testConstructor() {
 		var check = new RedundantModifierCheck();
-		assertNoMsg(check, RedundantModifierTests.TEST13);
-		assertMsg(check, RedundantModifierTests.TEST14, 'No need of private keyword: new');
-		assertNoMsg(check, RedundantModifierTests.TEST15);
+		assertNoMsg(check, TEST13);
+		assertMsg(check, TEST14, 'No need of private keyword: new');
+		assertNoMsg(check, TEST15);
 
 		check.enforcePublicPrivate = true;
-		assertMsg(check, RedundantModifierTests.TEST13, 'Missing private keyword: new');
-		assertNoMsg(check, RedundantModifierTests.TEST14);
-		assertNoMsg(check, RedundantModifierTests.TEST15);
+		assertMsg(check, TEST13, 'Missing private keyword: new');
+		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
 	}
 }
 
-class RedundantModifierTests {
-	public static inline var TEST:String = "
+@:enum
+abstract RedundantModifierCheckTests(String) to String {
+	var TEST = "
 	abstractAndClass Test {
 		var a:Int;
 
@@ -91,86 +92,86 @@ class RedundantModifierTests {
 		public function test(){}
 	}";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	abstractAndClass Test {
 		private var a:Int;
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	interface Test {
 		public var a:Int;
 	}";
 
-	public static inline var TEST3:String = "
+	var TEST3 = "
 	interface Test {
 		var a:Int;
 	}";
 
-	public static inline var TEST4:String = "
+	var TEST4 = "
 	@:publicFields
 	class Test {
 		private function foo() {}
 	}";
 
-	public static inline var TEST5:String = "
+	var TEST5 = "
 	@:publicFields
 	class Test {
 		public function foo() {}
 	}";
 
-	public static inline var TEST6:String = "
+	var TEST6 = "
 	@:publicFields
 	class Test {
 		function foo() {}
 	}";
 
-	public static inline var TEST7:String = "
+	var TEST7 = "
 	@:enum
 	abstract Test(Int) {
 		public var value = 0;
 	}";
 
-	public static inline var TEST8:String = "
+	var TEST8 = "
 	@:enum
 	abstract Test(Int) {
 		var value = 0;
 	}";
 
-	public static inline var TEST9:String = "
+	var TEST9 = "
 	@:enum
 	abstract Test(Int) {
 		private static inline var CONSTANT = 0;
 	}";
 
-	public static inline var TEST10:String = "
+	var TEST10 = "
 	@:enum
 	abstract Test(Int) {
 		static inline var CONSTANT = 0;
 	}";
 
-	public static inline var TEST11:String = "
+	var TEST11 = "
 	@:enum
 	abstract Test(Int) {
 		private function foo() {}
 	}";
 
-	public static inline var TEST12:String = "
+	var TEST12 = "
 	@:enum
 	abstract Test(Int) {
 		function foo() {}
 	}";
 
-	public static inline var TEST13:String = "
+	var TEST13 = "
 	abstractAndClass Test {
 		function new() {}
 	}";
 
-	public static inline var TEST14:String = "
+	var TEST14 = "
 	abstractAndClass Test {
 		private function new() {}
 	}";
 
-	public static inline var TEST15:String = "
+	var TEST15 = "
 	abstractAndClass Test {
 		public function new() {}
 	}";

--- a/test/checks/naming/ConstantNameCheckTest.hx
+++ b/test/checks/naming/ConstantNameCheckTest.hx
@@ -2,19 +2,19 @@ package checks.naming;
 
 import checkstyle.checks.naming.ConstantNameCheck;
 
-class ConstantNameCheckTest extends CheckTestCase {
+class ConstantNameCheckTest extends CheckTestCase<ConstantNameCheckTests> {
 
 	public function testCorrectNaming() {
 		var check = new ConstantNameCheck ();
-		assertNoMsg(check, ConstantNameTests.TEST);
-		assertNoMsg(check, ConstantNameTests.TEST3);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST3);
 	}
 
 	public function testWrongNaming() {
 		var check = new ConstantNameCheck ();
 		var message = 'Invalid const signature: Count (name should be ~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/)';
-		assertMsg(check, ConstantNameTests.TEST1, message);
-		assertMsg(check, ConstantNameTests.TEST2, message);
+		assertMsg(check, TEST1, message);
+		assertMsg(check, TEST2, message);
 	}
 
 	public function testIgnoreExtern() {
@@ -22,48 +22,49 @@ class ConstantNameCheckTest extends CheckTestCase {
 		check.ignoreExtern = false;
 
 		var message = 'Invalid const signature: Count (name should be ~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/)';
-		assertNoMsg(check, ConstantNameTests.TEST);
-		assertMsg(check, ConstantNameTests.TEST1, message);
-		assertMsg(check, ConstantNameTests.TEST2, message);
-		assertMsg(check, ConstantNameTests.TEST3, message);
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, message);
+		assertMsg(check, TEST2, message);
+		assertMsg(check, TEST3, message);
 	}
 
 	public function testTokenINLINE() {
 		var check = new ConstantNameCheck ();
 		check.tokens = [INLINE];
 
-		assertNoMsg(check, ConstantNameTests.TEST);
-		assertNoMsg(check, ConstantNameTests.TEST1);
-		assertMsg(check, ConstantNameTests.TEST2, 'Invalid const signature: Count (name should be ~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/)');
-		assertNoMsg(check, ConstantNameTests.TEST3);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, 'Invalid const signature: Count (name should be ~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/)');
+		assertNoMsg(check, TEST3);
 	}
 
 	public function testTokenNOTINLINE() {
 		var check = new ConstantNameCheck ();
 		check.tokens = [NOTINLINE];
 
-		assertNoMsg(check, ConstantNameTests.TEST);
-		assertMsg(check, ConstantNameTests.TEST1, 'Invalid const signature: Count (name should be ~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/)');
-		assertNoMsg(check, ConstantNameTests.TEST2);
-		assertNoMsg(check, ConstantNameTests.TEST3);
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, 'Invalid const signature: Count (name should be ~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/)');
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST3);
 	}
 
 	public function testFormat() {
 		var check = new ConstantNameCheck ();
 		check.format = "^[A-Z][a-z]*$";
 
-		assertMsg(check, ConstantNameTests.TEST, 'Invalid const signature: COUNT2 (name should be ~/^[A-Z][a-z]*$/)');
-		assertNoMsg(check, ConstantNameTests.TEST1);
-		assertNoMsg(check, ConstantNameTests.TEST2);
-		assertNoMsg(check, ConstantNameTests.TEST3);
+		assertMsg(check, TEST, 'Invalid const signature: COUNT2 (name should be ~/^[A-Z][a-z]*$/)');
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST3);
 
 		check.ignoreExtern = false;
-		assertNoMsg(check, ConstantNameTests.TEST3);
+		assertNoMsg(check, TEST3);
 	}
 }
 
-class ConstantNameTests {
-	public static inline var TEST:String = "
+@:enum
+abstract ConstantNameCheckTests(String) to String {
+	var TEST = "
 	class Test {
 		static var COUNT:Int = 1;
 		static inline var COUNT2:Int = 1;
@@ -78,14 +79,14 @@ class ConstantNameTests {
 		static var count7:Int = 1;
 	}";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	class Test {
 		static var Count:Int = 1;
 		public function test() {
 		}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"class Test {
 		static inline var Count:Int = 1;
 		public function test() {
@@ -93,7 +94,7 @@ class ConstantNameTests {
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"extern class Test {
 		static var Count:Int = 1;
 		static inline var Count:Int = 1;

--- a/test/checks/naming/ListenerNameCheckTest.hx
+++ b/test/checks/naming/ListenerNameCheckTest.hx
@@ -2,21 +2,22 @@ package checks.naming;
 
 import checkstyle.checks.naming.ListenerNameCheck;
 
-class ListenerNameCheckTest extends CheckTestCase {
+class ListenerNameCheckTest extends CheckTestCase<ListernerCheckTests> {
 
 	public function testCorrectListenerName() {
-		assertNoMsg(new ListenerNameCheck(), ListernerTests.TEST);
+		assertNoMsg(new ListenerNameCheck(), TEST);
 	}
 
 	public function testListenerName1() {
 		var check = new ListenerNameCheck();
 		check.format = "^_?on.*";
-		assertMsg(check, ListernerTests.TEST1, 'Wrong listener name: _testUpdate (should be ~/${check.format}/)');
+		assertMsg(check, TEST1, 'Wrong listener name: _testUpdate (should be ~/${check.format}/)');
 	}
 }
 
-class ListernerTests {
-	public static inline var TEST:String = "
+@:enum
+abstract ListernerCheckTests(String) to String {
+	var TEST = "
 	abstractAndClass Test {
 		var a:Stage;
 		public function new() {
@@ -26,7 +27,7 @@ class ListernerTests {
 		function _onUpdate() {}
 	}";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	abstractAndClass Test {
 		var a:Stage;
 		public function new() {

--- a/test/checks/naming/LocalVariableNameCheckTest.hx
+++ b/test/checks/naming/LocalVariableNameCheckTest.hx
@@ -2,46 +2,47 @@ package checks.naming;
 
 import checkstyle.checks.naming.LocalVariableNameCheck;
 
-class LocalVariableNameCheckTest extends CheckTestCase {
+class LocalVariableNameCheckTest extends CheckTestCase<LocalVariableNameCheckTests> {
 
 	public function testCorrectNaming() {
 		var check = new LocalVariableNameCheck ();
-		assertNoMsg(check, LocalVariableNameTests.TEST);
-		assertNoMsg(check, LocalVariableNameTests.TEST4);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST4);
 	}
 
 	public function testWrongNaming() {
 		var check = new LocalVariableNameCheck ();
 		var message = 'Invalid local var signature: Count (name should be ~/${check.format}/)';
-		assertMsg(check, LocalVariableNameTests.TEST1, message);
-		assertMsg(check, LocalVariableNameTests.TEST3, message);
+		assertMsg(check, TEST1, message);
+		assertMsg(check, TEST3, message);
 	}
 
 	public function testIgnoreExtern() {
 		var check = new LocalVariableNameCheck ();
 		check.ignoreExtern = false;
 
-		assertNoMsg(check, LocalVariableNameTests.TEST);
+		assertNoMsg(check, TEST);
 
 		var message = 'Invalid local var signature: Count (name should be ~/${check.format}/)';
-		assertMsg(check, LocalVariableNameTests.TEST1, message);
-		assertMsg(check, LocalVariableNameTests.TEST3, message);
-		assertMsg(check, LocalVariableNameTests.TEST4, message);
+		assertMsg(check, TEST1, message);
+		assertMsg(check, TEST3, message);
+		assertMsg(check, TEST4, message);
 	}
 
 	public function testFormat() {
 		var check = new LocalVariableNameCheck ();
 		check.format = "^[A-Za-z_]*$";
 
-		assertMsg(check, LocalVariableNameTests.TEST, 'Invalid local var signature: count2 (name should be ~/${check.format}/)');
-		assertNoMsg(check, LocalVariableNameTests.TEST1);
-		assertNoMsg(check, LocalVariableNameTests.TEST3);
-		assertNoMsg(check, LocalVariableNameTests.TEST4);
+		assertMsg(check, TEST, 'Invalid local var signature: count2 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
 	}
 }
 
-class LocalVariableNameTests {
-	public static inline var TEST:String = "
+@:enum
+abstract LocalVariableNameCheckTests(String) to String {
+	var TEST = "
 	class Test {
 		public function test() {
 			var a:Int;
@@ -74,21 +75,21 @@ class LocalVariableNameTests {
 		};
 	}";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	class Test {
 		public function test() {
 			var Count:Int = 1;
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"typedef Test = {
 		public function test() {
 			var Count:Int;
 		}
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"extern class Test {
 		public function test() {
 			var Count:Int = 1;

--- a/test/checks/naming/MemberNameCheckTest.hx
+++ b/test/checks/naming/MemberNameCheckTest.hx
@@ -2,21 +2,21 @@ package checks.naming;
 
 import checkstyle.checks.naming.MemberNameCheck;
 
-class MemberNameCheckTest extends CheckTestCase {
+class MemberNameCheckTest extends CheckTestCase<MemberNameCheckTests> {
 
 	public function testCorrectNaming() {
 		var check = new MemberNameCheck ();
-		assertNoMsg(check, MemberNameTests.TEST);
-		assertNoMsg(check, MemberNameTests.TEST4);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST4);
 	}
 
 	public function testWrongNaming() {
 		var check = new MemberNameCheck ();
-		assertMsg(check, MemberNameTests.TEST1, 'Invalid member signature: Count (name should be ~/${check.format}/)');
-		assertMsg(check, MemberNameTests.TEST2, 'Invalid member signature: Count (name should be ~/${check.format}/)');
-		assertMsg(check, MemberNameTests.TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
-		assertMsg(check, MemberNameTests.TEST5, 'Invalid enum member signature: VALUE_TEST (name should be ~/${check.format}/)');
-		assertMsg(check, MemberNameTests.PROPERTY_NAME, 'Invalid member signature: Example (name should be ~/^[a-z][a-zA-Z0-9]*$/)');
+		assertMsg(check, TEST1, 'Invalid member signature: Count (name should be ~/${check.format}/)');
+		assertMsg(check, TEST2, 'Invalid member signature: Count (name should be ~/${check.format}/)');
+		assertMsg(check, TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
+		assertMsg(check, TEST5, 'Invalid enum member signature: VALUE_TEST (name should be ~/${check.format}/)');
+		assertMsg(check, PROPERTY_NAME, 'Invalid member signature: Example (name should be ~/^[a-z][a-zA-Z0-9]*$/)');
 	}
 
 	public function testIgnoreExtern() {
@@ -24,12 +24,12 @@ class MemberNameCheckTest extends CheckTestCase {
 		check.ignoreExtern = false;
 
 		var memberMessage = 'Invalid member signature: Count (name should be ~/${check.format}/)';
-		assertNoMsg(check, MemberNameTests.TEST);
-		assertMsg(check, MemberNameTests.TEST1, memberMessage);
-		assertMsg(check, MemberNameTests.TEST2, memberMessage);
-		assertMsg(check, MemberNameTests.TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
-		assertMsg(check, MemberNameTests.TEST4, memberMessage);
-		assertMsg(check, MemberNameTests.TEST5, 'Invalid enum member signature: VALUE_TEST (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, memberMessage);
+		assertMsg(check, TEST2, memberMessage);
+		assertMsg(check, TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
+		assertMsg(check, TEST4, memberMessage);
+		assertMsg(check, TEST5, 'Invalid enum member signature: VALUE_TEST (name should be ~/${check.format}/)');
 	}
 
 	public function testTokenPublic() {
@@ -37,71 +37,71 @@ class MemberNameCheckTest extends CheckTestCase {
 		check.tokens = [CLASS, PUBLIC];
 
 		var memberMessage = 'Invalid member signature: Count (name should be ~/${check.format}/)';
-		assertNoMsg(check, MemberNameTests.TEST);
-		assertMsg(check, MemberNameTests.TEST1, memberMessage);
-		assertNoMsg(check, MemberNameTests.TEST2);
-		assertNoMsg(check, MemberNameTests.TEST3);
-		assertNoMsg(check, MemberNameTests.TEST4);
-		assertNoMsg(check, MemberNameTests.TEST5);
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, memberMessage);
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 
 		check.tokens = [PUBLIC, TYPEDEF];
-		assertMsg(check, MemberNameTests.TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
+		assertMsg(check, TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
 	}
 
 	public function testTokenPrivate() {
 		var check = new MemberNameCheck ();
 		check.tokens = [CLASS, PRIVATE];
 
-		assertNoMsg(check, MemberNameTests.TEST);
-		assertNoMsg(check, MemberNameTests.TEST1);
-		assertMsg(check, MemberNameTests.TEST2, 'Invalid member signature: Count (name should be ~/${check.format}/)');
-		assertNoMsg(check, MemberNameTests.TEST3);
-		assertNoMsg(check, MemberNameTests.TEST4);
-		assertNoMsg(check, MemberNameTests.TEST5);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, 'Invalid member signature: Count (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 
 		check.tokens = [PRIVATE, TYPEDEF];
-		assertMsg(check, MemberNameTests.TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
+		assertMsg(check, TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
 	}
 
 	public function testTokenEnum() {
 		var check = new MemberNameCheck ();
 		check.tokens = [ENUM];
 
-		assertNoMsg(check, MemberNameTests.TEST);
-		assertNoMsg(check, MemberNameTests.TEST1);
-		assertNoMsg(check, MemberNameTests.TEST3);
-		assertNoMsg(check, MemberNameTests.TEST4);
-		assertMsg(check, MemberNameTests.TEST5, 'Invalid enum member signature: VALUE_TEST (name should be ~/${check.format}/)');
-		assertMsg(check, MemberNameTests.TEST6, 'Invalid enum member signature: VALUE (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertMsg(check, TEST5, 'Invalid enum member signature: VALUE_TEST (name should be ~/${check.format}/)');
+		assertMsg(check, TEST6, 'Invalid enum member signature: VALUE (name should be ~/${check.format}/)');
 	}
 
 	public function testTokenTypedef() {
 		var check = new MemberNameCheck ();
 		check.tokens = [TYPEDEF];
 
-		assertNoMsg(check, MemberNameTests.TEST);
-		assertNoMsg(check, MemberNameTests.TEST1);
-		assertMsg(check, MemberNameTests.TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
-		assertNoMsg(check, MemberNameTests.TEST4);
-		assertNoMsg(check, MemberNameTests.TEST5);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 	}
 
 	public function testFormat() {
 		var check = new MemberNameCheck ();
 		check.format = "^[A-Z_]*$";
 
-		assertMsg(check, MemberNameTests.TEST, 'Invalid typedef member signature: count2 (name should be ~/${check.format}/)');
-		assertMsg(check, MemberNameTests.TEST1, 'Invalid member signature: Count (name should be ~/${check.format}/)');
-		assertMsg(check, MemberNameTests.TEST2, 'Invalid member signature: Count (name should be ~/${check.format}/)');
-		assertMsg(check, MemberNameTests.TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
-		assertNoMsg(check, MemberNameTests.TEST4);
-		assertNoMsg(check, MemberNameTests.TEST5);
-		assertNoMsg(check, MemberNameTests.TEST6);
-		assertMsg(check, MemberNameTests.ABSTRACT_FIELDS, 'Invalid member signature: EnumConstructor3 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST, 'Invalid typedef member signature: count2 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST1, 'Invalid member signature: Count (name should be ~/${check.format}/)');
+		assertMsg(check, TEST2, 'Invalid member signature: Count (name should be ~/${check.format}/)');
+		assertMsg(check, TEST3, 'Invalid typedef member signature: Count (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
+		assertNoMsg(check, TEST6);
+		assertMsg(check, ABSTRACT_FIELDS, 'Invalid member signature: EnumConstructor3 (name should be ~/${check.format}/)');
 
 		check.format = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
-		assertMsg(check, MemberNameTests.TEST5, 'Invalid enum member signature: VALUE_TEST_ (name should be ~/${check.format}/)');
-		assertMsg(check, MemberNameTests.TEST6, 'Invalid enum member signature: VALUE_ (name should be ~/${check.format}/)');
+		assertMsg(check, TEST5, 'Invalid enum member signature: VALUE_TEST_ (name should be ~/${check.format}/)');
+		assertMsg(check, TEST6, 'Invalid enum member signature: VALUE_ (name should be ~/${check.format}/)');
 	}
 
 	public function testTokenAbstract() {
@@ -109,25 +109,26 @@ class MemberNameCheckTest extends CheckTestCase {
 		check.tokens = [ABSTRACT, PUBLIC, PRIVATE];
 		check.format = "^[A-Z_]*$";
 
-		assertNoMsg(check, MemberNameTests.TEST);
-		assertMsg(check, MemberNameTests.ABSTRACT_FIELDS, 'Invalid member signature: EnumConstructor3 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST);
+		assertMsg(check, ABSTRACT_FIELDS, 'Invalid member signature: EnumConstructor3 (name should be ~/${check.format}/)');
 
 		check.tokens = [ABSTRACT, PRIVATE];
-		assertNoMsg(check, MemberNameTests.ABSTRACT_FIELDS);
+		assertNoMsg(check, ABSTRACT_FIELDS);
 
 		check.tokens = [ABSTRACT, PUBLIC];
-		assertMsg(check, MemberNameTests.ABSTRACT_FIELDS, 'Invalid member signature: EnumConstructor3 (name should be ~/${check.format}/)');
+		assertMsg(check, ABSTRACT_FIELDS, 'Invalid member signature: EnumConstructor3 (name should be ~/${check.format}/)');
 	}
 
 	public function testDefineCombinations() {
 		var check = new MemberNameCheck();
-		assertNoMsg(check, MemberNameTests.DEFINE_COMBINATIONS);
-		assertMsg(check, MemberNameTests.DEFINE_COMBINATIONS, 'Invalid member signature: Violation (name should be ~/${check.format}/)', [["flash"]]);
+		assertNoMsg(check, DEFINE_COMBINATIONS);
+		assertMsg(check, DEFINE_COMBINATIONS, 'Invalid member signature: Violation (name should be ~/${check.format}/)', [["flash"]]);
 	}
 }
 
-class MemberNameTests {
-	public static inline var TEST:String = "
+@:enum
+abstract MemberNameCheckTests(String) to String {
+	var TEST = "
 	class Test {
 		public var a:Int;
 		private var b:Int;
@@ -151,26 +152,26 @@ class MemberNameTests {
 		var COUNT6:Int = 1;
 	}";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	class Test {
 		public var Count:Int = 1;
 		public function test() {
 		}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	class Test {
 		var Count:Int = 1;
 		public function test() {
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"typedef Test = {
 		var Count:Int;
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"extern class Test {
 		var Count:Int = 1;
 		static inline var Count:Int = 1;
@@ -178,19 +179,19 @@ class MemberNameTests {
 		}
 	}";
 
-	public static inline var TEST5:String =
+	var TEST5 =
 	"enum Test {
 		VALUE_TEST_;
 		VALUE_TEST;
 	}";
 
-	public static inline var TEST6:String =
+	var TEST6 =
 	"enum Test {
 		VALUE_;
 		VALUE;
 	}";
 
-	public static inline var ABSTRACT_FIELDS:String =
+	var ABSTRACT_FIELDS =
 	"@:enum abstract MyAbstract(Int) from Int to Int
 	{
 		static public inline var NORMAL_CONST = 'hello, world';
@@ -202,12 +203,12 @@ class MemberNameTests {
 		static public function doSomething () : Void trace(NORMAL_CONST);
 	}";
 
-	public static inline var PROPERTY_NAME:String = "
+	var PROPERTY_NAME = "
 	class Test {
 		public var Example(default, null):Int;
 	}";
 
-	public static inline var DEFINE_COMBINATIONS:String = "
+	var DEFINE_COMBINATIONS = "
 	class Test {
 		#if flash
 		public var Violation:Int;

--- a/test/checks/naming/MethodNameCheckTest.hx
+++ b/test/checks/naming/MethodNameCheckTest.hx
@@ -3,21 +3,21 @@ package checks.naming;
 import checkstyle.checks.naming.MethodNameCheck;
 
 // TODO abstract tests
-class MethodNameCheckTest extends CheckTestCase {
+class MethodNameCheckTest extends CheckTestCase<MethodNameCheckTests> {
 
 	public function testCorrectNaming() {
 		var check = new MethodNameCheck ();
-		assertNoMsg(check, MethodNameTests.TEST);
-		assertNoMsg(check, MethodNameTests.TEST4);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST4);
 	}
 
 	public function testWrongNaming() {
 		var check = new MethodNameCheck ();
 		var test3Message = 'Invalid method name signature: Test3 (name should be ~/${check.format}/)';
-		assertMsg(check, MethodNameTests.TEST1, test3Message);
-		assertMsg(check, MethodNameTests.TEST2, test3Message);
-		assertMsg(check, MethodNameTests.TEST3, 'Invalid method name signature: Test (name should be ~/${check.format}/)');
-		assertMsg(check, MethodNameTests.TEST5, test3Message);
+		assertMsg(check, TEST1, test3Message);
+		assertMsg(check, TEST2, test3Message);
+		assertMsg(check, TEST3, 'Invalid method name signature: Test (name should be ~/${check.format}/)');
+		assertMsg(check, TEST5, test3Message);
 	}
 
 	public function testIgnoreExtern() {
@@ -26,101 +26,102 @@ class MethodNameCheckTest extends CheckTestCase {
 
 		var testMessage = 'Invalid method name signature: Test (name should be ~/${check.format}/)';
 		var test3Message = 'Invalid method name signature: Test3 (name should be ~/${check.format}/)';
-		assertNoMsg(check, MethodNameTests.TEST);
-		assertMsg(check, MethodNameTests.TEST1, test3Message);
-		assertMsg(check, MethodNameTests.TEST2, test3Message);
-		assertMsg(check, MethodNameTests.TEST3, testMessage);
-		assertMsg(check, MethodNameTests.TEST4, testMessage);
-		assertMsg(check, MethodNameTests.TEST5, test3Message);
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, test3Message);
+		assertMsg(check, TEST2, test3Message);
+		assertMsg(check, TEST3, testMessage);
+		assertMsg(check, TEST4, testMessage);
+		assertMsg(check, TEST5, test3Message);
 	}
 
 	public function testTokenPUBLIC() {
 		var check = new MethodNameCheck ();
 		check.tokens = [PUBLIC];
 
-		assertNoMsg(check, MethodNameTests.TEST);
-		assertMsg(check, MethodNameTests.TEST1, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
-		assertMsg(check, MethodNameTests.TEST2, 'Invalid method name signature: Test2 (name should be ~/${check.format}/)');
-		assertMsg(check, MethodNameTests.TEST3, 'Invalid method name signature: Test (name should be ~/${check.format}/)');
-		assertNoMsg(check, MethodNameTests.TEST4);
-		assertNoMsg(check, MethodNameTests.TEST5);
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST2, 'Invalid method name signature: Test2 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST3, 'Invalid method name signature: Test (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 	}
 
 	public function testTokenPRIVATE() {
 		var check = new MethodNameCheck ();
 		check.tokens = [PRIVATE];
 
-		assertNoMsg(check, MethodNameTests.TEST);
-		assertNoMsg(check, MethodNameTests.TEST1);
-		assertMsg(check, MethodNameTests.TEST2, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
-		assertNoMsg(check, MethodNameTests.TEST3);
-		assertNoMsg(check, MethodNameTests.TEST4);
-		assertMsg(check, MethodNameTests.TEST5, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertMsg(check, TEST5, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
 	}
 
 	public function testTokenSTATIC() {
 		var check = new MethodNameCheck ();
 		check.tokens = [STATIC];
 
-		assertNoMsg(check, MethodNameTests.TEST);
-		assertMsg(check, MethodNameTests.TEST1, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
-		assertMsg(check, MethodNameTests.TEST2, 'Invalid method name signature: Test1 (name should be ~/${check.format}/)');
-		assertNoMsg(check, MethodNameTests.TEST3);
-		assertNoMsg(check, MethodNameTests.TEST4);
-		assertMsg(check, MethodNameTests.TEST5, 'Invalid method name signature: Test1 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST2, 'Invalid method name signature: Test1 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertMsg(check, TEST5, 'Invalid method name signature: Test1 (name should be ~/${check.format}/)');
 	}
 
 	public function testTokenNOTSTATIC() {
 		var check = new MethodNameCheck ();
 		check.tokens = [NOTSTATIC];
 
-		assertNoMsg(check, MethodNameTests.TEST);
-		assertMsg(check, MethodNameTests.TEST1, 'Invalid method name signature: Test2 (name should be ~/${check.format}/)');
-		assertMsg(check, MethodNameTests.TEST2, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
-		assertMsg(check, MethodNameTests.TEST3, 'Invalid method name signature: Test (name should be ~/${check.format}/)');
-		assertNoMsg(check, MethodNameTests.TEST4);
-		assertMsg(check, MethodNameTests.TEST5, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, 'Invalid method name signature: Test2 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST2, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST3, 'Invalid method name signature: Test (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST4);
+		assertMsg(check, TEST5, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
 	}
 
 	public function testTokenINLINE() {
 		var check = new MethodNameCheck ();
 		check.tokens = [INLINE];
 
-		assertNoMsg(check, MethodNameTests.TEST);
-		assertMsg(check, MethodNameTests.TEST1, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
-		assertMsg(check, MethodNameTests.TEST2, 'Invalid method name signature: Test1 (name should be ~/${check.format}/)');
-		assertNoMsg(check, MethodNameTests.TEST3);
-		assertNoMsg(check, MethodNameTests.TEST4);
-		assertMsg(check, MethodNameTests.TEST5, 'Invalid method name signature: Test1 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST2, 'Invalid method name signature: Test1 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertMsg(check, TEST5, 'Invalid method name signature: Test1 (name should be ~/${check.format}/)');
 	}
 
 	public function testTokenNOTINLINE() {
 		var check = new MethodNameCheck ();
 		check.tokens = [NOTINLINE];
 
-		assertNoMsg(check, MethodNameTests.TEST);
-		assertMsg(check, MethodNameTests.TEST1, 'Invalid method name signature: Test2 (name should be ~/${check.format}/)');
-		assertMsg(check, MethodNameTests.TEST2, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
-		assertMsg(check, MethodNameTests.TEST3, 'Invalid method name signature: Test (name should be ~/${check.format}/)');
-		assertNoMsg(check, MethodNameTests.TEST4);
-		assertMsg(check, MethodNameTests.TEST5, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, 'Invalid method name signature: Test2 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST2, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST3, 'Invalid method name signature: Test (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST4);
+		assertMsg(check, TEST5, 'Invalid method name signature: Test3 (name should be ~/${check.format}/)');
 	}
 
 	public function testFormat() {
 		var check = new MethodNameCheck ();
 		check.format = "^[A-Z][a-z0-9]*$";
 
-		assertMsg(check, MethodNameTests.TEST, 'Invalid method name signature: testName (name should be ~/${check.format}/)');
-		assertNoMsg(check, MethodNameTests.TEST1);
-		assertNoMsg(check, MethodNameTests.TEST2);
-		assertNoMsg(check, MethodNameTests.TEST3);
-		assertNoMsg(check, MethodNameTests.TEST4);
-		assertNoMsg(check, MethodNameTests.TEST5);
+		assertMsg(check, TEST, 'Invalid method name signature: testName (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 	}
 }
 
-class MethodNameTests {
-	public static inline var TEST:String = "
+@:enum
+abstract MethodNameCheckTests(String) to String {
+	var TEST = "
 	class Test {
 		function test() {}
 		function testName() {}
@@ -137,14 +138,14 @@ class MethodNameTests {
 		function testName() {};
 	}";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	class Test {
 		static public function Test() {}
 		public function Test2() {}
 		static inline public function Test3() {}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	class Test {
 		static public function Test() {}
 		static inline public function Test1() {}
@@ -152,17 +153,17 @@ class MethodNameTests {
 		function Test3() {}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"typedef Test = {
 		public function Test() {}
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"extern class Test {
 		public function Test() {}
 	}";
 
-	public static inline var TEST5:String = "
+	var TEST5 = "
 	class Test {
 		static function Test() {}
 		static inline function Test1() {}

--- a/test/checks/naming/ParameterNameCheckTest.hx
+++ b/test/checks/naming/ParameterNameCheckTest.hx
@@ -2,20 +2,20 @@ package checks.naming;
 
 import checkstyle.checks.naming.ParameterNameCheck;
 
-class ParameterNameCheckTest extends CheckTestCase {
+class ParameterNameCheckTest extends CheckTestCase<ParameterNameCheckTests> {
 
 	public function testCorrectNaming() {
 		var check = new ParameterNameCheck ();
-		assertNoMsg(check, ParameterNameTests.TEST);
-		assertNoMsg(check, ParameterNameTests.TEST2);
-		assertNoMsg(check, ParameterNameTests.TEST4);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST4);
 	}
 
 	public function testWrongNaming() {
 		var check = new ParameterNameCheck ();
-		assertMsg(check, ParameterNameTests.TEST1, 'Invalid parameter name signature: Count (name should be ~/${check.format}/)');
-		assertMsg(check, ParameterNameTests.TEST3, 'Invalid parameter name signature: ParamName (name should be ~/${check.format}/)');
-		assertMsg(check, ParameterNameTests.TEST5, 'Invalid parameter name signature: ParamName (name should be ~/${check.format}/)');
+		assertMsg(check, TEST1, 'Invalid parameter name signature: Count (name should be ~/${check.format}/)');
+		assertMsg(check, TEST3, 'Invalid parameter name signature: ParamName (name should be ~/${check.format}/)');
+		assertMsg(check, TEST5, 'Invalid parameter name signature: ParamName (name should be ~/${check.format}/)');
 	}
 
 	public function testIgnoreExtern() {
@@ -23,29 +23,30 @@ class ParameterNameCheckTest extends CheckTestCase {
 		check.ignoreExtern = false;
 
 		var paramNameMessage = 'Invalid parameter name signature: ParamName (name should be ~/${check.format}/)';
-		assertNoMsg(check, ParameterNameTests.TEST);
-		assertNoMsg(check, ParameterNameTests.TEST2);
-		assertMsg(check, ParameterNameTests.TEST1, 'Invalid parameter name signature: Count (name should be ~/${check.format}/)');
-		assertMsg(check, ParameterNameTests.TEST3, paramNameMessage);
-		assertMsg(check, ParameterNameTests.TEST4, 'Invalid parameter name signature: Param1 (name should be ~/${check.format}/)');
-		assertMsg(check, ParameterNameTests.TEST5, paramNameMessage);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST2);
+		assertMsg(check, TEST1, 'Invalid parameter name signature: Count (name should be ~/${check.format}/)');
+		assertMsg(check, TEST3, paramNameMessage);
+		assertMsg(check, TEST4, 'Invalid parameter name signature: Param1 (name should be ~/${check.format}/)');
+		assertMsg(check, TEST5, paramNameMessage);
 	}
 
 	public function testFormat() {
 		var check = new ParameterNameCheck ();
 		check.format = "^[A-Z][a-zA-Z]*$";
 
-		assertMsg(check, ParameterNameTests.TEST, 'Invalid parameter name signature: paramName (name should be ~/${check.format}/)');
-		assertNoMsg(check, ParameterNameTests.TEST2);
-		assertNoMsg(check, ParameterNameTests.TEST1);
-		assertMsg(check, ParameterNameTests.TEST3, 'Invalid parameter name signature: param1 (name should be ~/${check.format}/)');
-		assertNoMsg(check, ParameterNameTests.TEST4);
-		assertNoMsg(check, ParameterNameTests.TEST5);
+		assertMsg(check, TEST, 'Invalid parameter name signature: paramName (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST3, 'Invalid parameter name signature: param1 (name should be ~/${check.format}/)');
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 	}
 }
 
-class ParameterNameTests {
-	public static inline var TEST:String = "
+@:enum
+abstract ParameterNameCheckTests(String) to String {
+	var TEST = "
 	abstractAndClass Test {
 		function test(param1:Int, paramName:String) {
 		}
@@ -66,31 +67,31 @@ class ParameterNameTests {
 		}
 	}";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	abstractAndClass Test {
 		public function test(Count:Int) {
 		}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	abstractAndClass Test {
 		public function test() {
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"typedef Test = {
 		function test(param1:Int, ParamName:String) {
 		}
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"extern class Test {
 		public function test(Param1:Int) {
 		}
 	}";
 
-	public static inline var TEST5:String =
+	var TEST5 =
 	"enum Test {
 		VALUE(ParamName:String);
 	}";

--- a/test/checks/naming/TypeNameCheckTest.hx
+++ b/test/checks/naming/TypeNameCheckTest.hx
@@ -3,42 +3,42 @@ package checks.naming;
 import checkstyle.checks.naming.TypeNameCheck;
 
 // TODO abstract tests
-class TypeNameCheckTest extends CheckTestCase {
+class TypeNameCheckTest extends CheckTestCase<TypeNameCheckTests> {
 
 	static inline var FORMAT_CLASS:String = "^C[A-Z][a-z]*$";
 
 	public function testCorrectNaming() {
 		var check = new TypeNameCheck ();
-		assertNoMsg(check, TypeNameTests.TEST);
-		assertNoMsg(check, TypeNameTests.TEST4);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST4);
 	}
 
 	public function testIncorrectNaming() {
 		var check = new TypeNameCheck ();
-		assertMsg(check, TypeNameTests.TEST6, 'Invalid class signature: Test_ (name should be ~/^[A-Z]+[a-zA-Z0-9]*$/)');
+		assertMsg(check, TEST6, 'Invalid class signature: Test_ (name should be ~/^[A-Z]+[a-zA-Z0-9]*$/)');
 	}
 
 	public function testFormat() {
 		var check = new TypeNameCheck ();
 		check.format = FORMAT_CLASS;
 
-		assertMsg(check, TypeNameTests.TEST, 'Invalid typedef signature: Test3 (name should be ~/^C[A-Z][a-z]*$/)');
-		assertNoMsg(check, TypeNameTests.TEST1);
-		assertMsg(check, TypeNameTests.TEST2, 'Invalid interface signature: Test (name should be ~/^C[A-Z][a-z]*$/)');
-		assertMsg(check, TypeNameTests.TEST3, 'Invalid typedef signature: TTest (name should be ~/^C[A-Z][a-z]*$/)');
-		assertNoMsg(check, TypeNameTests.TEST4);
-		assertMsg(check, TypeNameTests.TEST5, 'Invalid enum signature: EnumTest (name should be ~/^C[A-Z][a-z]*$/)');
+		assertMsg(check, TEST, 'Invalid typedef signature: Test3 (name should be ~/^C[A-Z][a-z]*$/)');
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, 'Invalid interface signature: Test (name should be ~/^C[A-Z][a-z]*$/)');
+		assertMsg(check, TEST3, 'Invalid typedef signature: TTest (name should be ~/^C[A-Z][a-z]*$/)');
+		assertNoMsg(check, TEST4);
+		assertMsg(check, TEST5, 'Invalid enum signature: EnumTest (name should be ~/^C[A-Z][a-z]*$/)');
 	}
 
 	public function testIgnoreExtern() {
 		var check = new TypeNameCheck ();
 		check.ignoreExtern = false;
 
-		assertNoMsg(check, TypeNameTests.TEST);
-		assertNoMsg(check, TypeNameTests.TEST4);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST4);
 
 		check.format = FORMAT_CLASS;
-		assertMsg(check, TypeNameTests.TEST4, 'Invalid class signature: TEST1 (name should be ~/^C[A-Z][a-z]*$/)');
+		assertMsg(check, TEST4, 'Invalid class signature: TEST1 (name should be ~/^C[A-Z][a-z]*$/)');
 	}
 
 	public function testTokenCLASS() {
@@ -46,12 +46,12 @@ class TypeNameCheckTest extends CheckTestCase {
 		check.tokens = [CLASS];
 		check.format = FORMAT_CLASS;
 
-		assertMsg(check, TypeNameTests.TEST, 'Invalid class signature: Test (name should be ~/^C[A-Z][a-z]*$/)');
-		assertNoMsg(check, TypeNameTests.TEST1);
-		assertNoMsg(check, TypeNameTests.TEST2);
-		assertNoMsg(check, TypeNameTests.TEST3);
-		assertNoMsg(check, TypeNameTests.TEST4);
-		assertNoMsg(check, TypeNameTests.TEST5);
+		assertMsg(check, TEST, 'Invalid class signature: Test (name should be ~/^C[A-Z][a-z]*$/)');
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 	}
 
 	public function testTokenINTERFACE() {
@@ -59,12 +59,12 @@ class TypeNameCheckTest extends CheckTestCase {
 		check.tokens = [INTERFACE];
 		check.format = "^I[A-Z][a-z]*$";
 
-		assertNoMsg(check, TypeNameTests.TEST);
-		assertNoMsg(check, TypeNameTests.TEST1);
-		assertMsg(check, TypeNameTests.TEST2, 'Invalid interface signature: Test (name should be ~/^I[A-Z][a-z]*$/)');
-		assertNoMsg(check, TypeNameTests.TEST3);
-		assertNoMsg(check, TypeNameTests.TEST4);
-		assertNoMsg(check, TypeNameTests.TEST5);
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, 'Invalid interface signature: Test (name should be ~/^I[A-Z][a-z]*$/)');
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 	}
 
 	public function testTokenENUM() {
@@ -72,12 +72,12 @@ class TypeNameCheckTest extends CheckTestCase {
 		check.tokens = [ENUM];
 		check.format = "^Enum[A-Z][a-z]*$";
 
-		assertMsg(check, TypeNameTests.TEST, 'Invalid enum signature: Test2 (name should be ~/^Enum[A-Z][a-z]*$/)');
-		assertNoMsg(check, TypeNameTests.TEST1);
-		assertNoMsg(check, TypeNameTests.TEST2);
-		assertNoMsg(check, TypeNameTests.TEST3);
-		assertNoMsg(check, TypeNameTests.TEST4);
-		assertNoMsg(check, TypeNameTests.TEST5);
+		assertMsg(check, TEST, 'Invalid enum signature: Test2 (name should be ~/^Enum[A-Z][a-z]*$/)');
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 	}
 
 	public function testTokenTYPEDEF() {
@@ -85,17 +85,18 @@ class TypeNameCheckTest extends CheckTestCase {
 		check.tokens = [TYPEDEF];
 		check.format = "^T[A-Z][a-z]*$";
 
-		assertMsg(check, TypeNameTests.TEST, 'Invalid typedef signature: Test3 (name should be ~/^T[A-Z][a-z]*$/)');
-		assertNoMsg(check, TypeNameTests.TEST1);
-		assertNoMsg(check, TypeNameTests.TEST2);
-		assertNoMsg(check, TypeNameTests.TEST3);
-		assertNoMsg(check, TypeNameTests.TEST4);
-		assertNoMsg(check, TypeNameTests.TEST5);
+		assertMsg(check, TEST, 'Invalid typedef signature: Test3 (name should be ~/^T[A-Z][a-z]*$/)');
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 	}
 }
 
-class TypeNameTests {
-	public static inline var TEST:String = "
+@:enum
+abstract TypeNameCheckTests(String) to String {
+	var TEST = "
 	class Test {
 		public var a:Int;
 		private var b:Int;
@@ -117,20 +118,20 @@ class TypeNameTests {
 		var count2:String;
 	}";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	class CTest {
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	interface Test {
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"typedef TTest = {
 		var Count:Int;
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"extern class TEST1 {
 		var Count:Int = 1;
 		static inline var Count:Int = 1;
@@ -138,12 +139,12 @@ class TypeNameTests {
 		}
 	}";
 
-	public static inline var TEST5:String =
+	var TEST5 =
 	"enum EnumTest {
 		VALUE;
 	}";
 
-	public static inline var TEST6:String = "
+	var TEST6 = "
 	class Test_ {
 	}";
 }

--- a/test/checks/size/FileLengthCheckTest.hx
+++ b/test/checks/size/FileLengthCheckTest.hx
@@ -3,32 +3,33 @@ package checks.size;
 import checkstyle.checks.size.FileLengthCheck;
 
 @SuppressWarnings('checkstyle:MagicNumber')
-class FileLengthCheckTest extends CheckTestCase {
+class FileLengthCheckTest extends CheckTestCase<FileLengthCheckTests> {
 
 	public function testCorrectLineCount() {
-		assertNoMsg(new FileLengthCheck(), FileLengthTests.TEST2000);
-		assertNoMsg(new FileLengthCheck(), FileLengthTests.TEST41);
+		assertNoMsg(new FileLengthCheck(), TEST2000);
+		assertNoMsg(new FileLengthCheck(), TEST41);
 	}
 
 	public function testDefaultFileLength() {
-		assertMsg(new FileLengthCheck(), FileLengthTests.TEST2001, 'Too many lines in file (> 2000)');
+		assertMsg(new FileLengthCheck(), TEST2001, 'Too many lines in file (> 2000)');
 	}
 
 	public function testConfigurableFileLength() {
 		var check = new FileLengthCheck();
 		check.max = 40;
-		assertMsg(check, FileLengthTests.TEST41, 'Too many lines in file (> 40)');
+		assertMsg(check, TEST41, 'Too many lines in file (> 40)');
 	}
 
 	public function testSupressFileLength() {
 		var check = new FileLengthCheck();
 		check.max = 40;
-		assertNoMsg(check, FileLengthTests.TEST42);
+		assertNoMsg(check, TEST42);
 	}
 }
 
-class FileLengthTests {
-	public static inline var TEST2001:String = "\n
+@:enum
+abstract FileLengthCheckTests(String) to String {
+	var TEST2001 = "\n
 	class Test {
 		public function new() {
 		}
@@ -75,7 +76,7 @@ class FileLengthTests {
 		\n\n\n\n\n\n\n\n\n\n \n\n\n\n\n\n\n\n\n\n \n\n\n\n\n\n\n\n\n\n \n\n\n\n\n\n\n\n\n\n \n\n\n             // 2000
 	}";                                                                                                        // 2001
 
-	public static inline var TEST2000:String = "\n
+	var TEST2000 = "\n
 	class Test {
 		public function new() {
 		}
@@ -122,7 +123,7 @@ class FileLengthTests {
 		\n\n\n\n\n\n\n\n\n\n \n\n\n\n\n\n\n\n\n\n \n\n\n\n\n\n\n\n\n\n \n\n\n\n\n\n\n\n\n\n \n\n               // 1999
 	}";                                                                                                        // 2000
 
-	public static inline var TEST41:String = "\n
+	var TEST41 = "\n
 	class Test {
 		public function new() {
 		}
@@ -130,7 +131,7 @@ class FileLengthTests {
 		\n\n\n\n\n\n\n\n\n\n \n\n\n\n\n\n\n\n\n\n \n\n\n\n\n\n\n\n\n\n \n\n\n\n                                // 40
 	}";
 
-	public static inline var TEST42:String = "\n
+	var TEST42 = "\n
 	@SuppressWarnings('checkstyle:FileLength')
 	class Test {
 		public function new() {

--- a/test/checks/size/LineLengthCheckTest.hx
+++ b/test/checks/size/LineLengthCheckTest.hx
@@ -2,14 +2,14 @@ package checks.size;
 
 import checkstyle.checks.size.LineLengthCheck;
 
-class LineLengthCheckTest extends CheckTestCase {
+class LineLengthCheckTest extends CheckTestCase<LineLengthCheckTests> {
 
 	public function testDefaultLineLength() {
-		assertMsg(new LineLengthCheck(), LineLengthTests.TEST1, 'Too long line (> 160)');
+		assertMsg(new LineLengthCheck(), TEST1, 'Too long line (> 160)');
 	}
 
 	public function testCorrectLineLength() {
-		assertNoMsg(new LineLengthCheck(), LineLengthTests.TEST2);
+		assertNoMsg(new LineLengthCheck(), TEST2);
 	}
 
 	@SuppressWarnings('checkstyle:MagicNumber')
@@ -17,12 +17,13 @@ class LineLengthCheckTest extends CheckTestCase {
 		var check = new LineLengthCheck();
 		check.max = 40;
 
-		assertMsg(check, LineLengthTests.TEST3, 'Too long line (> 40)');
+		assertMsg(check, TEST3, 'Too long line (> 40)');
 	}
 }
 
-class LineLengthTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract LineLengthCheckTests(String) to String {
+	var TEST1 = "
 	class Test {
 		var _a:Int;
 		public function new() {
@@ -33,7 +34,7 @@ class LineLengthTests {
 		}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"class Test {
 		public function new() {
 			var b:Int;
@@ -48,7 +49,7 @@ class LineLengthTests {
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"class Test {
 		public function new() {
 			_a = 10;

--- a/test/checks/size/MethodLengthCheckTest.hx
+++ b/test/checks/size/MethodLengthCheckTest.hx
@@ -2,14 +2,14 @@ package checks.size;
 
 import checkstyle.checks.size.MethodLengthCheck;
 
-class MethodLengthCheckTest extends CheckTestCase {
+class MethodLengthCheckTest extends CheckTestCase<MethodLengthCheckTests> {
 
 	public function testWrongMethodLength() {
-		assertMsg(new MethodLengthCheck(), MethodLengthTests.TEST1, 'Function is too long: test (> 50 lines, try splitting into multiple functions)');
+		assertMsg(new MethodLengthCheck(), TEST1, 'Function is too long: test (> 50 lines, try splitting into multiple functions)');
 	}
 
 	public function testCorrectMethodLength() {
-		assertNoMsg(new MethodLengthCheck(), MethodLengthTests.TEST2);
+		assertNoMsg(new MethodLengthCheck(), TEST2);
 	}
 
 	@SupressWarnings('checkstyle:MagicNumber')
@@ -17,12 +17,13 @@ class MethodLengthCheckTest extends CheckTestCase {
 		var check = new MethodLengthCheck();
 		check.max = 10;
 
-		assertMsg(check, MethodLengthTests.TEST3, 'Function is too long: test (> 10 lines, try splitting into multiple functions)');
+		assertMsg(check, TEST3, 'Function is too long: test (> 10 lines, try splitting into multiple functions)');
 	}
 }
 
-class MethodLengthTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract MethodLengthCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		public function test() {
 			tarce('TEST');\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n
@@ -38,7 +39,7 @@ class MethodLengthTests {
 		}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		public function test() {
 			tarce('TEST');
@@ -49,7 +50,7 @@ class MethodLengthTests {
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"abstractAndClass Test {
 		public function test() {
 			tarce('TEST');

--- a/test/checks/size/ParameterNumberCheckTest.hx
+++ b/test/checks/size/ParameterNumberCheckTest.hx
@@ -4,21 +4,21 @@ import checkstyle.checks.Check;
 import checkstyle.checks.size.ParameterNumberCheck;
 import haxe.PosInfos;
 
-class ParameterNumberCheckTest extends CheckTestCase {
+class ParameterNumberCheckTest extends CheckTestCase<ParameterNumberCheckTests> {
 
 	public function testNoParams() {
 		var check = new ParameterNumberCheck();
-		assertNoMsg(check, ParameterNumberTests.TEST1);
+		assertNoMsg(check, TEST1);
 	}
 
 	public function test10Parameters() {
 		var check = new ParameterNumberCheck();
-		assertNoMsg(check, ParameterNumberTests.TEST2);
+		assertNoMsg(check, TEST2);
 	}
 
 	public function test11Parameters() {
 		var check = new ParameterNumberCheck();
-		assertMsg(check, ParameterNumberTests.TEST3, 'Too many parameters for function: test2 (> 7)');
+		assertMsg(check, TEST3, 'Too many parameters for function: test2 (> 7)');
 	}
 
 	@SuppressWarnings('checkstyle:MagicNumber')
@@ -26,29 +26,30 @@ class ParameterNumberCheckTest extends CheckTestCase {
 		var check = new ParameterNumberCheck();
 		check.max = 11;
 
-		assertNoMsg(check, ParameterNumberTests.TEST3);
-		assertNoMsg(check, ParameterNumberTests.TEST4);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
 
 		check.max = 3;
-		assertNoMsg(check, ParameterNumberTests.TEST4);
-		assertMsg(check, ParameterNumberTests.TEST3, 'Too many parameters for function: test2 (> 3)');
+		assertNoMsg(check, TEST4);
+		assertMsg(check, TEST3, 'Too many parameters for function: test2 (> 3)');
 	}
 
 	public function testInterface() {
 		var check = new ParameterNumberCheck();
-		assertMsg(check, ParameterNumberTests.TEST5, 'Too many parameters for function: test4 (> 7)');
+		assertMsg(check, TEST5, 'Too many parameters for function: test4 (> 7)');
 	}
 
 	public function testIgnoreOverridenMethods() {
 		var check = new ParameterNumberCheck();
 		check.ignoreOverriddenMethods = true;
 
-		assertNoMsg(check, ParameterNumberTests.TEST3);
+		assertNoMsg(check, TEST3);
 	}
 }
 
-class ParameterNumberTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract ParameterNumberCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		var testVar1:Int;
 		public function test():Void {}
@@ -66,7 +67,7 @@ class ParameterNumberTests {
 		}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		public function test1(param1:Int,
 								param2:Int,
@@ -79,7 +80,7 @@ class ParameterNumberTests {
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"abstractAndClass Test {
 		override public function test2(param1:Int,
 								param2:Int,
@@ -93,7 +94,7 @@ class ParameterNumberTests {
 		}
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"abstractAndClass Test {
 		public function test3(param1:Int,
 								param2:Int,
@@ -102,7 +103,7 @@ class ParameterNumberTests {
 		}
 	}";
 
-	public static inline var TEST5:String =
+	var TEST5 =
 	"interface ITest {
 		public function test4(param1:Int,
 								param2:Int,

--- a/test/checks/type/AnonymousCheckTest.hx
+++ b/test/checks/type/AnonymousCheckTest.hx
@@ -2,24 +2,25 @@ package checks.type;
 
 import checkstyle.checks.type.AnonymousCheck;
 
-class AnonymousCheckTest extends CheckTestCase {
+class AnonymousCheckTest extends CheckTestCase<AnonymousCheckTests> {
 
 	public function testAnonymousStructureClassVar() {
-		assertMsg(new AnonymousCheck(), AnonymousTests.TEST1, 'Anonymous structure found, it is advised to use a typedef instead "anonymous"');
+		assertMsg(new AnonymousCheck(), TEST1, 'Anonymous structure found, it is advised to use a typedef instead "anonymous"');
 	}
 
 	public function testAnonymousStructureLocalVar() {
-		assertMsg(new AnonymousCheck(), AnonymousTests.TEST2, 'Anonymous structure found, it is advised to use a typedef instead "b"');
+		assertMsg(new AnonymousCheck(), TEST2, 'Anonymous structure found, it is advised to use a typedef instead "b"');
 	}
 }
 
-class AnonymousTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract AnonymousCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		var anonymous:{a:Int, b:Int};
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		public function new() {
 			var b:{a:Int, b:Int};

--- a/test/checks/type/DynamicCheckTest.hx
+++ b/test/checks/type/DynamicCheckTest.hx
@@ -2,28 +2,29 @@ package checks.type;
 
 import checkstyle.checks.type.DynamicCheck;
 
-class DynamicCheckTest extends CheckTestCase {
+class DynamicCheckTest extends CheckTestCase<DynamicCheckTests> {
 
 	public function testNoDynamic() {
 		var check = new DynamicCheck ();
-		assertNoMsg(check, DynamicTests.TEST);
+		assertNoMsg(check, TEST);
 	}
 
 	public function testDetectDynamic() {
 		var check = new DynamicCheck ();
-		assertMsg(check, DynamicTests.TEST1, 'Dynamic type used: Count');
-		assertMsg(check, DynamicTests.TEST2, 'Dynamic type used: test');
-		assertMsg(check, DynamicTests.TEST3, 'Dynamic type used: Count');
-		assertMsg(check, DynamicTests.TEST4, 'Dynamic type used: param');
-		assertMsg(check, DynamicTests.TEST5, 'Dynamic type used: test');
-		assertMsg(check, DynamicTests.TEST6, 'Dynamic type used: Test');
+		assertMsg(check, TEST1, 'Dynamic type used: Count');
+		assertMsg(check, TEST2, 'Dynamic type used: test');
+		assertMsg(check, TEST3, 'Dynamic type used: Count');
+		assertMsg(check, TEST4, 'Dynamic type used: param');
+		assertMsg(check, TEST5, 'Dynamic type used: test');
+		assertMsg(check, TEST6, 'Dynamic type used: Test');
 
-		assertNoMsg(check, DynamicTests.ISSUE_43);
+		assertNoMsg(check, ISSUE_43);
 	}
 }
 
-class DynamicTests {
-	public static inline var TEST:String = "
+@:enum
+abstract DynamicCheckTests(String) to String {
+	var TEST = "
 	class Test {
 		public var a:Int;
 		private var b:Int;
@@ -79,26 +80,26 @@ class DynamicTests {
 	@SuppressWarnings('checkstyle:Dynamic')
 	typedef Test3b = Array<Dynamic>;";
 
-	public static inline var TEST1:String = "
+	var TEST1 = "
 	class Test {
 		public var Count:Dynamic = 1;
 		public function test() {
 		}
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	class Test {
 		var Count:Int = 1;
 		public function test():Dynamic {
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"typedef Test = {
 		var Count:Dynamic;
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"extern class Test {
 		var Count:Int = 1;
 		static inline var Count:Int = 1;
@@ -106,7 +107,7 @@ class DynamicTests {
 		}
 	}";
 
-	public static inline var TEST5:String = "
+	var TEST5 = "
 	class Test {
 		var Count:Int = 1;
 		public function test() {
@@ -114,14 +115,13 @@ class DynamicTests {
 		}
 	}";
 
-	public static inline var TEST6:String =
+	var TEST6 =
 	"typedef Test = String -> Dynamic;";
 
-	public static inline var ISSUE_43:String =
+	var ISSUE_43 =
 	"class Test {
 		function test() {
 			cast (Type.createInstance(Array, []));
 		}
 	}";
-
 }

--- a/test/checks/type/ReturnCheckTest.hx
+++ b/test/checks/type/ReturnCheckTest.hx
@@ -2,7 +2,7 @@ package checks.type;
 
 import checkstyle.checks.type.ReturnCheck;
 
-class ReturnCheckTest extends CheckTestCase {
+class ReturnCheckTest extends CheckTestCase<ReturnCheckTests> {
 
 	static inline var MSG_VOID_RETURN:String = 'Void return should not explicitly be specified for function test';
 	static inline var MSG_NOT_TEST1_RETURN:String = 'Return type not specified for function: test1';
@@ -10,64 +10,65 @@ class ReturnCheckTest extends CheckTestCase {
 	static inline var MSG_NO_ANON_RETURN:String = 'Return type not specified for anonymous function';
 
 	public function testVoid() {
-		assertMsg(new ReturnCheck(), ReturnTests.TEST1, MSG_VOID_RETURN);
+		assertMsg(new ReturnCheck(), TEST1, MSG_VOID_RETURN);
 	}
 
 	public function testNoReturnType() {
-		assertMsg(new ReturnCheck(), ReturnTests.TEST2, MSG_NOT_TEST1_RETURN);
-		assertMsg(new ReturnCheck(), ReturnTests.TEST2A, MSG_NOT_TEST1_RETURN);
-		assertMsg(new ReturnCheck(), ReturnTests.TEST2B, MSG_NOT_TEST1_RETURN);
-		assertMsg(new ReturnCheck(), ReturnTests.TEST5, MSG_NO_ANON_RETURN);
+		assertMsg(new ReturnCheck(), TEST2, MSG_NOT_TEST1_RETURN);
+		assertMsg(new ReturnCheck(), TEST2A, MSG_NOT_TEST1_RETURN);
+		assertMsg(new ReturnCheck(), TEST2B, MSG_NOT_TEST1_RETURN);
+		assertMsg(new ReturnCheck(), TEST5, MSG_NO_ANON_RETURN);
 	}
 
 	public function testEmptyReturnType() {
-		assertNoMsg(new ReturnCheck(), ReturnTests.TEST3);
+		assertNoMsg(new ReturnCheck(), TEST3);
 	}
 
 	public function testEnforceReturnType() {
 		var check = new ReturnCheck();
 		check.enforceReturnType = true;
-		assertNoMsg(check, ReturnTests.TEST1);
-		assertNoMsg(check, ReturnTests.TEST4);
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST4);
 	}
 
 	public function testEnforceReturnTypeMissing() {
 		var check = new ReturnCheck();
 		check.enforceReturnType = true;
 
-		assertNoMsg(check, ReturnTests.TEST1);
-		assertMsg(check, ReturnTests.TEST2, MSG_NOT_TEST1_RETURN);
-		assertMsg(check, ReturnTests.TEST3, MSG_NOT_TEST2_RETURN);
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, MSG_NOT_TEST1_RETURN);
+		assertMsg(check, TEST3, MSG_NOT_TEST2_RETURN);
 	}
 
 	public function testReturnTypeAllowEmptyReturnFalse() {
 		var check = new ReturnCheck();
 		check.allowEmptyReturn = false;
 
-		assertMsg(check, ReturnTests.TEST3, MSG_NOT_TEST2_RETURN);
+		assertMsg(check, TEST3, MSG_NOT_TEST2_RETURN);
 	}
 
 	public function testReturnTypeAllowEmptyReturnTrue() {
 		var check = new ReturnCheck();
 		check.allowEmptyReturn = true;
 
-		assertNoMsg(check, ReturnTests.TEST3);
-		assertMsg(check, ReturnTests.TEST2, MSG_NOT_TEST1_RETURN);
+		assertNoMsg(check, TEST3);
+		assertMsg(check, TEST2, MSG_NOT_TEST1_RETURN);
 	}
 
 	public function testExternVoid() {
 		var check = new ReturnCheck();
-		assertNoMsg(check, ReturnTests.TEST6);
+		assertNoMsg(check, TEST6);
 	}
 }
 
-class ReturnTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract ReturnCheckTests(String) to String {
+	var TEST1 = "
 	abstractAndClass Test {
 		public function test():Void {}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"abstractAndClass Test {
 		public function test1() {
 			if (true) {
@@ -76,7 +77,7 @@ class ReturnTests {
 		}
 	}";
 
-	public static inline var TEST2A:String =
+	var TEST2A =
 	"abstractAndClass Test {
 		public function test1() {
 			switch (true) {
@@ -86,7 +87,7 @@ class ReturnTests {
 		}
 	}";
 
-	public static inline var TEST2B:String =
+	var TEST2B =
 	"abstractAndClass Test {
 		public function test1() {
 			try {
@@ -98,7 +99,7 @@ class ReturnTests {
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"abstractAndClass Test {
 		public function test2() {
 			var x = 1;
@@ -106,14 +107,14 @@ class ReturnTests {
 		}
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"abstractAndClass Test {
 		public function test3():Void {
 			return;
 		}
 	}";
 
-	public static inline var TEST5:String =
+	var TEST5 =
 	"abstractAndClass Test {
 		public function test4() {
 			var x = function(i){
@@ -123,7 +124,7 @@ class ReturnTests {
 		}
 	}";
 
-	public static inline var TEST6:String = "
+	var TEST6 = "
 	extern class Test {
 		function test4():Void;
 	}";

--- a/test/checks/type/TypeCheckTest.hx
+++ b/test/checks/type/TypeCheckTest.hx
@@ -2,28 +2,29 @@ package checks.type;
 
 import checkstyle.checks.type.TypeCheck;
 
-class TypeCheckTest extends CheckTestCase {
+class TypeCheckTest extends CheckTestCase<TypeCheckTests> {
 
 	public function testClassVar() {
-		assertMsg(new TypeCheck(), TypeTests.TEST1, 'Type not specified: _a');
+		assertMsg(new TypeCheck(), TEST1, 'Type not specified: _a');
 	}
 
 	public function testStaticClassVar() {
-		assertMsg(new TypeCheck(), TypeTests.TEST2, 'Type not specified: A');
+		assertMsg(new TypeCheck(), TEST2, 'Type not specified: A');
 	}
 
 	public function testEnumAbstract() {
-		assertNoMsg(new TypeCheck(), TypeTests.TEST3);
-		assertMsg(new TypeCheck(), TypeTests.TEST4, 'Type not specified: VALUE');
+		assertNoMsg(new TypeCheck(), TEST3);
+		assertMsg(new TypeCheck(), TEST4, 'Type not specified: VALUE');
 
 		var check = new TypeCheck();
 		check.ignoreEnumAbstractValues = false;
-		assertMsg(check, TypeTests.TEST3, 'Type not specified: VALUE');
+		assertMsg(check, TEST3, 'Type not specified: VALUE');
 	}
 }
 
-class TypeTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract TypeCheckTests(String) to String {
+	var TEST1 = "
 	class Test {
 		var _a;
 
@@ -31,18 +32,18 @@ class TypeTests {
 		var _b;
 	}";
 
-	public static inline var TEST2:String = "
+	var TEST2 = "
 	class Test {
 		static inline var A = 1;
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"@:enum
 	abstract Test(Int) {
 		var VALUE = 0;
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"@:enum
 	abstract Test(Int) {
 		static inline var VALUE = 0;

--- a/test/checks/whitespace/EmptyLinesCheckTest.hx
+++ b/test/checks/whitespace/EmptyLinesCheckTest.hx
@@ -2,58 +2,59 @@ package checks.whitespace;
 
 import checkstyle.checks.whitespace.EmptyLinesCheck;
 
-class EmptyLinesCheckTest extends CheckTestCase {
+class EmptyLinesCheckTest extends CheckTestCase<EmptyLinesCheckTests> {
 
 	static inline var MSG_TOO_MANY:String = 'Too many consecutive empty lines (> 1)';
 	static inline var MSG_AFTER_COMMENT:String = 'Empty line not allowed after comment(s)';
 
 	public function testDefaultEmptyLines() {
-		assertMsg(new EmptyLinesCheck(), EmptyLinesTests.TEST1, MSG_TOO_MANY);
+		assertMsg(new EmptyLinesCheck(), TEST1, MSG_TOO_MANY);
 	}
 
 	public function testCorrectEmptyLines() {
-		assertNoMsg(new EmptyLinesCheck(), EmptyLinesTests.TEST2);
+		assertNoMsg(new EmptyLinesCheck(), TEST2);
 	}
 
 	public function testConfigurableEmptyLines() {
 		var check = new EmptyLinesCheck();
 		check.max = 2;
-		assertNoMsg(check, EmptyLinesTests.TEST3);
+		assertNoMsg(check, TEST3);
 	}
 
 	public function testEmptyLineAfterSingleLineComment() {
 		var check = new EmptyLinesCheck();
 		check.allowEmptyLineAfterSingleLineComment = false;
 
-		assertMsg(check, EmptyLinesTests.TEST4, MSG_AFTER_COMMENT);
-		assertMsg(check, EmptyLinesTests.TEST5, MSG_AFTER_COMMENT);
+		assertMsg(check, TEST4, MSG_AFTER_COMMENT);
+		assertMsg(check, TEST5, MSG_AFTER_COMMENT);
 	}
 
 	public function testEmptyLineAfterMultiLineComment() {
 		var check = new EmptyLinesCheck();
 		check.allowEmptyLineAfterMultiLineComment = false;
 
-		assertMsg(check, EmptyLinesTests.TEST6, MSG_AFTER_COMMENT);
-		assertMsg(check, EmptyLinesTests.TEST7, MSG_AFTER_COMMENT);
+		assertMsg(check, TEST6, MSG_AFTER_COMMENT);
+		assertMsg(check, TEST7, MSG_AFTER_COMMENT);
 	}
 
 	public function testAllowEmptyLineAfterComment() {
-		assertNoMsg(new EmptyLinesCheck(), EmptyLinesTests.TEST4);
-		assertNoMsg(new EmptyLinesCheck(), EmptyLinesTests.TEST5);
-		assertNoMsg(new EmptyLinesCheck(), EmptyLinesTests.TEST6);
-		assertNoMsg(new EmptyLinesCheck(), EmptyLinesTests.TEST7);
+		assertNoMsg(new EmptyLinesCheck(), TEST4);
+		assertNoMsg(new EmptyLinesCheck(), TEST5);
+		assertNoMsg(new EmptyLinesCheck(), TEST6);
+		assertNoMsg(new EmptyLinesCheck(), TEST7);
 	}
 }
 
-class EmptyLinesTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract EmptyLinesCheckTests(String) to String {
+	var TEST1 = "
 	class Test {
 		var _a:Int;
 
 
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"class Test {
 		public function new() {
 			var b:Int;
@@ -61,7 +62,7 @@ class EmptyLinesTests {
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"class Test {
 		public function new() {
 			var b:Int;
@@ -70,7 +71,7 @@ class EmptyLinesTests {
 		}
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"class Test {
 
 		// comments
@@ -80,7 +81,7 @@ class EmptyLinesTests {
 		}
 	}";
 
-	public static inline var TEST5:String =
+	var TEST5 =
 	"class Test {
 
 		// comments
@@ -88,7 +89,7 @@ class EmptyLinesTests {
 		var a:Int;
 	}";
 
-	public static inline var TEST6:String =
+	var TEST6 =
 	"class Test {
 
 		/**
@@ -98,7 +99,7 @@ class EmptyLinesTests {
 		var a:Int;
 	}";
 
-	public static inline var TEST7:String =
+	var TEST7 =
 	"class Test {
 
 		/**

--- a/test/checks/whitespace/IndentationCharacterCheckTest.hx
+++ b/test/checks/whitespace/IndentationCharacterCheckTest.hx
@@ -2,47 +2,48 @@ package checks.whitespace;
 
 import checkstyle.checks.whitespace.IndentationCharacterCheck;
 
-class IndentationCharacterCheckTest extends CheckTestCase {
+class IndentationCharacterCheckTest extends CheckTestCase<IndentationCheckTests> {
 
 	public function testWrongIndentation() {
-		assertMsg(new IndentationCharacterCheck(), IndentationTests.TEST1, 'Wrong indentation character (should be tab)');
+		assertMsg(new IndentationCharacterCheck(), TEST1, 'Wrong indentation character (should be tab)');
 	}
 
 	public function testCorrectIndentation() {
-		assertNoMsg(new IndentationCharacterCheck(), IndentationTests.TEST2);
+		assertNoMsg(new IndentationCharacterCheck(), TEST2);
 	}
 
 	public function testConfigurableIndentation() {
 		var check = new IndentationCharacterCheck();
 		check.character = SPACE;
 
-		assertMsg(check, IndentationTests.TEST3, 'Wrong indentation character (should be space)');
+		assertMsg(check, TEST3, 'Wrong indentation character (should be space)');
 	}
 
 	public function testMultilineIfIndentation() {
-		assertNoMsg(new IndentationCharacterCheck(), IndentationTests.TEST4);
+		assertNoMsg(new IndentationCharacterCheck(), TEST4);
 	}
 }
 
-class IndentationTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract IndentationCheckTests(String) to String {
+	var TEST1 = "
 	class Test {
 		 var _a:Int;
 		public function new() {}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"class Test {
 		var _a:Int;
 		public function new() {}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"class Test {
 		public function new() {}
 	}";
 
-	public static inline var TEST4:String =
+	var TEST4 =
 	"class Test {
 		public function new() {
 			if (actionType == 'STREET' ||

--- a/test/checks/whitespace/OperatorWrapCheckTest.hx
+++ b/test/checks/whitespace/OperatorWrapCheckTest.hx
@@ -2,35 +2,36 @@ package checks.whitespace;
 
 import checkstyle.checks.whitespace.OperatorWrapCheck;
 
-class OperatorWrapCheckTest extends CheckTestCase {
+class OperatorWrapCheckTest extends CheckTestCase<OperatorWrapCheckTests> {
 
 	static inline var MSG_PLUS_EOL:String = 'Token "+" must be at the end of the line';
 	static inline var MSG_GT_NL:String = 'Token ">" must be on a new line';
 
 	public function testCorrectWrap() {
 		var check = new OperatorWrapCheck();
-		assertNoMsg(check, OperatorWrapTests.CORRECT_EOL_WRAP);
-		assertNoMsg(check, OperatorWrapTests.TYPE_PARAM);
+		assertNoMsg(check, CORRECT_EOL_WRAP);
+		assertNoMsg(check, TYPE_PARAM);
 	}
 
 	public function testIncorrectWrap() {
 		var check = new OperatorWrapCheck();
-		assertMsg(check, OperatorWrapTests.CORRECT_NL_WRAP_PLUS, MSG_PLUS_EOL);
+		assertMsg(check, CORRECT_NL_WRAP_PLUS, MSG_PLUS_EOL);
 	}
 
 	public function testOptionNL() {
 		var check = new OperatorWrapCheck();
 		check.option = NL;
-		assertNoMsg(check, OperatorWrapTests.CORRECT_NL_WRAP_PLUS);
-		assertNoMsg(check, OperatorWrapTests.CORRECT_NL_WRAP_GT);
-		assertNoMsg(check, OperatorWrapTests.TYPE_PARAM);
+		assertNoMsg(check, CORRECT_NL_WRAP_PLUS);
+		assertNoMsg(check, CORRECT_NL_WRAP_GT);
+		assertNoMsg(check, TYPE_PARAM);
 
-		assertMsg(check, OperatorWrapTests.CORRECT_EOL_WRAP, MSG_GT_NL);
+		assertMsg(check, CORRECT_EOL_WRAP, MSG_GT_NL);
 	}
 }
 
-class OperatorWrapTests {
-	public static inline var CORRECT_EOL_WRAP:String = "
+@:enum
+abstract OperatorWrapCheckTests(String) to String {
+	var CORRECT_EOL_WRAP = "
 	class Test {
 		function test(param1:String, param2:String) {
 			var test = test1 +
@@ -48,7 +49,7 @@ class OperatorWrapTests {
 		}
 	}";
 
-	public static inline var CORRECT_NL_WRAP_PLUS:String = "
+	var CORRECT_NL_WRAP_PLUS = "
 	class Test {
 		function test() {
 			var test = test1
@@ -56,7 +57,7 @@ class OperatorWrapTests {
 		}
 	}";
 
-	public static inline var CORRECT_NL_WRAP_GT:String = "
+	var CORRECT_NL_WRAP_GT = "
 	class Test {
 		function test() {
 			return a
@@ -64,7 +65,7 @@ class OperatorWrapTests {
 		}
 	}";
 
-	public static inline var TYPE_PARAM:String = "
+	var TYPE_PARAM = "
 	class Test {
 		function foo():Array<Int>
 		{

--- a/test/checks/whitespace/SeparatorWrapCheckTest.hx
+++ b/test/checks/whitespace/SeparatorWrapCheckTest.hx
@@ -2,7 +2,7 @@ package checks.whitespace;
 
 import checkstyle.checks.whitespace.SeparatorWrapCheck;
 
-class SeparatorWrapCheckTest extends CheckTestCase {
+class SeparatorWrapCheckTest extends CheckTestCase<SeparatorWrapCheckTests> {
 
 	static inline var MSG_COMMA_EOL:String = 'Token "," must be at the end of the line';
 	static inline var MSG_DOT_EOL:String = 'Token "." must be at the end of the line';
@@ -12,46 +12,47 @@ class SeparatorWrapCheckTest extends CheckTestCase {
 
 	public function testCorrectWrap() {
 		var check = new SeparatorWrapCheck();
-		assertNoMsg(check, SeparatorWrapTests.CORRECT_WRAP);
-		assertNoMsg(check, SeparatorWrapTests.CORRECT_NOWRAP);
-		assertNoMsg(check, SeparatorWrapTests.EOL_WRAP_ARRAY);
-		assertNoMsg(check, SeparatorWrapTests.EOL_WRAP_IMPORT);
-		assertNoMsg(check, SeparatorWrapTests.NOWRAP_ARRAY);
-		assertNoMsg(check, SeparatorWrapTests.NOWRAP_CALL);
-		assertNoMsg(check, SeparatorWrapTests.NOWRAP_IMPORT);
+		assertNoMsg(check, CORRECT_WRAP);
+		assertNoMsg(check, CORRECT_NOWRAP);
+		assertNoMsg(check, EOL_WRAP_ARRAY);
+		assertNoMsg(check, EOL_WRAP_IMPORT);
+		assertNoMsg(check, NOWRAP_ARRAY);
+		assertNoMsg(check, NOWRAP_CALL);
+		assertNoMsg(check, NOWRAP_IMPORT);
 	}
 
 	public function testIncorrectWrap() {
 		var check = new SeparatorWrapCheck();
-		assertMsg(check, SeparatorWrapTests.NL_WRAP_FUNC, MSG_COMMA_EOL);
-		assertMsg(check, SeparatorWrapTests.NL_WRAP_OBJECT_DECL, MSG_COMMA_EOL);
-		assertMsg(check, SeparatorWrapTests.NL_WRAP_ARRAY, MSG_COMMA_EOL);
-		assertMsg(check, SeparatorWrapTests.NL_WRAP_CALL, MSG_DOT_EOL);
-		assertMsg(check, SeparatorWrapTests.NL_WRAP_IMPORT, MSG_DOT_EOL);
+		assertMsg(check, NL_WRAP_FUNC, MSG_COMMA_EOL);
+		assertMsg(check, NL_WRAP_OBJECT_DECL, MSG_COMMA_EOL);
+		assertMsg(check, NL_WRAP_ARRAY, MSG_COMMA_EOL);
+		assertMsg(check, NL_WRAP_CALL, MSG_DOT_EOL);
+		assertMsg(check, NL_WRAP_IMPORT, MSG_DOT_EOL);
 	}
 
 	public function testOptionNL() {
 		var check = new SeparatorWrapCheck();
 		check.option = NL;
-		assertNoMsg(check, SeparatorWrapTests.NL_WRAP_FUNC);
-		assertNoMsg(check, SeparatorWrapTests.NL_WRAP_OBJECT_DECL);
-		assertNoMsg(check, SeparatorWrapTests.NL_WRAP_ARRAY);
-		assertNoMsg(check, SeparatorWrapTests.NL_WRAP_CALL);
-		assertNoMsg(check, SeparatorWrapTests.NL_WRAP_IMPORT);
+		assertNoMsg(check, NL_WRAP_FUNC);
+		assertNoMsg(check, NL_WRAP_OBJECT_DECL);
+		assertNoMsg(check, NL_WRAP_ARRAY);
+		assertNoMsg(check, NL_WRAP_CALL);
+		assertNoMsg(check, NL_WRAP_IMPORT);
 
-		assertNoMsg(check, SeparatorWrapTests.CORRECT_NOWRAP);
-		assertNoMsg(check, SeparatorWrapTests.NOWRAP_ARRAY);
-		assertNoMsg(check, SeparatorWrapTests.NOWRAP_CALL);
-		assertNoMsg(check, SeparatorWrapTests.NOWRAP_IMPORT);
+		assertNoMsg(check, CORRECT_NOWRAP);
+		assertNoMsg(check, NOWRAP_ARRAY);
+		assertNoMsg(check, NOWRAP_CALL);
+		assertNoMsg(check, NOWRAP_IMPORT);
 
-		assertMsg(check, SeparatorWrapTests.CORRECT_WRAP, MSG_COMMA_NL);
-		assertMsg(check, SeparatorWrapTests.EOL_WRAP_ARRAY, MSG_COMMA_NL);
-		assertMsg(check, SeparatorWrapTests.EOL_WRAP_IMPORT, MSG_DOT_NL);
+		assertMsg(check, CORRECT_WRAP, MSG_COMMA_NL);
+		assertMsg(check, EOL_WRAP_ARRAY, MSG_COMMA_NL);
+		assertMsg(check, EOL_WRAP_IMPORT, MSG_DOT_NL);
 	}
 }
 
-class SeparatorWrapTests {
-	public static inline var CORRECT_WRAP:String = "
+@:enum
+abstract SeparatorWrapCheckTests(String) to String {
+	var CORRECT_WRAP = "
 	package checkstyle.
 			tests;
 	import haxe.
@@ -83,7 +84,7 @@ class SeparatorWrapTests {
 		z:Int
 	}";
 
-	public static inline var CORRECT_NOWRAP:String = "
+	var CORRECT_NOWRAP = "
 	package checkstyle.tests;
 	import haxe.macro.Expr;
 
@@ -95,14 +96,14 @@ class SeparatorWrapTests {
 
 	typedef Test = { x:Int, y:Int, z:Int }";
 
-	public static inline var NL_WRAP_FUNC:String = "
+	var NL_WRAP_FUNC = "
 	class Test {
 		function test(param1:String
 				, param2:String) {
 		}
 	}";
 
-	public static inline var NL_WRAP_OBJECT_DECL:String = "
+	var NL_WRAP_OBJECT_DECL = "
 	class Test {
 		function test(param1:String, param2:String) {
 			var x={ x: 100
@@ -111,12 +112,12 @@ class SeparatorWrapTests {
 		}
 	}";
 
-	public static inline var NOWRAP_ARRAY:String = "
+	var NOWRAP_ARRAY = "
 	class Test {
 		var test:Array<String>=[1, 2, 3, 4];
 	}";
 
-	public static inline var EOL_WRAP_ARRAY:String = "
+	var EOL_WRAP_ARRAY = "
 	class Test {
 		var test:Array<String>=[1,
 			2,
@@ -124,7 +125,7 @@ class SeparatorWrapTests {
 			4];
 	}";
 
-	public static inline var NL_WRAP_ARRAY:String = "
+	var NL_WRAP_ARRAY = "
 	class Test {
 		var test:Array<String>=[1
 			, 2
@@ -132,14 +133,14 @@ class SeparatorWrapTests {
 			, 4];
 	}";
 
-	public static inline var NOWRAP_CALL:String = "
+	var NOWRAP_CALL = "
 	class Test {
 		function test(a:String) {
 			a.substr(0, 10);
 		}
 	}";
 
-	public static inline var EOL_WRAP_CALL:String = "
+	var EOL_WRAP_CALL = "
 	class Test {
 		function test(a:String) {
 			// invalid haxe code, won't compile
@@ -148,7 +149,7 @@ class SeparatorWrapTests {
 		}
 	}";
 
-	public static inline var NL_WRAP_CALL:String = "
+	var NL_WRAP_CALL = "
 	class Test {
 		function test(a:String) {
 			a
@@ -156,7 +157,7 @@ class SeparatorWrapTests {
 		}
 	}";
 
-	public static inline var EOL_WRAP_IMPORT:String = "
+	var EOL_WRAP_IMPORT = "
 	package checkstyle.
 			tests;
 	import haxe.
@@ -164,12 +165,12 @@ class SeparatorWrapTests {
 			Expr;
 	";
 
-	public static inline var NOWRAP_IMPORT:String = "
+	var NOWRAP_IMPORT = "
 	package checkstyle.tests;
 	import haxe.macro.Expr;
 	";
 
-	public static inline var NL_WRAP_IMPORT:String = "
+	var NL_WRAP_IMPORT = "
 	package checkstyle
 			.tests;
 	import haxe

--- a/test/checks/whitespace/SpacingCheckTest.hx
+++ b/test/checks/whitespace/SpacingCheckTest.hx
@@ -2,72 +2,73 @@ package checks.whitespace;
 
 import checkstyle.checks.whitespace.SpacingCheck;
 
-class SpacingCheckTest extends CheckTestCase {
+class SpacingCheckTest extends CheckTestCase<SpacingCheckTests> {
 
 	public function testIf() {
-		assertMsg(new SpacingCheck(), SpacingTests.TEST1A, 'No space between if and (');
-		assertNoMsg(new SpacingCheck(), SpacingTests.TEST1B);
+		assertMsg(new SpacingCheck(), TEST1A, 'No space between if and (');
+		assertNoMsg(new SpacingCheck(), TEST1B);
 	}
 
 	public function testBinaryOperator() {
-		assertMsg(new SpacingCheck(), SpacingTests.TEST2, 'No space around +');
+		assertMsg(new SpacingCheck(), TEST2, 'No space around +');
 	}
 
 	public function testUnaryOperator() {
-		assertMsg(new SpacingCheck(), SpacingTests.TEST3, 'Space around ++');
+		assertMsg(new SpacingCheck(), TEST3, 'Space around ++');
 	}
 
 	public function testFor() {
-		assertMsg(new SpacingCheck(), SpacingTests.TEST4A, 'No space between for and (');
-		assertNoMsg(new SpacingCheck(), SpacingTests.TEST4B);
+		assertMsg(new SpacingCheck(), TEST4A, 'No space between for and (');
+		assertNoMsg(new SpacingCheck(), TEST4B);
 	}
 
 	public function testWhile() {
-		assertMsg(new SpacingCheck(), SpacingTests.TEST5A, 'No space between while and (');
-		assertNoMsg(new SpacingCheck(), SpacingTests.TEST5B);
+		assertMsg(new SpacingCheck(), TEST5A, 'No space between while and (');
+		assertNoMsg(new SpacingCheck(), TEST5B);
 	}
 
 	public function testSwitch() {
-		assertMsg(new SpacingCheck(), SpacingTests.TEST6A, 'No space between switch and (');
-		assertNoMsg(new SpacingCheck(), SpacingTests.TEST6B);
+		assertMsg(new SpacingCheck(), TEST6A, 'No space between switch and (');
+		assertNoMsg(new SpacingCheck(), TEST6B);
 	}
 
 	public function testCatch() {
-		assertMsg(new SpacingCheck(), SpacingTests.TEST7A, 'No space between catch and (');
-		assertNoMsg(new SpacingCheck(), SpacingTests.TEST7B);
+		assertMsg(new SpacingCheck(), TEST7A, 'No space between catch and (');
+		assertNoMsg(new SpacingCheck(), TEST7B);
 	}
 }
 
-class SpacingTests {
-	public static inline var TEST1A:String = "
+@:enum
+abstract SpacingCheckTests(String) to String {
+	var TEST1A = "
 	class Test {
 		public function test() {
 			if(true) {}
 		}
 	}";
 
-	public static inline var TEST1B:String = "
+	var TEST1B = "
 	class Test {
 		public function test() {
 			if (true) {}
 		}
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"class Test {
 		public function test() {
 			var a = a+1;
 		}
 	}";
 
-	public static inline var TEST3:String =
+	var TEST3 =
 	"class Test {
 		public function test() {
 			var a = a ++;
 		}
 	}";
 
-	public static inline var TEST4A:String =
+	var TEST4A =
 	"class Test {
 		public function test() {
 			for(i in 0...10) {
@@ -76,7 +77,7 @@ class SpacingTests {
 		}
 	}";
 
-	public static inline var TEST4B:String =
+	var TEST4B =
 	"class Test {
 		public function test() {
 			for (i in 0...10) {
@@ -85,21 +86,21 @@ class SpacingTests {
 		}
 	}";
 
-	public static inline var TEST5A:String =
+	var TEST5A =
 	"class Test {
 		public function test() {
 			while(true) {}
 		}
 	}";
 
-	public static inline var TEST5B:String =
+	var TEST5B =
 	"class Test {
 		public function test() {
 			while (true) {}
 		}
 	}";
 
-	public static inline var TEST6A:String =
+	var TEST6A =
 	"class Test {
 		public function test() {
 			switch(0) {
@@ -109,7 +110,7 @@ class SpacingTests {
 		}
 	}";
 
-	public static inline var TEST6B:String =
+	var TEST6B =
 	"class Test {
 		public function test() {
 			switch (0) {
@@ -119,7 +120,7 @@ class SpacingTests {
 		}
 	}";
 
-	public static inline var TEST7A:String =
+	var TEST7A =
 	"class Test {
 		public function test() {
 			try {}
@@ -127,7 +128,7 @@ class SpacingTests {
 		}
 	}";
 
-	public static inline var TEST7B:String =
+	var TEST7B =
 	"class Test {
 		public function test() {
 			try {}

--- a/test/checks/whitespace/TabForAligningCheckTest.hx
+++ b/test/checks/whitespace/TabForAligningCheckTest.hx
@@ -2,25 +2,26 @@ package checks.whitespace;
 
 import checkstyle.checks.whitespace.TabForAligningCheck;
 
-class TabForAligningCheckTest extends CheckTestCase {
+class TabForAligningCheckTest extends CheckTestCase<TabForAligningCheckTests> {
 
 	public function testTab() {
-		assertMsg(new TabForAligningCheck(), TabForAlignTests.TEST1, 'Tab after non-space character. Use space for aligning');
+		assertMsg(new TabForAligningCheck(), TEST1, 'Tab after non-space character. Use space for aligning');
 	}
 
 	public function testMultiline() {
-		assertNoMsg(new TabForAligningCheck(), TabForAlignTests.TEST2);
+		assertNoMsg(new TabForAligningCheck(), TEST2);
 	}
 }
 
-class TabForAlignTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract TabForAligningCheckTests(String) to String {
+	var TEST1 = "
 	class Test {
 		var a:Int = 	1;
 
 	}";
 
-	public static inline var TEST2:String =
+	var TEST2 =
 	"class Test {
 		public function test() {
 			var a:Array<String> = ['one', 'two',

--- a/test/checks/whitespace/TrailingWhitespaceCheckTest.hx
+++ b/test/checks/whitespace/TrailingWhitespaceCheckTest.hx
@@ -2,15 +2,16 @@ package checks.whitespace;
 
 import checkstyle.checks.whitespace.TrailingWhitespaceCheck;
 
-class TrailingWhitespaceCheckTest extends CheckTestCase {
+class TrailingWhitespaceCheckTest extends CheckTestCase<TrailingWhitespaceCheckTests> {
 
 	public function test() {
-		assertMsg(new TrailingWhitespaceCheck(), TrailingWhitespaceTests.TEST1, 'Trailing whitespace');
+		assertMsg(new TrailingWhitespaceCheck(), TEST1, 'Trailing whitespace');
 	}
 }
 
-class TrailingWhitespaceTests {
-	public static inline var TEST1:String = "
+@:enum
+abstract TrailingWhitespaceCheckTests(String) to String {
+	var TEST1 = "
 	class Test {
 		public function test() {} 
 	}";

--- a/test/checks/whitespace/WhitespaceAfterCheckTest.hx
+++ b/test/checks/whitespace/WhitespaceAfterCheckTest.hx
@@ -2,7 +2,7 @@ package checks.whitespace;
 
 import checkstyle.checks.whitespace.WhitespaceAfterCheck;
 
-class WhitespaceAfterCheckTest extends CheckTestCase {
+class WhitespaceAfterCheckTest extends CheckTestCase<WhitespaceAfterCheckTests> {
 
 	static inline var MSG_COMMA:String = 'No whitespace after ","';
 	static inline var MSG_EQUALS:String = 'No whitespace after "="';
@@ -10,43 +10,44 @@ class WhitespaceAfterCheckTest extends CheckTestCase {
 
 	public function testCorrectWhitespace() {
 		var check = new WhitespaceAfterCheck();
-		assertNoMsg(check, WhitespaceAfterTests.CORRECT_WHITESPACE_AFTER);
-		assertNoMsg(check, WhitespaceAfterTests.ISSUE_57);
-		assertNoMsg(check, WhitespaceAfterTests.ISSUE_58);
-		assertNoMsg(check, WhitespaceAfterTests.ISSUE_59);
-		assertNoMsg(check, WhitespaceAfterTests.ISSUE_63);
-		assertNoMsg(check, WhitespaceAfterTests.ISSUE_64);
-		assertNoMsg(check, WhitespaceAfterTests.ISSUE_65);
-		assertNoMsg(check, WhitespaceAfterTests.ISSUE_66);
-		assertNoMsg(check, WhitespaceAfterTests.ISSUE_67);
+		assertNoMsg(check, CORRECT_WHITESPACE_AFTER);
+		assertNoMsg(check, ISSUE_57);
+		assertNoMsg(check, ISSUE_58);
+		assertNoMsg(check, ISSUE_59);
+		assertNoMsg(check, ISSUE_63);
+		assertNoMsg(check, ISSUE_64);
+		assertNoMsg(check, ISSUE_65);
+		assertNoMsg(check, ISSUE_66);
+		assertNoMsg(check, ISSUE_67);
 	}
 
 	public function testIncorrectWhitespace() {
 		var check = new WhitespaceAfterCheck();
-		assertMsg(check, WhitespaceAfterTests.NO_WHITESPACE_FUNC, MSG_COMMA);
-		assertMsg(check, WhitespaceAfterTests.NO_WHITESPACE_OBJECT_DECL, MSG_COMMA);
-		assertMsg(check, WhitespaceAfterTests.NO_WHITESPACE_TYPEDEF, MSG_COMMA);
+		assertMsg(check, NO_WHITESPACE_FUNC, MSG_COMMA);
+		assertMsg(check, NO_WHITESPACE_OBJECT_DECL, MSG_COMMA);
+		assertMsg(check, NO_WHITESPACE_TYPEDEF, MSG_COMMA);
 	}
 
 	public function testIncorrectWhitespaceToken() {
 		var check = new WhitespaceAfterCheck();
 		check.tokens = ["="];
-		assertNoMsg(check, WhitespaceAfterTests.CORRECT_WHITESPACE_AFTER);
-		assertNoMsg(check, WhitespaceAfterTests.NO_WHITESPACE_FUNC);
-		assertNoMsg(check, WhitespaceAfterTests.NO_WHITESPACE_GT);
-		assertMsg(check, WhitespaceAfterTests.NO_WHITESPACE_OBJECT_DECL, MSG_EQUALS);
-		assertMsg(check, WhitespaceAfterTests.NO_WHITESPACE_TYPEDEF, MSG_EQUALS);
-		assertMsg(check, WhitespaceAfterTests.NO_WHITESPACE_VAR_INIT, MSG_EQUALS);
+		assertNoMsg(check, CORRECT_WHITESPACE_AFTER);
+		assertNoMsg(check, NO_WHITESPACE_FUNC);
+		assertNoMsg(check, NO_WHITESPACE_GT);
+		assertMsg(check, NO_WHITESPACE_OBJECT_DECL, MSG_EQUALS);
+		assertMsg(check, NO_WHITESPACE_TYPEDEF, MSG_EQUALS);
+		assertMsg(check, NO_WHITESPACE_VAR_INIT, MSG_EQUALS);
 
 		check.tokens = [">"];
-		assertNoMsg(check, WhitespaceAfterTests.CORRECT_WHITESPACE_AFTER);
-		assertMsg(check, WhitespaceAfterTests.NO_WHITESPACE_VAR_INIT, MSG_GREATER);
-		assertMsg(check, WhitespaceAfterTests.NO_WHITESPACE_GT, MSG_GREATER);
+		assertNoMsg(check, CORRECT_WHITESPACE_AFTER);
+		assertMsg(check, NO_WHITESPACE_VAR_INIT, MSG_GREATER);
+		assertMsg(check, NO_WHITESPACE_GT, MSG_GREATER);
 	}
 }
 
-class WhitespaceAfterTests {
-	public static inline var CORRECT_WHITESPACE_AFTER:String = "
+@:enum
+abstract WhitespaceAfterCheckTests(String) to String {
+	var CORRECT_WHITESPACE_AFTER = "
 	class Test {
 		function test(param1:String, param2:String) {
 			var x = { x: 100, y: 100,
@@ -69,66 +70,66 @@ class WhitespaceAfterTests {
 		Friday; Weekend(day:String);
 	}";
 
-	public static inline var NO_WHITESPACE_FUNC:String = "
+	var NO_WHITESPACE_FUNC = "
 	class Test {
 		function test(param1:String,param2:String) {
 		}
 	}";
 
-	public static inline var NO_WHITESPACE_OBJECT_DECL:String = "
+	var NO_WHITESPACE_OBJECT_DECL = "
 	class Test {
 		function test(param1:String, param2:String) {
 			var x={ x: 100, y: 100,z: 20 };
 		}
 	}";
 
-	public static inline var NO_WHITESPACE_TYPEDEF:String = "
+	var NO_WHITESPACE_TYPEDEF = "
 	typedef Test ={
 		x:Int,
 		y:Int,z:Int
 	}";
 
-	public static inline var NO_WHITESPACE_VAR_INIT:String = "
+	var NO_WHITESPACE_VAR_INIT = "
 	class Test {
 		function test(param1:String, param2:String) {
 			var test:Array<String>=[];
 		}
 	}";
 
-	public static inline var NO_WHITESPACE_GT:String = "
+	var NO_WHITESPACE_GT = "
 	class Test {
 		function test(param1:String, param2:String) {
 			var test:Array<String>= [];
 		}
 	}";
 
-	public static inline var ISSUE_57:String = "
+	var ISSUE_57 = "
 	class Test {
 		public function new() {
 			trace(#if true cast #end 'text');
 		}
 	}";
 
-	public static inline var ISSUE_58:String = "
+	var ISSUE_58 = "
 	class Test {
 		public function new() {
 			var x:Int, y:Int;
 		}
 	}";
 
-	public static inline var ISSUE_59:String = "
+	var ISSUE_59 = "
 	typedef Test = Int
 	";
 
-	public static inline var ISSUE_63:String = "
+	var ISSUE_63 = "
 	typedef Test = #if true Int #else String #end
 	";
 
-	public static inline var ISSUE_64:String = "
+	var ISSUE_64 = "
 	class Test #if true extends Base #end {}
 	";
 
-	public static inline var ISSUE_65:String = "
+	var ISSUE_65 = "
 	class Test {
 		function foo() {
 			switch (0) {
@@ -138,12 +139,12 @@ class WhitespaceAfterTests {
 		}
 	}";
 
-	public static inline var ISSUE_66:String = "
+	var ISSUE_66 = "
 	class Test {
 		public inline function new<T>() {}
 	}";
 
-	public static inline var ISSUE_67:String = "
+	var ISSUE_67 = "
 	extern class Promise<T>
 	{
 		@:overload(function<T>(promise : Promise<T>) : Promise<T> {})

--- a/test/checks/whitespace/WhitespaceAroundCheckTest.hx
+++ b/test/checks/whitespace/WhitespaceAroundCheckTest.hx
@@ -2,49 +2,50 @@ package checks.whitespace;
 
 import checkstyle.checks.whitespace.WhitespaceAroundCheck;
 
-class WhitespaceAroundCheckTest extends CheckTestCase {
+class WhitespaceAroundCheckTest extends CheckTestCase<WhitespaceAroundCheckTests> {
 
 	static inline var MSG_EQUALS:String = 'No whitespace around "="';
 
 	public function testCorrectWhitespace() {
 		var check = new WhitespaceAroundCheck();
-		assertNoMsg(check, WhitespaceAroundTests.CORRECT_WHITESPACE_AROUND);
-		assertNoMsg(check, WhitespaceAroundTests.ISSUE_70);
-		assertNoMsg(check, WhitespaceAroundTests.ISSUE_71);
-		assertNoMsg(check, WhitespaceAroundTests.ISSUE_72);
-		assertNoMsg(check, WhitespaceAroundTests.ISSUE_77);
-		assertNoMsg(check, WhitespaceAroundTests.ISSUE_80);
-		assertNoMsg(check, WhitespaceAroundTests.ISSUE_81);
-		assertNoMsg(check, WhitespaceAroundTests.ISSUE_98);
-		assertNoMsg(check, WhitespaceAroundTests.MINUS_CONSTANT);
+		assertNoMsg(check, CORRECT_WHITESPACE_AROUND);
+		assertNoMsg(check, ISSUE_70);
+		assertNoMsg(check, ISSUE_71);
+		assertNoMsg(check, ISSUE_72);
+		assertNoMsg(check, ISSUE_77);
+		assertNoMsg(check, ISSUE_80);
+		assertNoMsg(check, ISSUE_81);
+		assertNoMsg(check, ISSUE_98);
+		assertNoMsg(check, MINUS_CONSTANT);
 	}
 
 	public function testIncorrectWhitespace() {
 		var check = new WhitespaceAroundCheck();
-		assertMsg(check, WhitespaceAroundTests.NO_WHITESPACE_OBJECT_DECL, MSG_EQUALS);
-		assertMsg(check, WhitespaceAroundTests.NO_WHITESPACE_TYPEDEF, MSG_EQUALS);
-		assertMsg(check, WhitespaceAroundTests.ISSUE_59, MSG_EQUALS);
-		assertMsg(check, WhitespaceAroundTests.ISSUE_63, MSG_EQUALS);
+		assertMsg(check, NO_WHITESPACE_OBJECT_DECL, MSG_EQUALS);
+		assertMsg(check, NO_WHITESPACE_TYPEDEF, MSG_EQUALS);
+		assertMsg(check, ISSUE_59, MSG_EQUALS);
+		assertMsg(check, ISSUE_63, MSG_EQUALS);
 	}
 
 	public function testIncorrectWhitespaceToken() {
 		var check = new WhitespaceAroundCheck();
 		check.tokens = ["="];
-		assertNoMsg(check, WhitespaceAroundTests.CORRECT_WHITESPACE_AROUND);
-		assertMsg(check, WhitespaceAroundTests.NO_WHITESPACE_GT, MSG_EQUALS);
-		assertMsg(check, WhitespaceAroundTests.NO_WHITESPACE_OBJECT_DECL, MSG_EQUALS);
-		assertMsg(check, WhitespaceAroundTests.NO_WHITESPACE_TYPEDEF, MSG_EQUALS);
-		assertMsg(check, WhitespaceAroundTests.NO_WHITESPACE_VAR_INIT, MSG_EQUALS);
+		assertNoMsg(check, CORRECT_WHITESPACE_AROUND);
+		assertMsg(check, NO_WHITESPACE_GT, MSG_EQUALS);
+		assertMsg(check, NO_WHITESPACE_OBJECT_DECL, MSG_EQUALS);
+		assertMsg(check, NO_WHITESPACE_TYPEDEF, MSG_EQUALS);
+		assertMsg(check, NO_WHITESPACE_VAR_INIT, MSG_EQUALS);
 
 		check.tokens = [">"];
-		assertNoMsg(check, WhitespaceAroundTests.CORRECT_WHITESPACE_AROUND);
-		assertNoMsg(check, WhitespaceAroundTests.NO_WHITESPACE_VAR_INIT);
-		assertNoMsg(check, WhitespaceAroundTests.NO_WHITESPACE_GT);
+		assertNoMsg(check, CORRECT_WHITESPACE_AROUND);
+		assertNoMsg(check, NO_WHITESPACE_VAR_INIT);
+		assertNoMsg(check, NO_WHITESPACE_GT);
 	}
 }
 
-class WhitespaceAroundTests {
-	public static inline var CORRECT_WHITESPACE_AROUND:String = "
+@:enum
+abstract WhitespaceAroundCheckTests(String) to String {
+	var CORRECT_WHITESPACE_AROUND = "
 	import haxe.macro.*;
 
 	class Test {
@@ -69,64 +70,64 @@ class WhitespaceAroundTests {
 		Friday; Weekend(day:String);
 	}";
 
-	public static inline var NO_WHITESPACE_OBJECT_DECL:String = "
+	var NO_WHITESPACE_OBJECT_DECL = "
 	class Test {
 		function test(param1:String, param2:String) {
 			var x={ x: 100, y: 100,z: 20 };
 		}
 	}";
 
-	public static inline var NO_WHITESPACE_TYPEDEF:String = "
+	var NO_WHITESPACE_TYPEDEF = "
 	typedef Test ={
 		x:Int,
 		y:Int,z:Int
 	}";
 
-	public static inline var NO_WHITESPACE_VAR_INIT:String = "
+	var NO_WHITESPACE_VAR_INIT = "
 	class Test {
 		function test(param1:String, param2:String) {
 			var test:Array<String>=[];
 		}
 	}";
 
-	public static inline var NO_WHITESPACE_GT:String = "
+	var NO_WHITESPACE_GT = "
 	class Test {
 		function test(param1:String, param2:String) {
 			var test:Array<String>= [];
 		}
 	}";
 
-	public static inline var ISSUE_58:String = "
+	var ISSUE_58 = "
 	class Test {
 		public function new() {
 			var x:Int, y:Int;
 		}
 	}";
 
-	public static inline var ISSUE_59:String = "
+	var ISSUE_59 = "
 	typedef Test=Int
 	";
 
-	public static inline var ISSUE_63:String = "
+	var ISSUE_63 = "
 	typedef Test =#if true Int #else String #end
 	";
 
-	public static inline var ISSUE_70:String = "
+	var ISSUE_70 = "
 		import haxe.macro.*;
 	";
 
-	public static inline var ISSUE_71:String = "
+	var ISSUE_71 = "
 		class Test {
 		function foo<T, X>() {
 			trace((null : Array<Int, String>));
 		}
 	}";
 
-	public static inline var ISSUE_72:String = "
+	var ISSUE_72 = "
 	abstract Test<T>(Array<T>) {}
 	";
 
-	public static inline var ISSUE_77:String = "
+	var ISSUE_77 = "
 	// comment
 	class Test // comment
 	{ // comment
@@ -139,11 +140,11 @@ class WhitespaceAroundTests {
 	} // comment
 	";
 
-	public static inline var ISSUE_80:String = "
+	var ISSUE_80 = "
 	interface Test implements Dynamic {}
 	";
 
-	public static inline var ISSUE_81:String = "
+	var ISSUE_81 = "
 	class Test {
 		function foo() {
 			do a++ while (true);
@@ -151,13 +152,13 @@ class WhitespaceAroundTests {
 		}
 	}";
 
-	public static inline var ISSUE_98:String = "
+	var ISSUE_98 = "
 	class Test {
 		// °öäüßÖÄÜ@łĸŋđđðſðæµ”“„¢«»Ø→↓←Ŧ¶€Ł}][{¬½¼³²
 		var test:Int = 0;
 	}";
 
-	public static inline var MINUS_CONSTANT:String = "
+	var MINUS_CONSTANT = "
 	class Test {
 		function test() {
 			if (re.match(line) && line.indexOf('//') == -1) {

--- a/test/token/TokenTreeBuilderTest.hx
+++ b/test/token/TokenTreeBuilderTest.hx
@@ -1,5 +1,6 @@
 package token;
 
+import haxe.PosInfos;
 import haxeparser.HaxeLexer;
 
 import haxeparser.Data.Token;
@@ -11,6 +12,10 @@ import checkstyle.token.TokenTreeBuilder;
 
 class TokenTreeBuilderTest extends haxe.unit.TestCase {
 
+	function assertTokenEquals(testCase:TokenTreeBuilderTests, actual:String, ?pos:PosInfos) {
+		assertEquals((testCase : String), actual, pos);
+	}
+	
 	public function testImports() {
 		var builder:TestTokenTreeBuilder = newBuilder (TokenTreeBuilderTests.IMPORT);
 		var root:TokenTree = new TokenTree(null, null);
@@ -21,7 +26,7 @@ class TokenTreeBuilderTest extends haxe.unit.TestCase {
 		builder.testWalkPackageImport(root);
 		checkStreamEmpty(builder);
 
-		assertEquals(TokenTreeBuilderTests.IMPORT_GOLD, treeToString(root));
+		assertTokenEquals(IMPORT_GOLD, treeToString(root));
 	}
 
 	public function testAt() {
@@ -34,7 +39,7 @@ class TokenTreeBuilderTest extends haxe.unit.TestCase {
 		builder.getTokenStream().consumeToken(); // remove comment line
 		checkStreamEmpty(builder);
 
-		assertEquals(TokenTreeBuilderTests.AT_ANNOTATION_GOLD, treeToString(root));
+		assertTokenEquals(AT_ANNOTATION_GOLD, treeToString(root));
 	}
 
 	public function testIf() {
@@ -46,7 +51,7 @@ class TokenTreeBuilderTest extends haxe.unit.TestCase {
 		builder.testWalkIf(root);
 		checkStreamEmpty(builder);
 
-		assertEquals(TokenTreeBuilderTests.IF_GOLD, treeToString(root));
+		assertTokenEquals(IF_GOLD, treeToString(root));
 	}
 
 	function newBuilder(code:String):TestTokenTreeBuilder {
@@ -82,15 +87,16 @@ class TokenTreeBuilderTest extends haxe.unit.TestCase {
 	}
 }
 
-class TokenTreeBuilderTests {
-	public static inline var IMPORT:String = "
+@:enum
+abstract TokenTreeBuilderTests(String) to String {
+	var IMPORT = "
 		package checkstyle.checks;
 		import haxeparser.*;
 		import checkstyle.TokenTree;
 		import checkstyle.TokenStream;
 		import checkstyle.TokenTreeBuilder;
 	";
-	public static inline var IMPORT_GOLD:String =
+	var IMPORT_GOLD =
 		'  Kwd(KwdPackage)\n' +
 		'    Const(CIdent(checkstyle))\n' +
 		'      Dot\n' +
@@ -117,14 +123,14 @@ class TokenTreeBuilderTests {
 		'        Const(CIdent(TokenTreeBuilder))\n' +
 		'          Semicolon\n';
 
-	public static inline var AT_ANNOTATION:String = '
+	var AT_ANNOTATION = '
 		@SuppressWarnings("checkstyle:MagicNumber")
 		@SuppressWarnings(["checkstyle:MagicNumber", "checkstyle:AvoidStarImport"])
 		@:from
 		@Before
 		// EOF
 	';
-	public static inline var AT_ANNOTATION_GOLD:String =
+	var AT_ANNOTATION_GOLD =
 		'  At\n' +
 		'    Const(CIdent(SuppressWarnings))\n' +
 		'      POpen\n' +
@@ -145,7 +151,7 @@ class TokenTreeBuilderTests {
 		'  At\n' +
 		'    Const(CIdent(Before))\n';
 
-	public static inline var IF:String = '
+	var IF = '
 		if (tokDef != null) return;
 		if (tokDef != null)
 			return;
@@ -161,7 +167,7 @@ class TokenTreeBuilderTests {
 			return [];
 		}
 	';
-	public static inline var IF_GOLD:String =
+	var IF_GOLD =
 		'  Kwd(KwdIf)\n' +
 		'    POpen\n' +
 		'      Const(CIdent(tokDef))\n' +


### PR DESCRIPTION
- in the assert calls, the type name doesn't have to be specified anymore
- "public static inline" and ":String" can be omitted
