### PR TITLE
exclude function body from ModifierOrderCheck, fixes #332

### DIFF
--- a/src/checkstyle/checks/modifier/ModifierOrderCheck.hx
+++ b/src/checkstyle/checks/modifier/ModifierOrderCheck.hx
@@ -1,5 +1,7 @@
 package checkstyle.checks.modifier;
 
+import haxe.macro.PositionTools;
+
 @name("ModifierOrder", "AccessOrder")
 @desc("Checks that the order of modifiers conforms to the standards.")
 class ModifierOrderCheck extends Check {
@@ -31,10 +33,23 @@ class ModifierOrderCheck extends Check {
 			var modifier:ModifierOrderCheckModifier = access;
 			index = modifiers.indexOf(modifier);
 			if (index < lastIndex) {
-				warnOrder(f.name, modifier, f.pos);
+				var pos = calcPos(f);
+				warnOrder(f.name, modifier, pos);
 				return;
 			}
 			lastIndex = index;
+		}
+	}
+
+	function calcPos(f:Field):Position {
+		switch (f.kind) {
+			case FVar(_, _), FProp(_, _, _, _):
+				return f.pos;
+			case FFun(fun):
+				if (fun.expr == null) {
+					return f.pos;
+				}
+				return PositionTools.make({min: f.pos.min, max: fun.expr.pos.min, file: f.pos.file});
 		}
 	}
 

--- a/test/checks/modifier/ModifierOrderCheckTest.hx
+++ b/test/checks/modifier/ModifierOrderCheckTest.hx
@@ -4,6 +4,8 @@ import checkstyle.checks.modifier.ModifierOrderCheck;
 
 class ModifierOrderCheckTest extends CheckTestCase<ModifierOrderCheckTests> {
 
+	static inline var ERROR:String = '"test" modifier order is invalid (modifier: "PUBLIC_PRIVATE")';
+
 	public function testCorrectOrder() {
 		var check = new ModifierOrderCheck();
 		assertNoMsg(check, TEST1);
@@ -14,7 +16,9 @@ class ModifierOrderCheckTest extends CheckTestCase<ModifierOrderCheckTests> {
 		assertMsg(check, TEST2, '"test" modifier order is invalid (modifier: "OVERRIDE")');
 		assertMsg(check, TEST3, '"test" modifier order is invalid (modifier: "STATIC")');
 		assertMsg(check, TEST4, '"test" modifier order is invalid (modifier: "MACRO")');
-		assertMsg(check, TEST5, '"test" modifier order is invalid (modifier: "PUBLIC_PRIVATE")');
+		assertMsg(check, TEST5, ERROR);
+		assertMsg(check, TEST7, ERROR);
+		assertMsg(check, TEST8, ERROR);
 	}
 
 	public function testModifiers() {
@@ -25,6 +29,7 @@ class ModifierOrderCheckTest extends CheckTestCase<ModifierOrderCheckTests> {
 		assertNoMsg(check, TEST3);
 		assertNoMsg(check, TEST4);
 		assertNoMsg(check, TEST5);
+		assertNoMsg(check, TEST6);
 	}
 
 	public function testIgnore() {
@@ -64,5 +69,20 @@ abstract ModifierOrderCheckTests(String) to String {
 	var TEST5 =
 	"abstractAndClass Test {
 		dynamic public function test() {}
+	}";
+
+	var TEST6 =
+	"interface Test {
+		dynamic public function test();
+	}";
+
+	var TEST7 =
+	"abstractAndClass Test {
+		inline public var test:String=0;
+	}";
+
+	var TEST8 =
+	"abstractAndClass Test {
+		inline public var test(default,null):String=0;
 	}";
 }


### PR DESCRIPTION
uses function body expression to reduce Position info