### PR TITLE
Fix parentheses with dot

### DIFF
--- a/src/checkstyle/checks/whitespace/IndentationCheck.hx
+++ b/src/checkstyle/checks/whitespace/IndentationCheck.hx
@@ -290,7 +290,14 @@ class IndentationCheck extends Check {
 			var pos = token.getPos();
 			var child:TokenTree = token.getFirstChild();
 			if (child == null) continue;
-			if (token.is(Dot)) pos = token.parent.getPos();
+			if (token.is(Dot)) {
+				var linePos:LinePos = checker.getLinePos(token.pos.min);
+				var line:String = checker.lines[linePos.line];
+				var prefix:String = line.substr(0, linePos.ofs + 1);
+				var isFirst:Bool = ~/^\s*\.$/.match(prefix);
+				if (!isFirst) continue;
+				pos = token.parent.getPos();
+			}
 			if (token.is(POpen)) {
 				var pClose:TokenTree = TokenTreeAccessHelper.access(token).firstOf(PClose).token;
 				if (pClose != null) {

--- a/test/checks/whitespace/IndentationCheckTest.hx
+++ b/test/checks/whitespace/IndentationCheckTest.hx
@@ -186,6 +186,9 @@ long comment
 		builder
 			.create
 			.something();
+		graphics.fillRect(
+			x, y, w, h
+		);
 	}
 }
 /*


### PR DESCRIPTION
Fix for this case
```haxe
graphics.func(
    something
);
```
