### PR TITLE
Fixes for #349

### DIFF
--- a/checkstyle.json
+++ b/checkstyle.json
@@ -518,6 +518,7 @@
 		}
 	],
 	"exclude": {
+		"path": "RELATIVE_TO_SOURCE",
 		"all": [],
 		"Dynamic": [
 			"checkstyle/Main",

--- a/src/checkstyle/Checker.hx
+++ b/src/checkstyle/Checker.hx
@@ -279,8 +279,7 @@ class Checker {
 		var slashes:EReg = ~/[\/\\]/g;
 		cls = slashes.replace(cls, ":");
 		for (exclude in excludesForCheck) {
-			var regStr:String = slashes.replace(exclude, ":") + ":.*?" + cls.substring(cls.lastIndexOf(":") + 1, cls.length) + "$";
-			var r = new EReg(regStr, "i");
+			var r = new EReg(exclude, "i");
 			if (r.match(cls)) return true;
 		}
 		return false;

--- a/src/checkstyle/Main.hx
+++ b/src/checkstyle/Main.hx
@@ -160,12 +160,14 @@ class Main {
 	function updateExcludes(exclude:String, val:String, pathType:ExcludePath) {
 		if (pathType == null) {
 			addToExclude(exclude, val);
-		} else {
+		}
+		else {
 			if (pathType == RELATIVE_TO_SOURCE) {
 				for (path in paths) {
 					addNormalisedPathToExclude(exclude, path + ":" + val);
 				}
-			} else {
+			}
+			else {
 				addNormalisedPathToExclude(exclude, val);
 			}
 		}

--- a/src/checkstyle/Main.hx
+++ b/src/checkstyle/Main.hx
@@ -164,16 +164,16 @@ class Main {
 		} else {
 			if (pathType == RELATIVE_TO_SOURCE) {
 				for (path in paths) {
-					addNormalisedPathToExclude(exclude, path);
+					addNormalisedPathToExclude(exclude, path + ":" + val);
 				} 
 			} else {
-				addNormalisedPathToExclude(exclude, path);
+				addNormalisedPathToExclude(exclude, val);
 			}
 		}		
 	}
 
 	function addNormalisedPathToExclude(exclude:String, path:String) {
-		var path = normalisePath(val);
+		var path = normalisePath(path);
 		addToExclude(exclude, path);
 	}
 

--- a/src/checkstyle/Main.hx
+++ b/src/checkstyle/Main.hx
@@ -144,7 +144,6 @@ class Main {
 	function parseExcludes(config:ExcludeConfig) {
 		var excludes = Reflect.fields(config);
 		var pathType = Reflect.field(config, "path");
-		if (pathType == null) pathType = RELATIVE_TO_SOURCE;
 		for (exclude in excludes) {
 			if (exclude == "path") continue;
 			createExcludeMapElement(exclude);
@@ -159,19 +158,35 @@ class Main {
 	}
 
 	function updateExcludes(exclude:String, val:String, pathType:ExcludePath) {
-		if (pathType == RELATIVE_TO_SOURCE) {
-			for (p in paths) {
-				//var basePath = ~/[\/\\]/.split(p)[0];
-				var path = p + "/" + val.split(".").join("/");
-				if (exclude == "all") allExcludes.push(path);
-				else excludesMap.get(exclude).push(path);
+		Sys.println(pathType);
+		if (pathType == null) {
+			addToExclude(exclude, val);
+		} else {
+			if (pathType == RELATIVE_TO_SOURCE) {
+				for (path in paths) {
+					addNormalisedPathToExclude(exclude, path);
+				} 
+			} else {
+				addNormalisedPathToExclude(exclude, path);
 			}
-		}
-		else {
-			var path = val.split(".").join("/");
-			if (exclude == "all") allExcludes.push(path);
-			else excludesMap.get(exclude).push(path);
-		}
+		}		
+	}
+
+	function addNormalisedPathToExclude(exclude:String, path:String) {
+		var path = normalisePath(val);
+		addToExclude(exclude, path);
+	}
+
+	function normalisePath(path:String) {
+		var slashes:EReg = ~/[\/\\]/g;
+		path = path.split(".").join(":");
+		path = slashes.replace(path, ":");
+		return path;
+	}
+
+	function addToExclude(exclude:String, value:String) {
+		if (exclude == "all") allExcludes.push(value);
+		else excludesMap.get(exclude).push(value);
 	}
 
 	function createCheck(checkConf:CheckConfig):Check {

--- a/src/checkstyle/Main.hx
+++ b/src/checkstyle/Main.hx
@@ -158,18 +158,17 @@ class Main {
 	}
 
 	function updateExcludes(exclude:String, val:String, pathType:ExcludePath) {
-		Sys.println(pathType);
 		if (pathType == null) {
 			addToExclude(exclude, val);
 		} else {
 			if (pathType == RELATIVE_TO_SOURCE) {
 				for (path in paths) {
 					addNormalisedPathToExclude(exclude, path + ":" + val);
-				} 
+				}
 			} else {
 				addNormalisedPathToExclude(exclude, val);
 			}
-		}		
+		}
 	}
 
 	function addNormalisedPathToExclude(exclude:String, path:String) {
@@ -177,7 +176,7 @@ class Main {
 		addToExclude(exclude, path);
 	}
 
-	function normalisePath(path:String) {
+	function normalisePath(path:String):String {
 		var slashes:EReg = ~/[\/\\]/g;
 		path = path.split(".").join(":");
 		path = slashes.replace(path, ":");


### PR DESCRIPTION
Changed the excludes to use the string as a regular expression except in
the case where a "path" option is provided. Where a path is provided, it
should work as before. Removed the appended class name because the
simpler provided path will still match paths checked against it.