### PR TITLE
CheckTestCase: more readable expected / actual formatting

### DIFF
--- a/test/checks/CheckTestCase.hx
+++ b/test/checks/CheckTestCase.hx
@@ -35,6 +35,16 @@ class CheckTestCase<T:String> extends haxe.unit.TestCase {
 		assertEquals(expected, msg, pos);
 	}
 
+	override function assertEquals<T>(expected:T, actual:T, ?c:PosInfos):Void {
+		currentTest.done = true;
+		if (actual != expected){
+			currentTest.success = false;
+			currentTest.error   = "\nexpected:\n\t'" + expected + "'\nactual:\n\t'" + actual + "'";
+			currentTest.posInfos = c;
+			throw currentTest;
+		}
+	}
+
 	function checkMessage(src:String, check:Check, defines:Array<Array<String>>, fileName:String = FILE_NAME, ?pos:PosInfos):String {
 		// a fresh Checker and Reporter for every checkMessage
 		// to allow multiple independant checkMessage calls in a single test

--- a/test/checks/CheckTestCase.hx
+++ b/test/checks/CheckTestCase.hx
@@ -35,11 +35,11 @@ class CheckTestCase<T:String> extends haxe.unit.TestCase {
 		assertEquals(expected, msg, pos);
 	}
 
-	override function assertEquals<T>(expected:T, actual:T, ?c:PosInfos):Void {
+	override function assertEquals<T>(expected:T, actual:T, ?c:PosInfos) {
 		currentTest.done = true;
-		if (actual != expected){
+		if (actual != expected) {
 			currentTest.success = false;
-			currentTest.error   = "\nexpected:\n\t'" + expected + "'\nactual:\n\t'" + actual + "'";
+			currentTest.error = "\nexpected:\n\t'" + expected + "'\nactual:\n\t'" + actual + "'";
 			currentTest.posInfos = c;
 			throw currentTest;
 		}

--- a/test/misc/ExtensionsTest.hx
+++ b/test/misc/ExtensionsTest.hx
@@ -1,6 +1,9 @@
 package misc;
 
 import checks.CheckTestCase;
+#if (haxeparser >= "3.3.0")
+import checkstyle.checks.whitespace.IndentationCharacterCheck;
+#end
 
 class ExtensionsTest extends CheckTestCase<ExtensionsTests> {
 

--- a/test/misc/ExtensionsTest.hx
+++ b/test/misc/ExtensionsTest.hx
@@ -1,21 +1,15 @@
 package misc;
 
 import checks.CheckTestCase;
-import checkstyle.checks.whitespace.IndentationCharacterCheck;
 
 class ExtensionsTest extends CheckTestCase<ExtensionsTests> {
 
 	public function testExtensions() {
-		try {
-			assertNoMsg(new IndentationCharacterCheck(), TEST1);
-			// the upcoming haxeparser does not fail here, so disabling failing part
-			// // unless haxeparse bug is fixed, this code is unreachable
-			// assertFalse(true);
-		}
-		catch (e:Dynamic) {
-			assertEquals("misc.ExtensionsTest", e.classname);
-			assertEquals("expected '' but was 'Parsing failed: Unexpected >", e.error.substr(0, 49));
-		}
+		#if (haxeparser >= "3.3.0")
+		assertNoMsg(new IndentationCharacterCheck(), TEST1);
+		#else
+		assertTrue(true);
+		#end
 	}
 }
 


### PR DESCRIPTION
Example:

![](http://i.imgur.com/UW3YM0j.png)

Before it was all in one line, making it almost impossible to tell the difference.
