### PR TITLE
introduced threads for parsing and checking

### DIFF
--- a/resources/default-config.json
+++ b/resources/default-config.json
@@ -574,5 +574,6 @@
 			},
 			"type": "WhitespaceAround"
 		}
-	]
+	],
+	"numberOfCheckerThreads": 5
 }

--- a/src/checkstyle/CheckerPool.hx
+++ b/src/checkstyle/CheckerPool.hx
@@ -1,0 +1,32 @@
+package checkstyle;
+
+class CheckerPool {
+
+	var parserQueue:ParserQueue;
+	var templateChecker:Checker;
+	var threads:Array<CheckerThread>;
+	var excludesMap:Map<String, Array<String>>;
+
+	public function new(parserQueue:ParserQueue, templateChecker:Checker, excludesMap:Map<String, Array<String>>) {
+		this.parserQueue = parserQueue;
+		this.excludesMap = excludesMap;
+		this.templateChecker = templateChecker;
+		threads = [];
+	}
+
+	public function start(count:Int) {
+		for (i in 0...count) {
+			var thread = new CheckerThread(parserQueue);
+			threads.push(thread);
+			thread.start(templateChecker, excludesMap);
+		}
+	}
+
+	public function isFinished():Bool {
+		if (!parserQueue.isFinished()) return false;
+		for (thread in threads) {
+			if (!thread.isFinished()) return false;
+		}
+		return true;
+	}
+}

--- a/src/checkstyle/CheckerThread.hx
+++ b/src/checkstyle/CheckerThread.hx
@@ -1,0 +1,115 @@
+package checkstyle;
+
+import neko.vm.Thread;
+
+import checkstyle.checks.Check;
+
+import checkstyle.reporter.ReporterManager;
+
+class CheckerThread {
+	static inline var SLEEP_TIME:Float = 0.1;
+
+	var parserQueue:ParserQueue;
+	var checks:Array<Check>;
+	var finished:Bool;
+	var excludes:Map<String, Array<String>>;
+
+	public function new(parserQueue:ParserQueue) {
+		this.parserQueue = parserQueue;
+		finished = false;
+		checks = [];
+	}
+
+	public function start(templateChecker:Checker, excludesMap:Map<String, Array<String>>) {
+		excludes = excludesMap;
+		cloneChecks(templateChecker.checks);
+		Thread.create(runChecker);
+	}
+
+	function cloneChecks(templateChecks:Array<Check>) {
+		checks = [];
+
+		var propsNotAllowed:Array<String> = [
+			"moduleName",  "type", "categories",
+			"points", "desc", "currentState", "skipOverStringStart",
+			"commentStartRE", "commentBlockEndRE", "stringStartRE",
+			"stringInterpolatedEndRE", "stringLiteralEndRE"
+		];
+
+		for (check in templateChecks) {
+			var newCheck = Type.createInstance (Type.getClass(check), []);
+
+			for (prop in Reflect.fields(check)) {
+				if (propsNotAllowed.contains(prop)) continue;
+				Reflect.setField(newCheck, prop, Reflect.field(check, prop));
+			}
+			checks.push(newCheck);
+		}
+	}
+
+	function runChecker() {
+		finished = false;
+		while (true) {
+			if (parserQueue.isFinished()) break;
+			var checker:Checker = parserQueue.nextFile();
+			if (checker == null) {
+				Sys.sleep(SLEEP_TIME);
+				continue;
+			}
+			runAllChecks(checker);
+		}
+		finished = true;
+	}
+
+	function runAllChecks(checker:Checker) {
+		for (check in checks) {
+			var messages = [];
+			if (check.type == AST) {
+				for (ast in checker.asts) {
+					checker.ast = ast;
+					messages = messages.concat(runCheck(check, checker));
+				}
+			}
+			else {
+				// non AST-based checks still need the AST for suppression checking
+				checker.ast = checker.asts[0];
+				var newMess = runCheck(check, checker);
+				messages = messages.concat(newMess);
+			}
+			ReporterManager.INSTANCE.addMessages(messages);
+		}
+		ReporterManager.INSTANCE.fileFinish(checker.file);
+	}
+
+	function runCheck(check:Check, checker:Checker):Array<CheckMessage> {
+		try {
+			if (checkForExclude(check.getModuleName(), checker)) return [];
+			return check.run(checker);
+		}
+		catch (e:Any) {
+			ReporterManager.INSTANCE.addCheckError(checker.file, e, check.getModuleName());
+			return [];
+		}
+	}
+
+	function checkForExclude(moduleName:String, checker:Checker):Bool {
+		if (excludes == null) return false;
+		var excludesForCheck:Array<String> = excludes.get(moduleName);
+		if (excludesForCheck == null || excludesForCheck.length == 0) return false;
+
+		var cls = checker.file.name.substring(0, checker.file.name.indexOf(".hx"));
+		if (excludesForCheck.contains(cls)) return true;
+
+		var slashes:EReg = ~/[\/\\]/g;
+		cls = slashes.replace(cls, ":");
+		for (exclude in excludesForCheck) {
+			var r = new EReg(exclude, "i");
+			if (r.match(cls)) return true;
+		}
+		return false;
+	}
+
+	public function isFinished():Bool {
+		return finished;
+	}
+}

--- a/src/checkstyle/Config.hx
+++ b/src/checkstyle/Config.hx
@@ -8,6 +8,7 @@ typedef Config = {
 	@:optional var baseDefines:Array<String>;
 	// different define combinations to use (on top of `defines`)
 	@:optional var defineCombinations:Array<Array<String>>;
+	@:optional var numberOfCheckerThreads:Int;
 	@:optional var checks:Array<CheckConfig>;
 	@:optional var exclude:ExcludeConfig;
 }

--- a/src/checkstyle/ParserQueue.hx
+++ b/src/checkstyle/ParserQueue.hx
@@ -1,0 +1,66 @@
+package checkstyle;
+
+import neko.vm.Mutex;
+import neko.vm.Thread;
+
+class ParserQueue {
+	static inline var SLEEP_TIME:Float = 0.1;
+
+	var files:Array<CheckFile>;
+	var checkers:Array<Checker>;
+	var finished:Bool;
+	var lock:Mutex;
+	var templateChecker:Checker;
+	var maxPreparse:Int;
+
+	public function new(files:Array<CheckFile>, templateChecker:Checker) {
+		this.files = files;
+		this.templateChecker = templateChecker;
+		lock = new Mutex();
+	}
+
+	public function start(max:Int) {
+		maxPreparse = max;
+		checkers = [];
+		Thread.create(runParser);
+	}
+
+	function runParser() {
+		finished = false;
+		while (files.length > 0) {
+			if (checkers.length > maxPreparse) {
+				Sys.sleep(SLEEP_TIME);
+				continue;
+			}
+			var file = files.shift ();
+			var checker:Checker = new Checker();
+			checker.baseDefines = templateChecker.baseDefines;
+			checker.defineCombinations = templateChecker.defineCombinations;
+			checker.loadFileContent(file);
+			if (!checker.createContext(file)) {
+				checker.unloadFileContent(file);
+				continue;
+			}
+
+			lock.acquire();
+			checkers.push(checker);
+			lock.release();
+		}
+		finished = true;
+	}
+
+	public function isFinished():Bool {
+		if (checkers.length > 0) return false;
+		return finished;
+	}
+
+	public function nextFile():Checker {
+		var checkFile:Checker = null;
+		lock.acquire();
+		if (checkers.length > 0) {
+			checkFile = checkers.shift();
+		}
+		lock.release();
+		return checkFile;
+	}
+}

--- a/src/checkstyle/checks/literal/MultipleStringLiteralsCheck.hx
+++ b/src/checkstyle/checks/literal/MultipleStringLiteralsCheck.hx
@@ -1,6 +1,5 @@
 package checkstyle.checks.literal;
 
-import checkstyle.token.TokenTreeBuilder;
 import checkstyle.utils.StringUtils;
 
 @name("MultipleStringLiterals")
@@ -24,7 +23,7 @@ class MultipleStringLiteralsCheck extends Check {
 
 	override function actualRun() {
 		ignoreRE = new EReg (ignore, "");
-		var root:TokenTree = TokenTreeBuilder.buildTokenTree(checker.tokens, checker.bytes);
+		var root:TokenTree = checker.getTokenTree();
 
 		var allLiterals:Map<String, Int> = new Map<String, Int>();
 		var allStringLiterals:Array<TokenTree> = root.filterCallback(function(token:TokenTree, depth:Int):FilterResult {

--- a/src/checkstyle/checks/literal/StringLiteralCheck.hx
+++ b/src/checkstyle/checks/literal/StringLiteralCheck.hx
@@ -1,6 +1,5 @@
 package checkstyle.checks.literal;
 
-import checkstyle.token.TokenTreeBuilder;
 import checkstyle.utils.StringUtils;
 
 @name("StringLiteral")
@@ -18,7 +17,7 @@ class StringLiteralCheck extends Check {
 	}
 
 	override function actualRun() {
-		var root:TokenTree = TokenTreeBuilder.buildTokenTree(checker.tokens, checker.bytes);
+		var root:TokenTree = checker.getTokenTree();
 
 		var allStringLiterals:Array<TokenTree> = root.filterCallback(function(token:TokenTree, depth:Int):FilterResult {
 			if (token.tok == null) return GO_DEEPER;

--- a/src/checkstyle/reporter/ReporterManager.hx
+++ b/src/checkstyle/reporter/ReporterManager.hx
@@ -1,0 +1,113 @@
+package checkstyle.reporter;
+
+import neko.vm.Mutex;
+
+import haxe.CallStack;
+
+import checkstyle.CheckMessage;
+
+import checkstyle.checks.Category;
+
+class ReporterManager {
+	public static var INSTANCE:ReporterManager = new ReporterManager();
+
+	var reporters:Array<IReporter>;
+	var lock:Mutex;
+
+	function new () {
+		clear();
+		lock = new Mutex();
+	}
+
+	public function clear() {
+		reporters = [];
+	}
+
+	public function addReporter(r:IReporter) {
+		reporters.push(r);
+	}
+
+	public function start() {
+		for (reporter in reporters) reporter.start();
+	}
+
+	public function finish() {
+		for (reporter in reporters) reporter.finish();
+	}
+
+	public function fileStart(f:CheckFile) {
+		lock.acquire();
+		for (reporter in reporters) reporter.fileStart(f);
+		lock.release();
+	}
+
+	public function fileFinish(f:CheckFile) {
+		lock.acquire();
+		for (reporter in reporters) reporter.fileFinish(f);
+		lock.release();
+	}
+
+	public function addParseError(f:CheckFile, e:Any) {
+		lock.acquire();
+		for (reporter in reporters) {
+			reporter.addMessage(getErrorMessage(e, f.name, "Parsing"));
+			reporter.fileFinish(f);
+		}
+		lock.release();
+	}
+
+	public function addCheckError(f:CheckFile, e:Any, name:String) {
+		lock.acquire();
+		for (reporter in reporters) reporter.addMessage(getErrorMessage(e, f.name, "Check " + name));
+		lock.release();
+	}
+
+	public function addMessages(messages:Array<CheckMessage>) {
+		if ((messages == null) || (messages.length <= 0)) return;
+		lock.acquire();
+		messages = filterDuplicateMessages(messages);
+		for (reporter in reporters) for (m in messages) reporter.addMessage(m);
+		lock.release();
+	}
+
+	function filterDuplicateMessages(messages:Array<CheckMessage>):Array<CheckMessage> {
+		var filteredMessages = [];
+		for (message in messages) {
+			var anyDuplicates = false;
+			for (filteredMessage in filteredMessages) {
+				if (areMessagesSame(message, filteredMessage)) {
+					anyDuplicates = true;
+					break;
+				}
+			}
+			if (!anyDuplicates) filteredMessages.push(message);
+		}
+		return filteredMessages;
+	}
+
+	function areMessagesSame(message1:CheckMessage, message2:CheckMessage):Bool {
+		return
+			message1.fileName == message2.fileName &&
+			message1.message == message2.message &&
+			message1.line == message2.line &&
+			message1.startColumn == message2.startColumn &&
+			message1.endColumn == message2.endColumn &&
+			message1.severity == message2.severity &&
+			message1.moduleName == message2.moduleName;
+	}
+
+	function getErrorMessage(e:Any, fileName:String, step:String):CheckMessage {
+		return {
+			fileName:fileName,
+			line:1,
+			startColumn:0,
+			endColumn:0,
+			severity:ERROR,
+			moduleName:"Checker",
+			categories:[Category.STYLE],
+			points:1,
+			desc: "",
+			message:step + " failed: " + e + "\nStacktrace: " + CallStack.toString(CallStack.exceptionStack())
+		};
+	}
+}

--- a/src/checkstyle/token/TokenTreeBuilder.hx
+++ b/src/checkstyle/token/TokenTreeBuilder.hx
@@ -3,9 +3,13 @@ package checkstyle.token;
 import byte.ByteData;
 
 import checkstyle.token.walk.WalkFile;
+import checkstyle.token.walk.WalkSharp;
 
 class TokenTreeBuilder {
 	public static function buildTokenTree(tokens:Array<Token>, bytes:ByteData):TokenTree {
+		// WalkSharp is not thread safe!!
+		WalkSharp.SHARP_IFS = [];
+
 		var stream:TokenStream = new TokenStream(tokens, bytes);
 		var root:TokenTree = new TokenTree(null, null, -1);
 		WalkFile.walkFile(stream, root);

--- a/src/checkstyle/token/TokenTreeBuilder.hx
+++ b/src/checkstyle/token/TokenTreeBuilder.hx
@@ -8,7 +8,7 @@ import checkstyle.token.walk.WalkSharp;
 class TokenTreeBuilder {
 	public static function buildTokenTree(tokens:Array<Token>, bytes:ByteData):TokenTree {
 		// WalkSharp is not thread safe!!
-		WalkSharp.SHARP_IFS = [];
+		WalkSharp.clear();
 
 		var stream:TokenStream = new TokenStream(tokens, bytes);
 		var root:TokenTree = new TokenTree(null, null, -1);

--- a/src/checkstyle/token/walk/WalkSwitch.hx
+++ b/src/checkstyle/token/walk/WalkSwitch.hx
@@ -45,7 +45,7 @@ class WalkSwitch {
 				case Sharp(_):
 					WalkSharp.walkSharp(stream, parent, WalkSwitch.walkSwitchCases);
 				case Comment(_), CommentLine(_):
-					WalkStatement.walkStatement(stream, parent);
+					WalkComment.walkComment(stream, parent);
 				default:
 					stream.error('bad token ${stream.token()} != case/default');
 			}

--- a/test/checks/CheckTestCase.hx
+++ b/test/checks/CheckTestCase.hx
@@ -5,6 +5,7 @@ import haxe.PosInfos;
 import checkstyle.CheckMessage;
 import checkstyle.CheckFile;
 import checkstyle.reporter.IReporter;
+import checkstyle.reporter.ReporterManager;
 import checkstyle.Checker;
 import checkstyle.checks.Check;
 
@@ -53,7 +54,9 @@ class CheckTestCase<T:String> extends haxe.unit.TestCase {
 
 		if (defines != null) checker.defineCombinations = defines;
 		checker.addCheck(check);
-		checker.addReporter(reporter);
+
+		ReporterManager.INSTANCE.clear();
+		ReporterManager.INSTANCE.addReporter(reporter);
 		checker.process([{name:fileName, content:src, index:0}], null);
 		return reporter.message;
 	}


### PR DESCRIPTION
use -checkerthreads N to set number of threads (1<= N <= 15; default: 5)
use -nothreads to turn off threads

When using threads there is one parser thread and N checker threads since checking usually takes longer than parsing (depends on the number of checks you enable). Any N >= 2 speeds up checkstyle runs, which roughly halfs the time it takes to complete on my test systems.
