### PR TITLE
Check: make the severity argument of log functions optional

### DIFF
--- a/src/checkstyle/checks/AvoidStarImportCheck.hx
+++ b/src/checkstyle/checks/AvoidStarImportCheck.hx
@@ -21,7 +21,7 @@ class AvoidStarImportCheck extends Check {
 		for (entry in importEntries) {
 			var stars:Array<TokenTree> = entry.filter([Binop(OpMult)], ALL);
 			if (stars.length <= 0) continue;
-			logPos("Import line uses a star (.*) import - consider using full type names", entry.pos, severity);
+			logPos("Import line uses a star (.*) import - consider using full type names", entry.pos);
 		}
 	}
 }

--- a/src/checkstyle/checks/Check.hx
+++ b/src/checkstyle/checks/Check.hx
@@ -42,18 +42,19 @@ class Check {
 		throw "Unimplemented";
 	}
 
-	public function logPos(msg:String, pos:Position, sev:SeverityLevel) {
+	public function logPos(msg:String, pos:Position, ?sev:SeverityLevel) {
 		logRange(msg, pos.min, pos.max, sev);
 	}
 
-	public function logRange(msg:String, startPos:Int, endPos:Int, sev:SeverityLevel) {
+	public function logRange(msg:String, startPos:Int, endPos:Int, ?sev:SeverityLevel) {
 		var lp = checker.getLinePos(startPos);
 		var length = endPos - startPos;
 		log(msg, lp.line + 1, lp.ofs, lp.ofs + length, sev);
 	}
 
-	public function log(msg:String, l:Int, startColumn:Int, ?endColumn:Int, sev:SeverityLevel) {
+	public function log(msg:String, l:Int, startColumn:Int, ?endColumn:Int, ?sev:SeverityLevel) {
 		if (endColumn == null) endColumn = startColumn;
+		if (sev == null) sev = severity;
 		messages.push({
 			fileName:checker.file.name,
 			message:msg,

--- a/src/checkstyle/checks/EmptyPackageCheck.hx
+++ b/src/checkstyle/checks/EmptyPackageCheck.hx
@@ -20,7 +20,7 @@ class EmptyPackageCheck extends Check {
 		var packageTokens = root.filter([Kwd(KwdPackage)], ALL);
 		if (enforceEmptyPackage) {
 			if (packageTokens.length == 0) {
-				log("Missing package declaration", 1, 0, 0, severity);
+				log("Missing package declaration", 1, 0, 0);
 			}
 		}
 		else {
@@ -31,7 +31,7 @@ class EmptyPackageCheck extends Check {
 	function checkPackageNames(entries:Array<TokenTree>) {
 		for (entry in entries) {
 			var firstChild = entry.getFirstChild();
-			if (firstChild.is(Semicolon)) logRange("Found empty package", entry.pos.min, firstChild.pos.max, severity);
+			if (firstChild.is(Semicolon)) logRange("Found empty package", entry.pos.min, firstChild.pos.max);
 		}
 	}
 }

--- a/src/checkstyle/checks/TODOCommentCheck.hx
+++ b/src/checkstyle/checks/TODOCommentCheck.hx
@@ -16,7 +16,7 @@ class TODOCommentCheck extends Check {
 		for (tk in checker.tokens) {
 			switch (tk.tok) {
 				case Comment(s) | CommentLine(s):
-					if (re.match(s)) logPos('TODO comment:' + s, tk.pos, severity);
+					if (re.match(s)) logPos('TODO comment:' + s, tk.pos);
 				default:
 			}
 		}

--- a/src/checkstyle/checks/block/EmptyBlockCheck.hx
+++ b/src/checkstyle/checks/block/EmptyBlockCheck.hx
@@ -105,14 +105,14 @@ class EmptyBlockCheck extends Check {
 
 	function checkForText(brOpen:TokenTree) {
 		if (brOpen.childs.length == 1) {
-			logPos('Empty block should contain a comment or a statement', brOpen.pos, severity);
+			logPos('Empty block should contain a comment or a statement', brOpen.pos);
 			return;
 		}
 	}
 
 	function checkForStatement(brOpen:TokenTree) {
 		if (brOpen.childs.length == 1) {
-			logPos('Empty block should contain a statement', brOpen.pos, severity);
+			logPos('Empty block should contain a statement', brOpen.pos);
 			return;
 		}
 		var onlyComments:Bool = true;
@@ -126,7 +126,7 @@ class EmptyBlockCheck extends Check {
 			}
 		}
 		if (onlyComments) {
-			logPos('Block should contain a statement', brOpen.pos, severity);
+			logPos('Block should contain a statement', brOpen.pos);
 		}
 	}
 
@@ -136,7 +136,7 @@ class EmptyBlockCheck extends Check {
 		}
 		var brClose:TokenTree = brOpen.childs[0];
 		if (brOpen.pos.max != brClose.pos.min) {
-			logPos("Empty block should be written as {}", brOpen.pos, severity);
+			logPos("Empty block should be written as {}", brOpen.pos);
 		}
 	}
 }

--- a/src/checkstyle/checks/block/LeftCurlyCheck.hx
+++ b/src/checkstyle/checks/block/LeftCurlyCheck.hx
@@ -200,7 +200,7 @@ class LeftCurlyCheck extends Check {
 
 	function logErrorIf(condition:Bool, msg:String, pos:Position) {
 		if (condition) {
-			logPos(msg, pos, severity);
+			logPos(msg, pos);
 			throw "exit";
 		}
 	}

--- a/src/checkstyle/checks/block/NeedBracesCheck.hx
+++ b/src/checkstyle/checks/block/NeedBracesCheck.hx
@@ -142,11 +142,11 @@ class NeedBracesCheck extends Check {
 		}
 		else {
 			if (singleLine) {
-				logPos('Body of "${TokenDefPrinter.print(parent.tok)}" on same line', child.pos, severity);
+				logPos('Body of "${TokenDefPrinter.print(parent.tok)}" on same line', child.pos);
 				return;
 			}
 		}
-		logPos('No braces used for body of "${TokenDefPrinter.print(parent.tok)}"', child.pos, severity);
+		logPos('No braces used for body of "${TokenDefPrinter.print(parent.tok)}"', child.pos);
 	}
 
 	function checkIfElseSingleline(parent:TokenTree, child:TokenTree):Bool {

--- a/src/checkstyle/checks/block/RightCurlyCheck.hx
+++ b/src/checkstyle/checks/block/RightCurlyCheck.hx
@@ -163,7 +163,7 @@ class RightCurlyCheck extends Check {
 
 	function logErrorIf(condition:Bool, msg:String, pos:Position) {
 		if (condition) {
-			logPos(msg, pos, severity);
+			logPos(msg, pos);
 			throw "exit";
 		}
 	}

--- a/src/checkstyle/checks/coding/AvoidInlineConditionalsCheck.hx
+++ b/src/checkstyle/checks/coding/AvoidInlineConditionalsCheck.hx
@@ -17,7 +17,7 @@ class AvoidInlineConditionalsCheck extends Check {
 			if (isPosSuppressed(e.pos)) return;
 			switch (e.expr){
 				case ETernary(econd, eif, eelse):
-					logPos('Avoid inline conditionals', e.pos, severity);
+					logPos('Avoid inline conditionals', e.pos);
 				default:
 			}
 		});

--- a/src/checkstyle/checks/coding/HiddenFieldCheck.hx
+++ b/src/checkstyle/checks/coding/HiddenFieldCheck.hx
@@ -114,7 +114,7 @@ class HiddenFieldCheck extends Check {
 		switch (token.tok) {
 			case Const(CIdent(name)):
 				if (memberNames.contains(name)) {
-					logPos('$logText of "$name" masks member of same name', token.pos, severity);
+					logPos('$logText of "$name" masks member of same name', token.pos);
 				}
 			default:
 		}

--- a/src/checkstyle/checks/coding/InnerAssignmentCheck.hx
+++ b/src/checkstyle/checks/coding/InnerAssignmentCheck.hx
@@ -31,7 +31,7 @@ class InnerAssignmentCheck extends Check {
 		var x:Int = 0;
 		for (assignToken in allAssignments) {
 			if (isPosSuppressed(assignToken.pos) || !filterAssignment(assignToken)) continue;
-			logPos('Inner assignment detected', assignToken.pos, severity);
+			logPos('Inner assignment detected', assignToken.pos);
 		}
 	}
 

--- a/src/checkstyle/checks/coding/MagicNumberCheck.hx
+++ b/src/checkstyle/checks/coding/MagicNumberCheck.hx
@@ -43,11 +43,11 @@ class MagicNumberCheck extends Check {
 				case Const(CInt(n)):
 					var number:Int = Std.parseInt(n);
 					if (ignoreNumbers.contains(number)) continue;
-					logPos('Magic number "$n" detected - consider using a constant', numberToken.pos, severity);
+					logPos('Magic number "$n" detected - consider using a constant', numberToken.pos);
 				case Const(CFloat(n)):
 					var number:Float = Std.parseFloat(n);
 					if (ignoreNumbers.contains(number)) continue;
-					logPos('Magic number "$n" detected - consider using a constant', numberToken.pos, severity);
+					logPos('Magic number "$n" detected - consider using a constant', numberToken.pos);
 				default:
 			}
 		}

--- a/src/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.hx
+++ b/src/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.hx
@@ -27,14 +27,14 @@ class MultipleVariableDeclarationsCheck extends Check {
 					default:
 				}
 			}
-			if (count > 1) logPos('Each variable declaration must be in its own statement', v.pos, severity);
+			if (count > 1) logPos('Each variable declaration must be in its own statement', v.pos);
 		}
 
 		// Need line no of each token to remove line based check
 		for (i in 0 ... checker.lines.length) {
 			if (isLineSuppressed(i)) return;
 			var line = checker.lines[i];
-			if (~/(var ).*;.*(var ).*;$/.match(line)) log('Only one variable definition per line allowed', i + 1, 0, null, severity);
+			if (~/(var ).*;.*(var ).*;$/.match(line)) log('Only one variable definition per line allowed', i + 1, 0);
 		}
 	}
 }

--- a/src/checkstyle/checks/coding/NestedForDepthCheck.hx
+++ b/src/checkstyle/checks/coding/NestedForDepthCheck.hx
@@ -51,7 +51,6 @@ class NestedForDepthCheck extends Check {
 	}
 
 	function warnNestedForDepth(depth:Int, pos:Position) {
-		logPos('Nested for depth is $depth (max allowed is ${max})',
-		pos, severity);
+		logPos('Nested for depth is $depth (max allowed is ${max})', pos);
 	}
 }

--- a/src/checkstyle/checks/coding/NestedIfDepthCheck.hx
+++ b/src/checkstyle/checks/coding/NestedIfDepthCheck.hx
@@ -50,6 +50,6 @@ class NestedIfDepthCheck extends Check {
 	}
 
 	function warnNestedIfDepth(depth:Int, pos:Position) {
-		logPos('Nested if-else depth is $depth (max allowed is ${max})', pos, severity);
+		logPos('Nested if-else depth is $depth (max allowed is ${max})', pos);
 	}
 }

--- a/src/checkstyle/checks/coding/NestedTryDepthCheck.hx
+++ b/src/checkstyle/checks/coding/NestedTryDepthCheck.hx
@@ -56,6 +56,6 @@ class NestedTryDepthCheck extends Check {
 	}
 
 	function warnNestedTryDepth(depth:Int, pos:Position) {
-		logPos('Nested try depth is $depth (max allowed is ${max})', pos, severity);
+		logPos('Nested try depth is $depth (max allowed is ${max})', pos);
 	}
 }

--- a/src/checkstyle/checks/coding/NullableParameterCheck.hx
+++ b/src/checkstyle/checks/coding/NullableParameterCheck.hx
@@ -33,9 +33,9 @@ class NullableParameterCheck extends Check {
 
 		switch (option) {
 			case QUESTION_MARK:
-				if (hasNullDefault) logRange('Function parameter $formatted should be ${formatArguments(true, arg.name, false)}', pos.min, pos.min, severity);
+				if (hasNullDefault) logRange('Function parameter $formatted should be ${formatArguments(true, arg.name, false)}', pos.min, pos.min);
 			case NULL_DEFAULT:
-				if (arg.opt) logRange('Function parameter $formatted should be ${formatArguments(false, arg.name, true)}', pos.min, pos.min, severity);
+				if (arg.opt) logRange('Function parameter $formatted should be ${formatArguments(false, arg.name, true)}', pos.min, pos.min);
 		}
 	}
 

--- a/src/checkstyle/checks/coding/ReturnCountCheck.hx
+++ b/src/checkstyle/checks/coding/ReturnCountCheck.hx
@@ -32,7 +32,7 @@ class ReturnCountCheck extends Check {
 			if (!fn.hasChilds()) throw "function has invalid structure!";
 			var returns = fn.filterCallback(filterReturns);
 			if (returns.length > max) {
-				logPos('Return count is ${returns.length} (max allowed is ${max})', fn.pos, severity);
+				logPos('Return count is ${returns.length} (max allowed is ${max})', fn.pos);
 			}
 		}
 	}

--- a/src/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.hx
+++ b/src/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.hx
@@ -36,7 +36,7 @@ class SimplifyBooleanExpressionCheck extends Check {
 		if (parent.is(Binop(OpEq)) || parent.is(Binop(OpNotEq)) || parent.is(Unop(OpNot)) ||
 			parent.is(Binop(OpOr)) || parent.is(Binop(OpAnd)) || parent.is(Binop(OpBoolOr)) ||
 			parent.is(Binop(OpBoolAnd))) {
-			logPos('Boolean expression can be simplified', token.pos, severity);
+			logPos('Boolean expression can be simplified', token.pos);
 		}
 	}
 }

--- a/src/checkstyle/checks/coding/SimplifyBooleanReturnCheck.hx
+++ b/src/checkstyle/checks/coding/SimplifyBooleanReturnCheck.hx
@@ -22,7 +22,7 @@ class SimplifyBooleanReturnCheck extends Check {
 			var thenStatement = token.childs[1];
 
 			if (canReturnOnlyBooleanLiteral(thenStatement) && canReturnOnlyBooleanLiteral(elseStatement)) {
-				logPos('Conditional logic can be removed', token.pos, severity);
+				logPos('Conditional logic can be removed', token.pos);
 			}
 		}
 	}

--- a/src/checkstyle/checks/coding/VariableInitialisationCheck.hx
+++ b/src/checkstyle/checks/coding/VariableInitialisationCheck.hx
@@ -43,6 +43,6 @@ class VariableInitialisationCheck extends Check {
 	}
 
 	function warnVarInit(name:String, pos:Position) {
-		logPos('Invalid variable initialisation: ${name} (move initialisation to constructor or function)', pos, severity);
+		logPos('Invalid variable initialisation: ${name} (move initialisation to constructor or function)', pos);
 	}
 }

--- a/src/checkstyle/checks/design/InterfaceIsTypeCheck.hx
+++ b/src/checkstyle/checks/design/InterfaceIsTypeCheck.hx
@@ -24,7 +24,7 @@ class InterfaceIsTypeCheck extends Check {
 
 			if (allowMarkerInterfaces && functions.length == 0 && vars.length == 0) continue;
 
-			if (functions.length == 0) logPos("Interfaces should describe a type and hence have methods", intr.pos, severity);
+			if (functions.length == 0) logPos("Interfaces should describe a type and hence have methods", intr.pos);
 		}
 	}
 }

--- a/src/checkstyle/checks/design/UnnecessaryConstructorCheck.hx
+++ b/src/checkstyle/checks/design/UnnecessaryConstructorCheck.hx
@@ -38,7 +38,7 @@ class UnnecessaryConstructorCheck extends Check {
 			}
 
 			if (haveConstructor && acceptableTokens.length > 1 && acceptableTokens.length == staticTokens + 1) {
-				logPos("Unnecessary constructor found", constructorPos, severity);
+				logPos("Unnecessary constructor found", constructorPos);
 			}
 		}
 	}

--- a/src/checkstyle/checks/literal/ArrayLiteralCheck.hx
+++ b/src/checkstyle/checks/literal/ArrayLiteralCheck.hx
@@ -17,7 +17,7 @@ class ArrayLiteralCheck extends Check {
 		ExprUtils.walkFile(checker.ast, function(e:Expr) {
 			switch (e.expr){
 				case ENew({pack:[], name:"Array"}, _):
-					logPos('Bad array instantiation, use the array literal notation [] which is shorter and cleaner', e.pos, severity);
+					logPos('Bad array instantiation, use the array literal notation [] which is shorter and cleaner', e.pos);
 				default:
 			}
 		});

--- a/src/checkstyle/checks/literal/ERegLiteralCheck.hx
+++ b/src/checkstyle/checks/literal/ERegLiteralCheck.hx
@@ -22,7 +22,7 @@ class ERegLiteralCheck extends Check {
 					[{expr:EConst(CString(re)), pos:_}, {expr:EConst(CString(opt)), pos:_}]
 				):
 					if (~/\$\{.+\}/.match(re)) return;
-					logPos('Bad EReg instantiation, define expression between ~/ and /', e.pos, severity);
+					logPos('Bad EReg instantiation, define expression between ~/ and /', e.pos);
 				default:
 			}
 		});

--- a/src/checkstyle/checks/literal/HexadecimalLiteralCheck.hx
+++ b/src/checkstyle/checks/literal/HexadecimalLiteralCheck.hx
@@ -33,7 +33,7 @@ class HexadecimalLiteralCheck extends Check {
 			var bodyExpected = bodyActual;
 			if (option.toLowerCase() == "lowercase") bodyExpected = bodyExpected.toLowerCase();
 			else bodyExpected = bodyExpected.toUpperCase();
-			if (bodyExpected != bodyActual) logPos('Bad hexademical literal, use ' + option, p, severity);
+			if (bodyExpected != bodyActual) logPos('Bad hexademical literal, use ' + option, p);
 		}
 	}
 }

--- a/src/checkstyle/checks/literal/MultipleStringLiteralsCheck.hx
+++ b/src/checkstyle/checks/literal/MultipleStringLiteralsCheck.hx
@@ -46,8 +46,7 @@ class MultipleStringLiteralsCheck extends Check {
 					if (s.length < minLength) continue;
 					if (checkLiteralCount(s, allLiterals)) {
 						if (isPosSuppressed(literalToken.pos)) continue;
-						logPos('Multiple string literal "$s" detected - consider using a constant',
-						literalToken.pos, severity);
+						logPos('Multiple string literal "$s" detected - consider using a constant', literalToken.pos);
 					}
 				default:
 			}

--- a/src/checkstyle/checks/modifier/ModifierOrderCheck.hx
+++ b/src/checkstyle/checks/modifier/ModifierOrderCheck.hx
@@ -42,7 +42,7 @@ class ModifierOrderCheck extends Check {
 	}
 
 	function warnOrder(name:String, modifier:ModifierOrderCheckModifier, pos:Position) {
-		logPos('Invalid modifier order: ${name} (modifier: ${modifier})', pos, severity);
+		logPos('Invalid modifier order: ${name} (modifier: ${modifier})', pos);
 	}
 }
 

--- a/src/checkstyle/checks/modifier/RedundantModifierCheck.hx
+++ b/src/checkstyle/checks/modifier/RedundantModifierCheck.hx
@@ -27,11 +27,11 @@ class RedundantModifierCheck extends Check {
 		var implicitAccess = isDefaultPrivate ? "private" : "public";
 		if (enforcePublicPrivate) {
 			if (!f.access.contains(APublic) && !f.access.contains(APrivate)) {
-				logPos('Missing $implicitAccess keyword: ${f.name}', f.pos, severity);
+				logPos('Missing $implicitAccess keyword: ${f.name}', f.pos);
 			}
 		}
 		else if ((isDefaultPrivate && f.access.contains(APrivate)) || (!isDefaultPrivate && f.access.contains(APublic))) {
-			logPos('No need of $implicitAccess keyword: ${f.name}', f.pos, severity);
+			logPos('No need of $implicitAccess keyword: ${f.name}', f.pos);
 		}
 	}
 }

--- a/src/checkstyle/checks/naming/ListenerNameCheck.hx
+++ b/src/checkstyle/checks/naming/ListenerNameCheck.hx
@@ -59,6 +59,6 @@ class ListenerNameCheck extends Check {
 	function checkListenerName(name:String, pos:Position) {
 		formatRE = new EReg (format, "");
 		var match = formatRE.match(name);
-		if (!match) logPos('Wrong listener name: ' + name + ' (should be ~/${format}/)', pos, severity);
+		if (!match) logPos('Wrong listener name: ' + name + ' (should be ~/${format}/)', pos);
 	}
 }

--- a/src/checkstyle/checks/naming/NameCheckBase.hx
+++ b/src/checkstyle/checks/naming/NameCheckBase.hx
@@ -62,6 +62,6 @@ class NameCheckBase<T> extends Check {
 	}
 
 	function warn(type:String, name:String, pos:Position) {
-		logPos('Invalid ${type} signature: ${name} (name should be ~/${format}/)', pos, severity);
+		logPos('Invalid ${type} signature: ${name} (name should be ~/${format}/)', pos);
 	}
 }

--- a/src/checkstyle/checks/size/FileLengthCheck.hx
+++ b/src/checkstyle/checks/size/FileLengthCheck.hx
@@ -23,6 +23,6 @@ class FileLengthCheck extends Check {
 				default:
 			}
 		}
-		if (checker.lines.length > max) log('Too many lines in file (> ${max})', checker.lines.length, 0, null, severity);
+		if (checker.lines.length > max) log('Too many lines in file (> ${max})', checker.lines.length, 0);
 	}
 }

--- a/src/checkstyle/checks/size/LineLengthCheck.hx
+++ b/src/checkstyle/checks/size/LineLengthCheck.hx
@@ -20,7 +20,7 @@ class LineLengthCheck extends Check {
 			var line = checker.lines[i];
 			if (line.length > max) {
 				if (isLineSuppressed(i)) continue;
-				log('Too long line (> ${max})', i + 1, 0, line.length, severity);
+				log('Too long line (> ${max})', i + 1, 0, line.length);
 			}
 		}
 	}

--- a/src/checkstyle/checks/size/MethodLengthCheck.hx
+++ b/src/checkstyle/checks/size/MethodLengthCheck.hx
@@ -64,6 +64,6 @@ class MethodLengthCheck extends Check {
 	}
 
 	function warnFunctionLength(name:String, pos:Position) {
-		logPos('Function is too long: ${name} (> ${max} lines, try splitting into multiple functions)', pos, severity);
+		logPos('Function is too long: ${name} (> ${max} lines, try splitting into multiple functions)', pos);
 	}
 }

--- a/src/checkstyle/checks/size/ParameterNumberCheck.hx
+++ b/src/checkstyle/checks/size/ParameterNumberCheck.hx
@@ -37,6 +37,6 @@ class ParameterNumberCheck extends Check {
 	}
 
 	function warnMaxParameter(name:String, pos:Position) {
-		logPos('Too many parameters for function: ${name} (> ${max})', pos, severity);
+		logPos('Too many parameters for function: ${name} (> ${max})', pos);
 	}
 }

--- a/src/checkstyle/checks/type/AnonymousCheck.hx
+++ b/src/checkstyle/checks/type/AnonymousCheck.hx
@@ -47,6 +47,6 @@ class AnonymousCheck extends Check {
 	}
 
 	function error(name:String, pos:Position) {
-		logPos('Anonymous structure found, it is advised to use a typedef instead \"${name}\"', pos, severity);
+		logPos('Anonymous structure found, it is advised to use a typedef instead \"${name}\"', pos);
 	}
 }

--- a/src/checkstyle/checks/type/DynamicCheck.hx
+++ b/src/checkstyle/checks/type/DynamicCheck.hx
@@ -28,6 +28,6 @@ class DynamicCheck extends Check {
 	}
 
 	function error(name:String, pos:Position) {
-		logPos('Dynamic type used: ${name}', pos, severity);
+		logPos('Dynamic type used: ${name}', pos);
 	}
 }

--- a/src/checkstyle/checks/type/ReturnCheck.hx
+++ b/src/checkstyle/checks/type/ReturnCheck.hx
@@ -102,15 +102,15 @@ class ReturnCheck extends Check {
 	}
 
 	function warnVoid(name:String, pos:Position) {
-		logPos('Void return should not explicitly be specified for function $name', pos, severity);
+		logPos('Void return should not explicitly be specified for function $name', pos);
 	}
 
 	function warnReturnTypeMissing(name:String, pos:Position) {
 		if (name == null) {
-			logPos('Return type not specified for anonymous function', pos, severity);
+			logPos('Return type not specified for anonymous function', pos);
 		}
 		else {
-			logPos('Return type not specified for function: ${name}', pos, severity);
+			logPos('Return type not specified for function: ${name}', pos);
 		}
 	}
 }

--- a/src/checkstyle/checks/type/TypeCheck.hx
+++ b/src/checkstyle/checks/type/TypeCheck.hx
@@ -31,6 +31,6 @@ class TypeCheck extends Check {
 	}
 
 	function error(name:String, pos:Position) {
-		logPos('Type not specified: ${name}', pos, severity);
+		logPos('Type not specified: ${name}', pos);
 	}
 }

--- a/src/checkstyle/checks/whitespace/EmptyLinesCheck.hx
+++ b/src/checkstyle/checks/whitespace/EmptyLinesCheck.hx
@@ -50,11 +50,11 @@ class EmptyLinesCheck extends Check {
 
 	function checkComment(i, start, regex) {
 		if (i > 0 && regex.match(StringTools.trim(checker.lines[i - 1]))) {
-			log('Empty line not allowed after comment(s)', start, 0, null, severity);
+			log('Empty line not allowed after comment(s)', start, 0);
 		}
 	}
 
 	function logInfo(pos) {
-		log('Too many consecutive empty lines (> ${max})', pos, 0, null, severity);
+		log('Too many consecutive empty lines (> ${max})', pos, 0);
 	}
 }

--- a/src/checkstyle/checks/whitespace/IndentationCharacterCheck.hx
+++ b/src/checkstyle/checks/whitespace/IndentationCharacterCheck.hx
@@ -25,7 +25,7 @@ class IndentationCharacterCheck extends Check {
 		}
 		for (i in 0 ... checker.lines.length) {
 			var line = checker.lines[i];
-			if (line.length > 0 && !re.match(line)) log('Wrong indentation character (should be ${character})', i + 1, 0, null, severity);
+			if (line.length > 0 && !re.match(line)) log('Wrong indentation character (should be ${character})', i + 1, 0);
 		}
 	}
 }

--- a/src/checkstyle/checks/whitespace/SpacingCheck.hx
+++ b/src/checkstyle/checks/whitespace/SpacingCheck.hx
@@ -45,12 +45,12 @@ class SpacingCheck extends Check {
 			switch (e.expr) {
 				case EBinop(bo, l, r) if (spaceAroundBinop):
 					if (ignoreRangeOperator && binopString(bo) == "...") return;
-					if (r.pos.min - l.pos.max < binopSize(bo) + 2) logPos('No space around ${binopString(bo)}', e.pos, severity);
+					if (r.pos.min - l.pos.max < binopSize(bo) + 2) logPos('No space around ${binopString(bo)}', e.pos);
 				case EUnop(uo, post, e2) if (noSpaceAroundUnop):
 					var dist = 0;
 					if (post) dist = e.pos.max - e2.pos.max;
 					else dist = e2.pos.min - e.pos.min;
-					if (dist > unopSize(uo)) logPos('Space around ${unopString(uo)}', e.pos, severity);
+					if (dist > unopSize(uo)) logPos('Space around ${unopString(uo)}', e.pos);
 				case EIf(econd, _, _) if (spaceIfCondition):
 					checkSpaceBetweenExpressions('if', e, econd);
 				case EFor(it, _) if (spaceForLoop):
@@ -90,7 +90,7 @@ class SpacingCheck extends Check {
 
 	function checkSpaceBetweenExpressions(name:String, e1:Expr, e2:Expr) {
 		if (e2.pos.min - e1.pos.min < '$name ('.length) {
-			logRange('No space between $name and (', e1.pos.max, e2.pos.min, severity);
+			logRange('No space between $name and (', e1.pos.max, e2.pos.min);
 		}
 	}
 
@@ -99,7 +99,7 @@ class SpacingCheck extends Check {
 		var checkPos = prevExprUntilChecked.lastIndexOf('$name(');
 		if (checkPos > -1) {
 			var fileCheckPos = before.pos.min + checkPos;
-			logRange('No space between $name and (', fileCheckPos, fileCheckPos + '$name('.length, severity);
+			logRange('No space between $name and (', fileCheckPos, fileCheckPos + '$name('.length);
 		}
 	}
 }

--- a/src/checkstyle/checks/whitespace/TabForAligningCheck.hx
+++ b/src/checkstyle/checks/whitespace/TabForAligningCheck.hx
@@ -17,7 +17,7 @@ class TabForAligningCheck extends Check {
 		for (i in 0 ... checker.lines.length) {
 			var line = checker.lines[i];
 			if (re.match(line) && !line.contains("//")) {
-				log("Tab after non-space character. Use space for aligning", i + 1, line.length, null, severity);
+				log("Tab after non-space character. Use space for aligning", i + 1, line.length);
 			}
 		}
 	}

--- a/src/checkstyle/checks/whitespace/TrailingWhitespaceCheck.hx
+++ b/src/checkstyle/checks/whitespace/TrailingWhitespaceCheck.hx
@@ -15,7 +15,7 @@ class TrailingWhitespaceCheck extends Check {
 		var re = ~/\s+$/;
 		for (i in 0 ... checker.lines.length) {
 			var line = checker.lines[i];
-			if (re.match(line)) log('Trailing whitespace', i + 1, line.length, null, severity);
+			if (re.match(line)) log('Trailing whitespace', i + 1, line.length);
 		}
 	}
 }

--- a/src/checkstyle/checks/whitespace/WhitespaceAfterCheck.hx
+++ b/src/checkstyle/checks/whitespace/WhitespaceAfterCheck.hx
@@ -96,7 +96,7 @@ class WhitespaceAfterCheck extends Check {
 			var contentAfter:String = checker.file.content.substr(tok.pos.max, 1);
 			if (~/^(\s|)$/.match(contentAfter)) continue;
 
-			logPos('No whitespace after "${TokenDefPrinter.print(tok.tok)}"', tok.pos, severity);
+			logPos('No whitespace after "${TokenDefPrinter.print(tok.tok)}"', tok.pos);
 		}
 	}
 }

--- a/src/checkstyle/checks/whitespace/WhitespaceAroundCheck.hx
+++ b/src/checkstyle/checks/whitespace/WhitespaceAroundCheck.hx
@@ -136,11 +136,11 @@ class WhitespaceAroundCheck extends Check {
 			var after:String = line.substr(linePos.ofs + tokLen);
 
 			if (!(~/^.*\s$/.match(before))) {
-				logPos('No whitespace around "${TokenDefPrinter.print(tok.tok)}"', tok.pos, severity);
+				logPos('No whitespace around "${TokenDefPrinter.print(tok.tok)}"', tok.pos);
 				continue;
 			}
 			if (!(~/^(\s.*|)$/.match(after))) {
-				logPos('No whitespace around "${TokenDefPrinter.print(tok.tok)}"', tok.pos, severity);
+				logPos('No whitespace around "${TokenDefPrinter.print(tok.tok)}"', tok.pos);
 				continue;
 			}
 		}

--- a/src/checkstyle/checks/whitespace/WrapCheckBase.hx
+++ b/src/checkstyle/checks/whitespace/WrapCheckBase.hx
@@ -41,13 +41,13 @@ class WrapCheckBase extends Check {
 
 			if (~/^\s*$/.match(before)) {
 				if (option != NL) {
-					logPos('Token "${TokenDefPrinter.print(tok.tok)}" must be at the end of the line', tok.pos, severity);
+					logPos('Token "${TokenDefPrinter.print(tok.tok)}" must be at the end of the line', tok.pos);
 					continue;
 				}
 			}
 			if (~/^\s*(\/\/.*|\/\*.*|)$/.match(after)) {
 				if (option != EOL) {
-					logPos('Token "${TokenDefPrinter.print(tok.tok)}" must be on a new line', tok.pos, severity);
+					logPos('Token "${TokenDefPrinter.print(tok.tok)}" must be on a new line', tok.pos);
 				}
 			}
 		}


### PR DESCRIPTION
Every single check except for CycolmaticComplexityCheck was passing the instance variable here.
