### PR TITLE
fixed false unnecessary constructor warning

### DIFF
--- a/src/checkstyle/checks/design/UnnecessaryConstructorCheck.hx
+++ b/src/checkstyle/checks/design/UnnecessaryConstructorCheck.hx
@@ -19,19 +19,19 @@ class UnnecessaryConstructorCheck extends Check {
 			var acceptableTokens:Array<TokenTree> = cls.filter([
 				Kwd(KwdFunction),
 				Kwd(KwdVar)
-			], ALL);
+			], FIRST);
 
 			var haveConstructor:Bool = false;
 			var staticTokens:Int = 0;
 			var constructorPos = null;
 			for (token in acceptableTokens) {
-				if (token.filter([Kwd(KwdNew)], FIRST).length > 0) {
+				if (token.filter([Kwd(KwdNew)], FIRST, 2).length > 0) {
 					haveConstructor = true;
 					constructorPos = token.pos;
 					continue;
 				}
 
-				if (token.filter([Kwd(KwdStatic)], FIRST).length > 0) {
+				if (token.filter([Kwd(KwdStatic)], FIRST, 2).length > 0) {
 					staticTokens++;
 					continue;
 				}

--- a/test/TestMain.hx
+++ b/test/TestMain.hx
@@ -30,7 +30,7 @@ class TestMain {
 		Sys.exit(success ? 0 : 1);
 	}
 
-	static function setupCoverageReport() {
+	function setupCoverageReport() {
 		var client:PrintClient = new PrintClient();
 		var logger = MCoverage.getLogger();
 		logger.addClient(client);

--- a/test/checks/design/UnnecessaryConstructorCheckTest.hx
+++ b/test/checks/design/UnnecessaryConstructorCheckTest.hx
@@ -27,6 +27,10 @@ class UnnecessaryConstructorCheckTest extends CheckTestCase<UnnecessaryConstruct
 	public function testJustWithConstructor() {
 		assertNoMsg(new UnnecessaryConstructorCheck(), TEST6);
 	}
+
+	public function testStaticOnlyWithNew() {
+		assertNoMsg(new UnnecessaryConstructorCheck(), TEST_STATIC_ONLY_WITH_NEW);
+	}
 }
 
 @:enum
@@ -88,5 +92,16 @@ abstract UnnecessaryConstructorCheckTests(String) to String {
 	var TEST6 = "
 	class Test {
 		public function new() {}
+	}";
+
+	var TEST_STATIC_ONLY_WITH_NEW = "
+	class Test
+	{
+		public static var VAR1(default, null):String;
+
+		public static function init():Void
+		{
+			VAR1 = new String();
+		}
 	}";
 }


### PR DESCRIPTION
reduced search scope of filters in UnnecessaryConstructorCheck, so using `x = new Type()` doesn't trigger a warning
