### PR TITLE
Avoid deprecation warnings with haxeparser 3.3.0

### DIFF
--- a/src/checkstyle/checks/block/NeedBracesCheck.hx
+++ b/src/checkstyle/checks/block/NeedBracesCheck.hx
@@ -144,11 +144,11 @@ class NeedBracesCheck extends Check {
 		}
 		else {
 			if (singleLine) {
-				logPos('Body of "${TokenDefPrinter.print(parent.tok)}" on same line', child.pos);
+				logPos('Body of "$parent" on same line', child.pos);
 				return;
 			}
 		}
-		logPos('No braces used for body of "${TokenDefPrinter.print(parent.tok)}"', child.pos);
+		logPos('No braces used for body of "$parent"', child.pos);
 	}
 
 	function checkIfElseSingleline(parent:TokenTree, child:TokenTree):Bool {

--- a/src/checkstyle/checks/imports/UnusedImportCheck.hx
+++ b/src/checkstyle/checks/imports/UnusedImportCheck.hx
@@ -3,7 +3,6 @@ package checkstyle.checks.imports;
 import checkstyle.token.TokenTree;
 import checkstyle.utils.TokenTreeCheckUtils;
 import haxe.io.Path;
-import haxeparser.Data;
 
 using checkstyle.utils.ArrayUtils;
 
@@ -98,12 +97,12 @@ class UnusedImportCheck extends Check {
 				case Kwd(KwdPackage):
 				case Semicolon: return moduleName.toString();
 				case Kwd(KwdIn):
-					if (token.parent.tok.match(Dot)) moduleName.add(TokenDefPrinter.print(token.tok));
+					if (token.parent.tok.match(Dot)) moduleName.add(token.toString());
 					else moduleName.add(" in ");
 				case Const(CIdent("as")):
-					if (token.parent.tok.match(Dot)) moduleName.add(TokenDefPrinter.print(token.tok));
+					if (token.parent.tok.match(Dot)) moduleName.add(token.toString());
 					else moduleName.add(" as ");
-				default: moduleName.add(TokenDefPrinter.print(token.tok));
+				default: moduleName.add(token.toString());
 			}
 			token = token.getFirstChild();
 		}
@@ -127,7 +126,7 @@ class UnusedImportCheck extends Check {
 
 	function checkUsage(typeName:String, moduleName:String, importTok:TokenTree, idents:Array<TokenTree>, stringLiterals:Array<TokenTree>) {
 		for (ident in idents) {
-			var name:String = TokenDefPrinter.print(ident.tok);
+			var name:String = ident.toString();
 			if (!checkName(typeName, moduleName, name)) continue;
 			switch (ident.parent.tok) {
 				case Kwd(KwdClass), Kwd(KwdInterface), Kwd(KwdAbstract), Kwd(KwdEnum), Kwd(KwdTypedef): continue;
@@ -136,7 +135,7 @@ class UnusedImportCheck extends Check {
 			}
 		}
 		for (literal in stringLiterals) {
-			var names : Array<String> = extractLiteralNames(TokenDefPrinter.print (literal.tok));
+			var names:Array<String> = extractLiteralNames(literal.toString());
 			for (name in names) {
 				if (checkName(typeName, moduleName, name)) return;
 			}
@@ -144,16 +143,16 @@ class UnusedImportCheck extends Check {
 		logPos('Unused import "$moduleName" detected', importTok.pos);
 	}
 
-	function extractLiteralNames(text : String):Array<String> {
-		var names : Array<String> = [];
-		var interpols : Array<String> = [];
-		var interpolRegEx : EReg = ~/\$\{([^\}]+)\}/g;
+	function extractLiteralNames(text:String):Array<String> {
+		var names:Array<String> = [];
+		var interpols:Array<String> = [];
+		var interpolRegEx:EReg = ~/\$\{([^\}]+)\}/g;
 		while (true) {
 			if (!interpolRegEx.match(text)) break;
 			interpols.push(interpolRegEx.matched(1));
 			text = interpolRegEx.matchedRight();
 		}
-		var namesRegEx : EReg = ~/([A-Z][A-Za-z0-9_]*)/g;
+		var namesRegEx:EReg = ~/([A-Z][A-Za-z0-9_]*)/g;
 		for (interpol in interpols) {
 			while (true) {
 				if (!namesRegEx.match(interpol)) break;

--- a/src/checkstyle/checks/whitespace/OperatorWhitespaceCheck.hx
+++ b/src/checkstyle/checks/whitespace/OperatorWhitespaceCheck.hx
@@ -4,7 +4,6 @@ import checkstyle.token.TokenTree;
 import checkstyle.utils.TokenTreeCheckUtils;
 import checkstyle.checks.whitespace.WhitespaceCheckBase.WhitespacePolicy;
 import checkstyle.checks.whitespace.WhitespaceCheckBase.WhitespaceUnaryPolicy;
-import haxeparser.Data;
 
 @name("OperatorWhitespace")
 @desc("Checks that whitespace is present or absent around a operators.")
@@ -170,6 +169,6 @@ class OperatorWhitespaceCheck extends WhitespaceCheckBase {
 	}
 
 	override function violation(tok:TokenTree, policy:String) {
-		logPos('OperatorWhitespace policy "$policy" violated by "${TokenDefPrinter.print(tok.tok)}"', tok.pos);
+		logPos('OperatorWhitespace policy "$policy" violated by "$tok"', tok.pos);
 	}
 }

--- a/src/checkstyle/checks/whitespace/SeparatorWhitespaceCheck.hx
+++ b/src/checkstyle/checks/whitespace/SeparatorWhitespaceCheck.hx
@@ -35,7 +35,7 @@ class SeparatorWhitespaceCheck extends WhitespaceCheckBase {
 
 	override function violation(tok:TokenTree, policy:String) {
 		if (isWrapped(tok, cast (policy, WhitespacePolicy))) return;
-		logPos('SeparatorWhitespace policy "$policy" violated by "${TokenDefPrinter.print(tok.tok)}"', tok.pos);
+		logPos('SeparatorWhitespace policy "$policy" violated by "$tok"', tok.pos);
 	}
 
 	function isWrapped(tok:TokenTree, policy:WhitespacePolicy):Bool {

--- a/src/checkstyle/checks/whitespace/WhitespaceAfterCheck.hx
+++ b/src/checkstyle/checks/whitespace/WhitespaceAfterCheck.hx
@@ -94,7 +94,7 @@ class WhitespaceAfterCheck extends Check {
 			var contentAfter:String = checker.file.content.substr(tok.pos.max, 1);
 			if (~/^(\s|)$/.match(contentAfter)) continue;
 
-			logPos('No whitespace after "${TokenDefPrinter.print(tok.tok)}"', tok.pos);
+			logPos('No whitespace after "$tok"', tok.pos);
 		}
 	}
 }

--- a/src/checkstyle/checks/whitespace/WhitespaceAroundCheck.hx
+++ b/src/checkstyle/checks/whitespace/WhitespaceAroundCheck.hx
@@ -132,15 +132,15 @@ class WhitespaceAroundCheck extends Check {
 			var linePos:LinePos = checker.getLinePos(tok.pos.min);
 			var line:String = checker.lines[linePos.line];
 			var before:String = line.substr(0, linePos.ofs);
-			var tokLen:Int = TokenDefPrinter.print(tok.tok).length;
+			var tokLen:Int = tok.toString().length;
 			var after:String = line.substr(linePos.ofs + tokLen);
 
 			if (!(~/^.*\s$/.match(before))) {
-				logPos('No whitespace around "${TokenDefPrinter.print(tok.tok)}"', tok.pos);
+				logPos('No whitespace around "$tok"', tok.pos);
 				continue;
 			}
 			if (!(~/^(\s.*|)$/.match(after))) {
-				logPos('No whitespace around "${TokenDefPrinter.print(tok.tok)}"', tok.pos);
+				logPos('No whitespace around "$tok"', tok.pos);
 				continue;
 			}
 		}

--- a/src/checkstyle/checks/whitespace/WhitespaceCheckBase.hx
+++ b/src/checkstyle/checks/whitespace/WhitespaceCheckBase.hx
@@ -67,7 +67,7 @@ class WhitespaceCheckBase extends Check {
 
 	function checkWhitespaceExt(tok:TokenTree, checkCallback:WhitespacePolicyCheck) {
 		var linePos:LinePos = checker.getLinePos(tok.pos.min);
-		var tokLen:Int = TokenDefPrinter.print(tok.tok).length;
+		var tokLen:Int = tok.toString().length;
 		if (tok.tok.match(IntInterval(_))) {
 			linePos = checker.getLinePos(tok.pos.max - 3);
 			tokLen = 3;

--- a/src/checkstyle/checks/whitespace/WrapCheckBase.hx
+++ b/src/checkstyle/checks/whitespace/WrapCheckBase.hx
@@ -36,18 +36,18 @@ class WrapCheckBase extends Check {
 			var linePos:LinePos = checker.getLinePos(tok.pos.min);
 			var line:String = checker.lines[linePos.line];
 			var before:String = line.substr(0, linePos.ofs);
-			var tokLen:Int = TokenDefPrinter.print(tok.tok).length;
+			var tokLen:Int = tok.toString().length;
 			var after:String = line.substr(linePos.ofs + tokLen);
 
 			if (~/^\s*$/.match(before)) {
 				if (option != NL) {
-					logPos('Token "${TokenDefPrinter.print(tok.tok)}" must be at the end of the line', tok.pos);
+					logPos('Token "$tok" must be at the end of the line', tok.pos);
 					continue;
 				}
 			}
 			if (~/^\s*(\/\/.*|\/\*.*|)$/.match(after)) {
 				if (option != EOL) {
-					logPos('Token "${TokenDefPrinter.print(tok.tok)}" must be on a new line', tok.pos);
+					logPos('Token "$tok" must be on a new line', tok.pos);
 				}
 			}
 		}

--- a/src/checkstyle/token/TokenTree.hx
+++ b/src/checkstyle/token/TokenTree.hx
@@ -103,10 +103,6 @@ class TokenTree extends Token {
 		return false;
 	}
 
-	override public function toString():String {
-		return printTokenTree();
-	}
-
 	public function printTokenTree(prefix:String = ""):String {
 		var buf:StringBuf = new StringBuf();
 		if (tok != null) buf.add('$prefix${tok}\t\t\t\t${getPos()}');


### PR DESCRIPTION
TokenDefPrinter.print() was deprecated (outputs "use toString() instead" warnings when used).
