### PR TITLE
Output position information on TokenTreeBuilder crashes

### DIFF
--- a/src/checkstyle/Checker.hx
+++ b/src/checkstyle/Checker.hx
@@ -1,5 +1,6 @@
 package checkstyle;
 
+import byte.ByteData;
 import haxe.CallStack;
 import checkstyle.checks.Check;
 import haxeparser.Data.TypeDecl;
@@ -19,6 +20,7 @@ using StringTools;
 class Checker {
 
 	public var file:CheckFile;
+	public var bytes:ByteData;
 	public var lines:Array<String>;
 	public var tokens:Array<Token>;
 	public var ast:Ast;
@@ -50,7 +52,7 @@ class Checker {
 
 	public function getTokenTree():TokenTree {
 		if (tokens == null) return null;
-		if (tokenTree == null) tokenTree = TokenTreeBuilder.buildTokenTree(tokens);
+		if (tokenTree == null) tokenTree = TokenTreeBuilder.buildTokenTree(tokens, bytes);
 		return tokenTree;
 	}
 
@@ -112,7 +114,7 @@ class Checker {
 			var code = file.content;
 			tokens = [];
 			tokenTree = null;
-			var lexer = new HaxeLexer(byte.ByteData.ofString(code), file.name);
+			var lexer = new HaxeLexer(bytes, file.name);
 			var t:Token = lexer.token(HaxeLexer.tok);
 
 			while (t.tok != Eof) {
@@ -197,6 +199,7 @@ class Checker {
 
 	function createContext(checkFile:CheckFile):Bool {
 		file = checkFile;
+		bytes = byte.ByteData.ofString(file.content);
 		for (reporter in reporters) reporter.fileStart(file);
 		try {
 			findLineSeparator();

--- a/src/checkstyle/checks/literal/MultipleStringLiteralsCheck.hx
+++ b/src/checkstyle/checks/literal/MultipleStringLiteralsCheck.hx
@@ -26,7 +26,7 @@ class MultipleStringLiteralsCheck extends Check {
 
 	override function actualRun() {
 		ignoreRE = new EReg (ignore, "");
-		var root:TokenTree = TokenTreeBuilder.buildTokenTree(checker.tokens);
+		var root:TokenTree = TokenTreeBuilder.buildTokenTree(checker.tokens, checker.bytes);
 
 		var allLiterals:Map<String, Int> = new Map<String, Int>();
 		var allStringLiterals:Array<TokenTree> = root.filterCallback(function(token:TokenTree, depth:Int):FilterResult {

--- a/src/checkstyle/checks/literal/StringLiteralCheck.hx
+++ b/src/checkstyle/checks/literal/StringLiteralCheck.hx
@@ -20,7 +20,7 @@ class StringLiteralCheck extends Check {
 	}
 
 	override function actualRun() {
-		var root:TokenTree = TokenTreeBuilder.buildTokenTree(checker.tokens);
+		var root:TokenTree = TokenTreeBuilder.buildTokenTree(checker.tokens, checker.bytes);
 
 		var allLiterals:Map<String, Int> = new Map<String, Int>();
 		var allStringLiterals:Array<TokenTree> = root.filterCallback(function(token:TokenTree, depth:Int):FilterResult {

--- a/src/checkstyle/token/TokenStream.hx
+++ b/src/checkstyle/token/TokenStream.hx
@@ -1,8 +1,10 @@
 package checkstyle.token;
 
+import byte.ByteData;
 import haxe.macro.Expr;
 import haxeparser.Data.Token;
 import haxeparser.Data.TokenDef;
+import hxparse.Position;
 
 class TokenStream {
 
@@ -10,9 +12,11 @@ class TokenStream {
 
 	var tokens:Array<Token>;
 	var current:Int;
+	var bytes:ByteData;
 
-	public function new(tokens:Array<Token>) {
+	public function new(tokens:Array<Token>, bytes:ByteData) {
 		this.tokens = tokens;
+		this.bytes = bytes;
 		current = 0;
 	}
 
@@ -30,20 +34,29 @@ class TokenStream {
 	public function consumeConstIdent():TokenTree {
 		switch (token()) {
 			case Const(CIdent(_)): return consumeToken();
-			default: throw 'bad token ${token()} != Const(CIdent(_))';
+			default: error('bad token ${token()} != Const(CIdent(_))');
 		}
 	}
 
 	public function consumeConst():TokenTree {
 		switch (token()) {
 			case Const(_): return consumeToken();
-			default: throw 'bad token ${token()} != Const(_)';
+			default: error('bad token ${token()} != Const(_)');
 		}
 	}
 
 	public function consumeTokenDef(tokenDef:TokenDef):TokenTree {
 		if (is(tokenDef)) return consumeToken();
-		throw 'bad token ${token()} != $tokenDef';
+		error('bad token ${token()} != $tokenDef');
+	}
+
+	public inline function error(s:String) {
+		throw formatCurrentPos() + " " + s;
+	}
+	
+	function formatCurrentPos():String {
+		var pos = tokens[current].pos;
+		return new Position(pos.file, pos.min, pos.max).format(bytes);
 	}
 
 	public function is(tokenDef:TokenDef):Bool {

--- a/src/checkstyle/token/TokenTreeBuilder.hx
+++ b/src/checkstyle/token/TokenTreeBuilder.hx
@@ -1,5 +1,6 @@
 package checkstyle.token;
 
+import byte.ByteData;
 import haxe.macro.Expr;
 import haxeparser.Data.Token;
 import haxeparser.Data.TokenDef;
@@ -7,8 +8,8 @@ import haxeparser.Data.TokenDef;
 import checkstyle.token.walk.WalkFile;
 
 class TokenTreeBuilder {
-	public static function buildTokenTree(tokens:Array<Token>):TokenTree {
-		var stream:TokenStream = new TokenStream(tokens);
+	public static function buildTokenTree(tokens:Array<Token>, bytes:ByteData):TokenTree {
+		var stream:TokenStream = new TokenStream(tokens, bytes);
 		var root:TokenTree = new TokenTree(null, null, -1);
 		WalkFile.walkFile(stream, root);
 		return root;

--- a/src/checkstyle/token/walk/WalkSharp.hx
+++ b/src/checkstyle/token/walk/WalkSharp.hx
@@ -80,7 +80,7 @@ class WalkSharp {
 		WalkSharp.walkSharpIfExpr(stream, ifToken);
 		WalkSharp.walkSharpExpr(stream, ifToken);
 		if (stream.token().match(Sharp(_))) return;
-		throw 'bad token ${stream.token()} != #elseif/#end';
+		stream.error('bad token ${stream.token()} != #elseif/#end');
 	}
 
 	static function walkSharpIfExpr(stream:TokenStream, parent:TokenTree) {

--- a/src/checkstyle/token/walk/WalkSwitch.hx
+++ b/src/checkstyle/token/walk/WalkSwitch.hx
@@ -50,7 +50,7 @@ class WalkSwitch {
 				case Comment(_), CommentLine(_):
 					WalkStatement.walkStatement(stream, brOpen);
 				default:
-					throw 'bad token ${stream.token()} != case/default';
+					stream.error('bad token ${stream.token()} != case/default');
 			}
 		}
 		brOpen.addChild(stream.consumeTokenDef(BrClose));

--- a/test/token/TestTokenTreeBuilder.hx
+++ b/test/token/TestTokenTreeBuilder.hx
@@ -1,5 +1,6 @@
 package token;
 
+import byte.ByteData;
 import haxeparser.HaxeLexer;
 
 import haxeparser.Data.Token;
@@ -28,7 +29,7 @@ class TestTokenTreeBuilder extends TokenTreeBuilder {
 			tokens.push(t);
 			t = lexer.token(haxeparser.HaxeLexer.tok);
 		}
-		return new TokenStream(tokens);
+		return new TokenStream(tokens, ByteData.ofString(code));
 	}
 
 	var stream:TokenStream;


### PR DESCRIPTION
This makes isolating crashes a lot easier, since the position where it went wrong is output like a regular Haxe compiler error now (compatible with FD's results panel).
