### PR TITLE
Avoid matching TODOComments on commented code

### DIFF
--- a/resources/default-config.json
+++ b/resources/default-config.json
@@ -521,7 +521,7 @@
 		},
 		{
 			"props": {
-				"format": "TODO|FIXME|HACK|XXX|BUG",
+				"format": "^\\s*[TODO|FIXME|HACK|XXX|BUG]",
 				"severity": "IGNORE"
 			},
 			"type": "TODOComment"

--- a/src/checkstyle/checks/comments/TODOCommentCheck.hx
+++ b/src/checkstyle/checks/comments/TODOCommentCheck.hx
@@ -12,7 +12,7 @@ class TODOCommentCheck extends Check {
 	public function new() {
 		super(LINE);
 		severity = SeverityLevel.IGNORE;
-		format = "TODO|FIXME|HACK|XXX|BUG";
+		format = "^\\s*[TODO|FIXME|HACK|XXX|BUG]";
 		categories = [Category.BUG_RISK];
 		points = 8;
 	}


### PR DESCRIPTION
This is to avoid false positive on commented code lines that contains TODO/FIXME/...

```
//trace("TODO");
```

Not 100% sure about the regex.
