### PR TITLE
Fix false positive with EmptyLinesCheck.

### DIFF
--- a/src/checkstyle/checks/whitespace/EmptyLinesCheck.hx
+++ b/src/checkstyle/checks/whitespace/EmptyLinesCheck.hx
@@ -38,7 +38,14 @@ class EmptyLinesCheck extends LineCheckBase {
 		for (i in 0...checker.lines.length) {
 			var line = checker.lines[i];
 			var ranges = getRanges(line);
-			if (ranges.length == 1 && ranges[0].type != TEXT) continue;
+			//if (ranges.length == 1 && ranges[0].type != TEXT) continue;
+			if (ranges.length == 1) {
+				switch (ranges[0].type) {
+					case TEXT:
+					case COMMENT(isBlock): if (isBlock) continue;
+					case STRING(isInterpolated): continue;
+				}
+			}
 
 			if (~/^\s*$/.match(line)) {
 				if (!inGroup) {

--- a/src/checkstyle/checks/whitespace/EmptyLinesCheck.hx
+++ b/src/checkstyle/checks/whitespace/EmptyLinesCheck.hx
@@ -38,7 +38,6 @@ class EmptyLinesCheck extends LineCheckBase {
 		for (i in 0...checker.lines.length) {
 			var line = checker.lines[i];
 			var ranges = getRanges(line);
-			//if (ranges.length == 1 && ranges[0].type != TEXT) continue;
 			if (ranges.length == 1) {
 				switch (ranges[0].type) {
 					case TEXT:

--- a/test/checks/whitespace/EmptyLinesCheckTest.hx
+++ b/test/checks/whitespace/EmptyLinesCheckTest.hx
@@ -126,7 +126,7 @@ abstract EmptyLinesCheckTests(String) to String {
 	var TEST4 =
 	"class Test {
 
-		// comments
+		// comments (with text before)
 
 		public function new() {
 			var b:Int;
@@ -136,7 +136,7 @@ abstract EmptyLinesCheckTests(String) to String {
 	var TEST5 =
 	"class Test {
 
-		// comments
+// comments (with no text before)
 
 		var a:Int;
 	}";


### PR DESCRIPTION
The logic incorrectly skipped over lines that had single-line comments filling the entire line.  Fixed issue and updated unit tests to prevent regression.