### PR TITLE
Enable comments and add schema docs to extendsConfigPath

### DIFF
--- a/checkstyle.json
+++ b/checkstyle.json
@@ -14,6 +14,7 @@
 			"type": "AvoidStarImport"
 		},
 		{
+			"comment": "Testing!",
 			"type": "BlockBreakingConditional"
 		},
 		{

--- a/resources/checkstyle-excludes-schema.json
+++ b/resources/checkstyle-excludes-schema.json
@@ -359,7 +359,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }

--- a/resources/checkstyle-excludes-schema.json
+++ b/resources/checkstyle-excludes-schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "definitions": {
         "ExcludeFilterList": {
             "description": "list of path filters, e.g.\n\t- full type names\n\t- names of individual folder or subfolders\n\t- partial folder or type names\n\n\teach line can have an additional range specification:\n\t- \":<linenumber>\" = only matches a specific line number - valid line number start at 1\n\t- \":<start>-<end>\" = matches line numbers from <start> to <end> (including both)\n\t- \":<identifier>\" = matches any line or block that has <identifier> name (Haxe keywords currently unsupported)",
@@ -357,7 +357,12 @@
                     "propertyOrder": 26
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         }
     },
     "$ref": "#/definitions/ExcludeConfig",

--- a/resources/checkstyle-schema.json
+++ b/resources/checkstyle-schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "definitions": {
         "TrailingWhitespaceCheck": {
             "description": "Checks if there are any trailing white spaces.",
@@ -28,10 +28,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "DynamicCheck": {
             "description": "Checks for use of Dynamic type anywhere in the code.",
@@ -60,10 +70,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "InterfaceCheck": {
             "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
@@ -102,10 +122,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "TabForAligningCheck": {
             "description": "Checks if there are any tabs in the middle of a line.",
@@ -139,10 +169,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "IndentationCheck": {
             "description": "Checks correct indentation",
@@ -218,10 +258,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ArrowFunctionCheck": {
             "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
@@ -270,10 +320,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "UnusedLocalVarCheck": {
             "description": "Checks for unused local variables.",
@@ -302,10 +362,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ModifierOrderCheck": {
             "description": "Checks that the order of modifiers conforms to the standards.",
@@ -355,10 +425,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "StringLiteralCheck": {
             "description": "Checks for single or double quote string literals.",
@@ -402,10 +482,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "DocCommentStyleCheck": {
             "description": "Checks code documentation style (/**...**/ vs /*...*/)",
@@ -456,10 +546,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "DefaultComesLastCheck": {
             "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
@@ -488,10 +588,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "MethodNameCheck": {
             "description": "Checks that method names conform to a format specified by the `format` property.",
@@ -547,10 +657,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "WhitespaceAfterCheck": {
             "description": "Checks for whitespace after a token.",
@@ -592,10 +712,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "InnerAssignmentCheck": {
             "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
@@ -629,10 +759,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "MagicNumberCheck": {
             "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
@@ -669,10 +809,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "FieldDocCommentCheck": {
             "description": "Checks code documentation on fields",
@@ -759,10 +909,20 @@
                             "propertyOrder": 6
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "HexadecimalLiteralCheck": {
             "description": "Checks the letter case of hexadecimal literals.",
@@ -800,10 +960,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "LeftCurlyCheck": {
             "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
@@ -878,10 +1048,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "FileLengthCheck": {
             "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
@@ -920,10 +1100,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ConstantNameCheck": {
             "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
@@ -975,10 +1165,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "LocalVariableNameCheck": {
             "description": "Checks that the local variable names conform to a format specified by the `format` property.",
@@ -1025,10 +1225,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ParameterNumberCheck": {
             "description": "Checks the number of parameters of a method.",
@@ -1067,10 +1277,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ExtendedEmptyLinesCheck": {
             "description": "Checks for consecutive empty lines.",
@@ -1366,10 +1586,20 @@
                             "propertyOrder": 8
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "UnusedImportCheck": {
             "description": "Checks for unused or duplicate imports.",
@@ -1411,10 +1641,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "RedundantAllowMetaCheck": {
             "description": "Checks for redundant @:allow metadata",
@@ -1448,10 +1688,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "IndentationCharacterCheck": {
             "description": "Checks indentation character (tab/space, default is tab).",
@@ -1494,10 +1744,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "TraceCheck": {
             "description": "Checks for trace calls in code.",
@@ -1526,10 +1786,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "OperatorWrapCheck": {
             "description": "Checks line wrapping with operators.",
@@ -1575,10 +1845,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "PublicAccessorCheck": {
             "description": "Checks for public accessors.",
@@ -1607,10 +1887,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "NestedIfDepthCheck": {
             "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
@@ -1644,10 +1934,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "AvoidTernaryOperatorCheck": {
             "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
@@ -1676,10 +1976,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "Threshold": {
             "description": "threshold for code complexity",
@@ -1706,7 +2016,12 @@
                     "propertyOrder": 1
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "CyclomaticComplexityCheck": {
             "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
@@ -1743,10 +2058,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "SimplifyBooleanReturnCheck": {
             "description": "Checks for over-complicated boolean return statements.",
@@ -1775,10 +2100,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "SpacingCheck": {
             "description": "Spacing check on if, for, while, switch, try statements and around operators.",
@@ -1872,10 +2207,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "AvoidStarImportCheck": {
             "description": "Checks for import statements that use the * notation and using directives.",
@@ -1904,10 +2249,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "HiddenFieldCheck": {
             "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
@@ -1951,10 +2306,20 @@
                             "propertyOrder": 3
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "LineLengthCheck": {
             "description": "Checks for long lines. Long lines are hard to read.",
@@ -1993,10 +2358,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "RedundantAccessMetaCheck": {
             "description": "Checks for redundant @:access metadata",
@@ -2030,10 +2405,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ReturnCountCheck": {
             "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
@@ -2072,10 +2457,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "TypeDocCommentCheck": {
             "description": "Checks code documentation on type level",
@@ -2119,10 +2514,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "FileNameCaseCheck": {
             "description": "Checks that file names match the case of their module name.",
@@ -2151,10 +2556,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ListenerNameCheck": {
             "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
@@ -2196,10 +2611,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "NestedTryDepthCheck": {
             "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
@@ -2233,10 +2658,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "CommentedOutCodeCheck": {
             "description": "Checks sections of commented out code",
@@ -2265,10 +2700,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "MultipleVariableDeclarationsCheck": {
             "description": "Checks that each variable declaration is in its own statement and on its own line.",
@@ -2297,10 +2742,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ArrayLiteralCheck": {
             "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
@@ -2329,10 +2784,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "EmptyPackageCheck": {
             "description": "Checks for empty package names.",
@@ -2366,10 +2831,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "TypeCheck": {
             "description": "Checks if type is specified or not for member variables.",
@@ -2403,10 +2878,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "RightCurlyCheck": {
             "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
@@ -2470,10 +2955,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ExcludeFilterList": {
             "description": "list of path filters, e.g.\n\t- full type names\n\t- names of individual folder or subfolders\n\t- partial folder or type names\n\n\teach line can have an additional range specification:\n\t- \":<linenumber>\" = only matches a specific line number - valid line number start at 1\n\t- \":<start>-<end>\" = matches line numbers from <start> to <end> (including both)\n\t- \":<identifier>\" = matches any line or block that has <identifier> name (Haxe keywords currently unsupported)",
@@ -2651,10 +3146,20 @@
                             "propertyOrder": 9
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "TypeNameCheck": {
             "description": "Checks that type names conform to a format specified by the `format` property.",
@@ -2709,10 +3214,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "EmptyBlockCheck": {
             "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
@@ -2775,10 +3290,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "NestedControlFlowCheck": {
             "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
@@ -2812,10 +3337,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "EmptyLinesCheck": {
             "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
@@ -2879,10 +3414,20 @@
                             "propertyOrder": 3
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "NestedForDepthCheck": {
             "description": "Restricts nested loop blocks to a specified depth (default = 1).",
@@ -2916,10 +3461,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ArrayAccessCheck": {
             "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
@@ -2958,10 +3513,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "CatchParameterNameCheck": {
             "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
@@ -2995,10 +3560,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "WhitespaceAroundCheck": {
             "description": "Checks that a token is surrounded by whitespace.",
@@ -3035,10 +3610,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ExcludeConfig": {
             "description": "defines filters to exclude folders, types or files from all or specific checks",
@@ -3389,7 +3974,12 @@
                     "propertyOrder": 26
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "RedundantModifierCheck": {
             "description": "Checks for redundant modifiers.",
@@ -3433,10 +4023,20 @@
                             "propertyOrder": 3
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "TODOCommentCheck": {
             "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
@@ -3470,10 +4070,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "BlockBreakingConditionalCheck": {
             "description": "Checks for block breaking conditionals.",
@@ -3502,10 +4112,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "VarTypeHintCheck": {
             "description": "Checks type hints of variables.",
@@ -3549,10 +4169,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "CodeSimilarityCheck": {
             "description": "Checks for identical or similar code.",
@@ -3602,10 +4232,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "UnnecessaryConstructorCheck": {
             "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
@@ -3634,10 +4274,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ParameterNameCheck": {
             "description": "Checks that parameter names conform to a format specified by the `format` property.",
@@ -3684,10 +4334,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "AnonymousCheck": {
             "description": "Check to find any anonymous type structures used.",
@@ -3716,10 +4376,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "MethodCountCheck": {
             "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
@@ -3763,10 +4433,20 @@
                             "propertyOrder": 3
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "FinalCheck": {
             "description": "Checks for places that use var instead of final (Haxe 4+).",
@@ -3795,10 +4475,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ConditionalCompilationCheck": {
             "description": "Checks placement and indentation of conditional compilation flags.",
@@ -3841,10 +4531,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "MemberNameCheck": {
             "description": "Checks that instance variable names conform to a format specified by the `format` property.",
@@ -3900,10 +4600,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ERegLiteralCheck": {
             "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
@@ -3932,10 +4642,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "SimplifyBooleanExpressionCheck": {
             "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
@@ -3964,10 +4684,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "VariableInitialisationCheck": {
             "description": "Checks for instance variables that are initialised at class level.",
@@ -4001,10 +4731,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "MethodLengthCheck": {
             "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
@@ -4043,10 +4783,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "AvoidIdentifierCheck": {
             "description": "Checks for identifiers to avoid.",
@@ -4083,10 +4833,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "NeedBracesCheck": {
             "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
@@ -4137,10 +4897,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "NullableParameterCheck": {
             "description": "Enforces a style for nullable parameters.",
@@ -4178,10 +4948,20 @@
                             "propertyOrder": 1
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "ReturnCheck": {
             "description": "Warns if Void is used for return or if return type is not specified when returning.",
@@ -4225,10 +5005,20 @@
                             "propertyOrder": 3
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "MultipleStringLiteralsCheck": {
             "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
@@ -4272,10 +5062,20 @@
                             "propertyOrder": 0
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "Config": {
             "additionalProperties": false,
@@ -4306,6 +5106,7 @@
                     ]
                 },
                 "extendsConfigPath": {
+                    "description": "Choose a master config file to extend from.\nChecks and excludes are combined from both master and current config, and can continue chaining as long as it does not cycle.\nThere is no shadowing or overwriting. Checkstile runs every check and exclude regardless where it comes from.",
                     "type": "string"
                 },
                 "version": {
@@ -4572,7 +5373,12 @@
                     "minimum": 1
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "SeparatorWrapCheck": {
             "description": "Checks line wrapping with separators.",
@@ -4618,10 +5424,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         },
         "SeparatorWhitespaceCheck": {
             "description": "Checks that whitespace is present or absent around a separators.",
@@ -4691,10 +5507,20 @@
                             "propertyOrder": 2
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                        "^_.*": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+                "^_.*": {
+                    "type": "string"
+                }
+            }
         }
     },
     "$ref": "#/definitions/Config",

--- a/resources/checkstyle-schema.json
+++ b/resources/checkstyle-schema.json
@@ -30,7 +30,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -38,7 +38,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -72,7 +72,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -80,7 +80,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -124,7 +124,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -132,7 +132,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -171,7 +171,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -179,7 +179,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -260,7 +260,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -268,7 +268,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -322,7 +322,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -330,7 +330,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -364,7 +364,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -372,7 +372,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -427,7 +427,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -435,7 +435,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -484,7 +484,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -492,7 +492,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -548,7 +548,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -556,7 +556,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -590,7 +590,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -598,7 +598,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -659,7 +659,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -667,7 +667,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -714,7 +714,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -722,7 +722,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -761,7 +761,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -769,7 +769,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -811,7 +811,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -819,7 +819,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -911,7 +911,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -919,7 +919,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -962,7 +962,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -970,7 +970,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1050,7 +1050,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1058,7 +1058,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1102,7 +1102,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1110,7 +1110,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1167,7 +1167,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1175,7 +1175,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1227,7 +1227,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1235,7 +1235,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1279,7 +1279,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1287,7 +1287,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1588,7 +1588,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1596,7 +1596,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1643,7 +1643,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1651,7 +1651,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1690,7 +1690,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1698,7 +1698,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1746,7 +1746,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1754,7 +1754,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1788,7 +1788,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1796,7 +1796,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1847,7 +1847,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1855,7 +1855,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1889,7 +1889,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1897,7 +1897,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1936,7 +1936,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1944,7 +1944,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -1978,7 +1978,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -1986,7 +1986,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2018,7 +2018,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2060,7 +2060,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2068,7 +2068,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2102,7 +2102,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2110,7 +2110,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2209,7 +2209,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2217,7 +2217,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2251,7 +2251,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2259,7 +2259,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2308,7 +2308,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2316,7 +2316,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2360,7 +2360,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2368,7 +2368,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2407,7 +2407,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2415,7 +2415,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2459,7 +2459,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2467,7 +2467,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2516,7 +2516,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2524,7 +2524,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2558,7 +2558,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2566,7 +2566,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2613,7 +2613,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2621,7 +2621,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2660,7 +2660,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2668,7 +2668,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2702,7 +2702,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2710,7 +2710,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2744,7 +2744,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2752,7 +2752,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2786,7 +2786,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2794,7 +2794,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2833,7 +2833,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2841,7 +2841,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2880,7 +2880,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2888,7 +2888,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -2957,7 +2957,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -2965,7 +2965,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -3148,7 +3148,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -3156,7 +3156,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -3216,7 +3216,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -3224,7 +3224,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -3292,7 +3292,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -3300,7 +3300,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -3339,7 +3339,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -3347,7 +3347,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -3416,7 +3416,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -3424,7 +3424,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -3463,7 +3463,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -3471,7 +3471,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -3515,7 +3515,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -3523,7 +3523,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -3562,7 +3562,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -3570,7 +3570,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -3612,7 +3612,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -3620,7 +3620,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -3976,7 +3976,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4025,7 +4025,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4033,7 +4033,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4072,7 +4072,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4080,7 +4080,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4114,7 +4114,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4122,7 +4122,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4171,7 +4171,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4179,7 +4179,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4234,7 +4234,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4242,7 +4242,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4276,7 +4276,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4284,7 +4284,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4336,7 +4336,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4344,7 +4344,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4378,7 +4378,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4386,7 +4386,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4435,7 +4435,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4443,7 +4443,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4477,7 +4477,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4485,7 +4485,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4533,7 +4533,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4541,7 +4541,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4602,7 +4602,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4610,7 +4610,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4644,7 +4644,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4652,7 +4652,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4686,7 +4686,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4694,7 +4694,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4733,7 +4733,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4741,7 +4741,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4785,7 +4785,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4793,7 +4793,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4835,7 +4835,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4843,7 +4843,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4899,7 +4899,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4907,7 +4907,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -4950,7 +4950,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -4958,7 +4958,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -5007,7 +5007,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -5015,7 +5015,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -5064,7 +5064,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -5072,7 +5072,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -5375,7 +5375,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -5426,7 +5426,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -5434,7 +5434,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }
@@ -5509,7 +5509,7 @@
                     },
                     "type": "object",
                     "patternProperties": {
-                        "^_.*": {
+                        "^comment$": {
                             "type": "string"
                         }
                     }
@@ -5517,7 +5517,7 @@
             },
             "type": "object",
             "patternProperties": {
-                "^_.*": {
+                "^comment$": {
                     "type": "string"
                 }
             }

--- a/schema/CheckstyleSchemaGenerator.hx
+++ b/schema/CheckstyleSchemaGenerator.hx
@@ -34,6 +34,12 @@ class CheckstyleSchemaGenerator {
 						expr: JsonSchemaGenerator.genSchema(filterListType, "ExcludeFilterList", pos, null, refs, order++, null)
 					});
 				}
+			case "Config.extendsConfigPath":
+				fields.push({field: "description",
+					expr: macro "Choose a master config file to extend from."+
+					"\nChecks and excludes are combined from both master and current config, and can continue chaining as long as it does not cycle."+
+					"\nThere is no shadowing or overwriting. Checkstile runs every check and exclude regardless where it comes from."
+				});
 			case "Config.checks":
 				fields.pop();
 				fields.pop();

--- a/schema/JsonSchemaGenerator.hx
+++ b/schema/JsonSchemaGenerator.hx
@@ -31,7 +31,7 @@ class JsonSchemaGenerator {
 		switch (main.expr) {
 			case EObjectDecl(fields):
 				fields.push({field: "definitions", expr: definitions});
-				fields.push({field: DollarName.DollarSchema, expr: macro "http://json-schema.org/schema#"});
+				fields.push({field: DollarName.DollarSchema, expr: macro "https://json-schema.org/draft/2020-12/schema"});
 				if (id != null) {
 					fields.push({field: "id", expr: macro $v{id}});
 				}
@@ -91,7 +91,11 @@ class JsonSchemaGenerator {
 			case TInst(_.get() => cl, params):
 				switch [cl, params] {
 					case [{pack: [], name: "String"}, []]:
-						return SchemaUtils.makeObjectDecl([{field: "type", expr: macro "string"}], structInfo, order, pos);
+						var fields:Array<ObjectDeclField> = [
+							{field: "type", expr: macro "string"}
+						];
+						if (extendCB != null) extendCB(fields, typeName, pos, refs);
+						return SchemaUtils.makeObjectDecl(fields, structInfo, order, pos);
 					case [{pack: [], name: "Array"}, [elemType]]:
 						var fields:Array<ObjectDeclField> = [
 							{field: "type", expr: macro "array"},
@@ -112,11 +116,17 @@ class JsonSchemaGenerator {
 						if (extendCB != null) extendCB(fields, typeName, pos, refs);
 						return SchemaUtils.makeObjectDecl(fields, structInfo, order, pos);
 					case [{pack: [], name: "Float"}, []]:
-						return SchemaUtils.makeObjectDecl([{field: "type", expr: macro "number"}], structInfo, order, pos);
+						var fields:Array<ObjectDeclField> = [{field: "type", expr: macro "number"}];
+						if (extendCB != null) extendCB(fields, typeName, pos, refs);
+						return SchemaUtils.makeObjectDecl(fields, structInfo, order, pos);
 					case [{pack: [], name: "Bool"}, []]:
-						return SchemaUtils.makeObjectDecl([{field: "type", expr: macro "boolean"}], structInfo, order, pos);
+						var fields:Array<ObjectDeclField> = [{field: "type", expr: macro "boolean"}];
+						if (extendCB != null) extendCB(fields, typeName, pos, refs);
+						return SchemaUtils.makeObjectDecl(fields, structInfo, order, pos);
 					case [{pack: [], name: "Any"}, []]:
-						return SchemaUtils.makeObjectDecl([{field: "type", expr: macro "object"}], structInfo, order, pos);
+						var fields:Array<ObjectDeclField> = [{field: "type", expr: macro "object"}];
+						if (extendCB != null) extendCB(fields, typeName, pos, refs);
+						return SchemaUtils.makeObjectDecl(fields, structInfo, order, pos);
 					case [{pack: [], name: "Null"}, [t]]:
 						return genSchema(t, typeName, pos, null, refs, -1, extendCB);
 					default:

--- a/schema/SchemaUtils.hx
+++ b/schema/SchemaUtils.hx
@@ -11,9 +11,17 @@ class SchemaUtils {
 	}
 
 	public static function makeObject(props:Expr, structInfo:Null<StructInfo>, required:Array<String>, order:Int, pos:Position):Expr {
+		var patternProperties:Expr = macro {
+			// Enable "comments" by allowing ignored string properties that start with "_".
+			"^_.*": {
+				"type": "string"
+			}
+		};
+		
 		var fields:Array<ObjectDeclField> = [
 			{field: "type", expr: macro "object"},
 			{field: "properties", expr: props},
+			{field: "patternProperties", expr: patternProperties},
 			{field: "additionalProperties", expr: macro false}
 		];
 		if (required.length > 0) {

--- a/schema/SchemaUtils.hx
+++ b/schema/SchemaUtils.hx
@@ -13,7 +13,7 @@ class SchemaUtils {
 	public static function makeObject(props:Expr, structInfo:Null<StructInfo>, required:Array<String>, order:Int, pos:Position):Expr {
 		var patternProperties:Expr = macro {
 			// Enable "comments" by allowing ignored string properties that start with "_".
-			"^_.*": {
+			"^comment$": {
 				"type": "string"
 			}
 		};

--- a/src/checkstyle/config/ConfigParser.hx
+++ b/src/checkstyle/config/ConfigParser.hx
@@ -189,6 +189,8 @@ class ConfigParser {
 
 	function validateAllowedFields<T>(object:T, allowedFields:Array<String>, messagePrefix:String) {
 		for (field in Reflect.fields(object)) {
+			// Ignore comments.
+			if (field == "comment") continue;
 			if (!allowedFields.contains(field)) {
 				failWith(messagePrefix + " has unknown field '" + field + "'");
 			}


### PR DESCRIPTION
- Change the JSON schema `$schema` URL to remove a warning.
- Add documentation to the `extendsConfigPath` property so it shows up when you hover on it in checkstyle.json.
- Allowed the string property "comment" inside props, resolving #525 .