### PR TITLE
LineCheckBase: Fix end-of-string detection.

### DIFF
--- a/test/checks/whitespace/EmptyLinesCheckTest.hx
+++ b/test/checks/whitespace/EmptyLinesCheckTest.hx
@@ -75,6 +75,8 @@ abstract EmptyLinesCheckTests(String) to String {
 
 		var a:Int;
 
+		var b:String = '\\\\';
+
 
 	}";
 

--- a/test/checks/whitespace/EmptyLinesCheckTest.hx
+++ b/test/checks/whitespace/EmptyLinesCheckTest.hx
@@ -75,7 +75,7 @@ abstract EmptyLinesCheckTests(String) to String {
 
 		var a:Int;
 
-		var b:String = '\\\\';
+		var b:String = '\\\\' + \"\\\\\";
 
 
 	}";


### PR DESCRIPTION
I found an edge case that was not being tested and, as a result, was not being handled properly.  The logic for detecting an escaped quote did not consider the backslash itself being escaped, as in this string: `"\\"`.

One of the test cases was updated to include an example of this, and the logic within `LineCheckBase` was updated to properly handle it.  I also reduced some code duplication with the handling of interpolated and literal strings.