### PR TITLE
Replace LineCheckBase line handling logic - Fixes #278

### DIFF
--- a/src/checkstyle/Main.hx
+++ b/src/checkstyle/Main.hx
@@ -286,8 +286,9 @@ class Main {
 		addAllChecks();
 		var propsNotAllowed:Array<String> = [
 			"moduleName", "severity", "type", "categories",
-			"points", "desc", "quotesRE", "multilineStartRE",
-			"escapeRE", "multilineStringStart"
+			"points", "desc", "currentState", "skipOverStringStart",
+			"commentStartRE", "commentBlockEndRE", "stringStartRE",
+			"stringInterpolatedEndRE", "stringLiteralEndRE"
 		];
 		var config = getEmptyConfig();
 		for (check in checker.checks) {

--- a/src/checkstyle/checks/whitespace/EmptyLinesCheck.hx
+++ b/src/checkstyle/checks/whitespace/EmptyLinesCheck.hx
@@ -37,7 +37,9 @@ class EmptyLinesCheck extends LineCheckBase {
 
 		for (i in 0...checker.lines.length) {
 			var line = checker.lines[i];
-			if (isMultineString(line)) continue;
+			var ranges = getRanges(line);
+			if (ranges.length == 1 && ranges[0].type != TEXT) continue;
+
 			if (~/^\s*$/.match(line)) {
 				if (!inGroup) {
 					inGroup = true;

--- a/src/checkstyle/checks/whitespace/IndentationCharacterCheck.hx
+++ b/src/checkstyle/checks/whitespace/IndentationCharacterCheck.hx
@@ -21,9 +21,13 @@ class IndentationCharacterCheck extends LineCheckBase {
 		var re = (character == TAB) ? ~/^\t*(\S.*| \*.*)?$/ : ~/^ *(\S.*)?$/;
 		for (i in 0...checker.lines.length) {
 			var line = checker.lines[i];
+			var ranges = getRanges(line);
+			var startTextRange = ranges.filter(function(r):Bool return r.type == TEXT && r.start == 0)[0];
+			if (startTextRange == null) continue;
+			var startText = line.substring(startTextRange.start, startTextRange.end);
+
 			if (ignoreRE.match(line) || isLineSuppressed(i)) continue;
-			if (isMultineString(line)) continue;
-			if (line.length > 0 && !re.match(line)) log('Wrong indentation character (should be ${character})', i + 1, 0);
+			if (!re.match(startText)) log('Wrong indentation character (should be ${character})', i + 1, 0);
 		}
 	}
 }

--- a/src/checkstyle/checks/whitespace/LineCheckBase.hx
+++ b/src/checkstyle/checks/whitespace/LineCheckBase.hx
@@ -3,37 +3,124 @@ package checkstyle.checks.whitespace;
 @ignore("base class line based whitespace checks")
 class LineCheckBase extends Check {
 
-	var quotesRE:EReg;
-	var multilineStartRE:EReg;
-	var escapeRE:EReg;
-	var multilineStringStart:Bool;
+	var currentState:RangeType;
+	var skipOverInitialQuote:Bool;
+
+	var commentStartRE:EReg;
+	var commentBlockEndRE:EReg;
+	var stringStartRE:EReg;
+	var stringInterpolatedEndRE:EReg;
+	var stringLiteralEndRE:EReg;
 
 	public function new() {
 		super(LINE);
-		quotesRE = ~/('|")/;
-		multilineStartRE = null;
-		escapeRE = null;
-		multilineStringStart = false;
+
+		commentStartRE = ~/\/([\/*])/;
+		commentBlockEndRE = ~/\*\//;
+		stringStartRE = ~/['"]/;
+		stringInterpolatedEndRE = ~/(?<!\\)'/;
+		stringLiteralEndRE = ~/(?<!\\)"/;
 	}
 
 	override public function run(checker:Checker):Array<CheckMessage> {
-		multilineStringStart = false;
+		currentState = TEXT;
+		skipOverInitialQuote = false;
 		return super.run(checker);
 	}
 
-	function isMultineString(line:String):Bool {
-		if (!multilineStringStart && quotesRE.match(line)) {
-			var matched = quotesRE.matched(0);
-			var matchedRight = quotesRE.matchedRight();
-			multilineStartRE = new EReg(matched, "");
-			escapeRE = new EReg("\\" + matched, "");
-			multilineStringStart = !multilineStartRE.match(matchedRight) && !escapeRE.match(matchedRight);
+	function getRanges(line:String):Array<Range> {
+		var ranges = [];
+		var currentStart = 0;
+		while (currentStart < line.length) {
+			currentStart = switch (currentState) {
+				case TEXT: handleTextState(line, ranges, currentStart);
+				case COMMENT(isBlock): handleCommentState(line, ranges, currentStart, isBlock);
+				case STRING(isInterpolated): handleStringState(line, ranges, currentStart, isInterpolated);
+			};
 		}
-		else if (multilineStringStart && multilineStartRE != null && multilineStartRE.match(line) && !escapeRE.match(line)) {
-			multilineStringStart = false;
-			multilineStartRE = null;
-			escapeRE = null;
-		}
-		return multilineStringStart;
+		if (line.length == 0) ranges.push({ type: currentState, start: 0, end: 0 });
+		return ranges;
 	}
+
+	function handleTextState(line:String, ranges:Array<Range>, currentStart:Int):Int {
+		var foundCommentStart = commentStartRE.matchSub(line, currentStart);
+		var commentStart = foundCommentStart ? commentStartRE.matchedPos().pos : line.length;
+		var foundStringStart = stringStartRE.matchSub(line, currentStart);
+		var stringStart = foundStringStart ? stringStartRE.matchedPos().pos : line.length;
+
+		if (foundCommentStart && commentStart < stringStart) {
+			if (commentStart > currentStart) {
+				ranges.push({ type: currentState, start: currentStart, end: commentStart });
+			}
+
+			currentState = COMMENT(commentStartRE.matched(1) == "*");
+			return commentStart;
+		}
+		else if (foundStringStart && stringStart < commentStart) {
+			if (stringStart > currentStart) {
+				ranges.push({ type: currentState, start: currentStart, end: stringStart });
+			}
+
+			skipOverInitialQuote = true;
+			currentState = STRING(stringStartRE.matched(0) == "'");
+			return stringStart;
+		}
+		else {
+			ranges.push({ type: currentState, start: currentStart, end: line.length });
+			
+			return line.length;
+		}
+	}
+
+	function handleCommentState(line:String, ranges:Array<Range>, currentStart:Int, isBlock:Bool):Int {
+		if (isBlock && commentBlockEndRE.matchSub(line, currentStart)) {
+			var commentEnd = commentBlockEndRE.matchedPos().pos + 2;
+			ranges.push({ type: currentState, start: currentStart, end: commentEnd });
+			
+			currentState = TEXT;
+			return commentEnd;
+		}
+		else {
+			ranges.push({ type: currentState, start: currentStart, end: line.length });
+			
+			if (!isBlock) currentState = TEXT;
+			return line.length;
+		}
+	}
+
+	function handleStringState(line:String, ranges:Array<Range>, currentStart:Int, isInterpolated:Bool):Int {
+		var adjustedStart = currentStart + (skipOverInitialQuote ? 1 : 0);
+		skipOverInitialQuote = false; 
+		if (isInterpolated && stringInterpolatedEndRE.matchSub(line, adjustedStart)) {
+			var stringEnd = stringInterpolatedEndRE.matchedPos().pos + 1;
+			ranges.push({ type: currentState, start: currentStart, end: stringEnd });
+			
+			currentState = TEXT;
+			return stringEnd;
+		}
+		else if (!isInterpolated && stringLiteralEndRE.matchSub(line, adjustedStart)) {
+			var stringEnd = stringLiteralEndRE.matchedPos().pos + 1;
+			ranges.push({ type: currentState, start: currentStart, end: stringEnd });
+			
+			currentState = TEXT;
+			return stringEnd;
+		}
+		else {
+			ranges.push({ type: currentState, start: currentStart, end: line.length });
+			
+			return line.length;
+		}
+	}
+}
+
+enum RangeType {
+	TEXT;
+	COMMENT(isBlock:Bool);
+	STRING(isInterpolated:Bool);
+}
+
+typedef Range = {
+	var type:RangeType;
+	var start:Int;
+	var end:Int;
 }

--- a/src/checkstyle/checks/whitespace/TabForAligningCheck.hx
+++ b/src/checkstyle/checks/whitespace/TabForAligningCheck.hx
@@ -17,12 +17,17 @@ class TabForAligningCheck extends LineCheckBase {
 
 	override function actualRun() {
 		var ignoreRE = new EReg(ignorePattern, "");
-		var re = ~/^\s*\S[^\t]*\t/;
 		for (i in 0...checker.lines.length) {
 			var line = checker.lines[i];
+			var ranges = getRanges(line);
+
 			if (ignoreRE.match(line)) continue;
-			if (isMultineString(line)) continue;
-			if (re.match(line)) log("Tab after non-space character, use space for aligning", i + 1, line.length);
+
+			for (range in ranges.filter(function(r):Bool return r.type == TEXT)) {
+				var re = range.start == 0 ? ~/\S[ ]*\t/ : ~/\t/;
+				var rangeText = line.substring(range.start, range.end);
+				if (re.match(rangeText)) log("Tab after non-space character, use space for aligning", i + 1, line.length);
+			}
 		}
 	}
 }

--- a/src/checkstyle/checks/whitespace/TrailingWhitespaceCheck.hx
+++ b/src/checkstyle/checks/whitespace/TrailingWhitespaceCheck.hx
@@ -15,8 +15,12 @@ class TrailingWhitespaceCheck extends LineCheckBase {
 		var re = ~/\s+$/;
 		for (i in 0...checker.lines.length) {
 			var line = checker.lines[i];
-			if (isMultineString(line)) continue;
-			if (re.match(line)) log("Trailing whitespace", i + 1, line.length);
+			var ranges = getRanges(line);
+			var endTextRange = ranges.filter(function(r):Bool return r.type == TEXT && r.end == line.length)[0];
+			if (endTextRange == null) continue;
+			var endText = line.substring(endTextRange.start, endTextRange.end);
+
+			if (re.match(endText)) log("Trailing whitespace", i + 1, line.length);
 		}
 	}
 }

--- a/test/checks/whitespace/SpacingCheckTest.hx
+++ b/test/checks/whitespace/SpacingCheckTest.hx
@@ -103,7 +103,6 @@ abstract SpacingCheckTests(String) to String {
 		}
 	}";
 
-
 	var TEST2 =
 	"class Test {
 		public function test() {


### PR DESCRIPTION
Here's hoping this fixes #278 and other related issues.

As the token tree system was not immediately straightforward to me how to adapt for use in this case, I instead opted to build a really simple state machine to track whether the content in the file is within the scope of a comment or string.

The main function used by derived classes, now called `getRanges`, returns an `Array<Range>` detailing the breakdown of the line passed into it.  `Range` is a structure type that stores the type of content within the range, along with the starting and ending character indices within the line.  This makes it easy for individual checks to focus on just the relevant parts of the source file.  For example, `IndentationCharacterCheck` only needs to care about text that starts a line, and `TrailingWhitespaceCheck` likewise only needs to look at the end of each line.

Currently, none of the existing derived checks do anything in particular with comments or strings.  However, I could feasibly see the addition of style checks that affect other contexts.  For instance, `TrailingWhitespaceCheck` could have configurable options to apply it to comment blocks and multi-line strings.  I tried to keep the existing behavior, in as much as ensuring all of the current test cases pass.

An interesting outcome of this work was discovering that a file in the project already had a style issue (specifically, too many blank lines in a row) that was not being detected before.  Now I wonder, with this improved logic, how many style issues have been hiding in other projects, such as HaxeFlixel.  `(:`