### PR TITLE
Added ability to filter ConstantName by FINAL/NOTFINAL

### DIFF
--- a/resources/checkstyle-schema.json
+++ b/resources/checkstyle-schema.json
@@ -948,11 +948,13 @@
                         "tokens": {
                             "description": "list of tokens to limit where names should conform to \"format\"",
                             "items": {
-                                "description": "supports inline and non inline constants\n\t- INLINE = \"static inline var\"\n\t- NOTINLINE = \"static var\"",
+                                "description": "supports inline and non inline constants\n\t- INLINE = \"static inline var\"\n\t- NOTINLINE = \"static var\"\n\t- FINAL = \"static final\"\n\t- NOTFINAL = \"static var\"",
                                 "type": "string",
                                 "enum": [
                                     "INLINE",
-                                    "NOTINLINE"
+                                    "NOTINLINE",
+                                    "FINAL",
+                                    "NOTFINAL"
                                 ]
                             },
                             "type": "array",

--- a/src/checkstyle/checks/naming/ConstantNameCheck.hx
+++ b/src/checkstyle/checks/naming/ConstantNameCheck.hx
@@ -39,17 +39,25 @@ class ConstantNameCheck extends NameCheckBase<ConstantNameCheckToken> {
 
 	function checkField(f:Field, t:ComplexType, e:Expr, p:ParentType) {
 		if (e == null || e.expr == null || !f.isStatic(p)) return;
-		if (!hasToken(INLINE) && f.isInline(p)) return;
-		if (!hasToken(NOTINLINE) && !f.isInline(p)) return;
+
+		if (hasToken(INLINE) != hasToken(NOTINLINE)) { // != -> xor
+			if (!hasToken(INLINE) && f.isInline(p)) return;
+			if (!hasToken(NOTINLINE) && !f.isInline(p)) return;
+		}
+
+		if (hasToken(FINAL) != hasToken(NOTFINAL)) { // != -> xor
+			if (!hasToken(FINAL) && f.isFinal(p)) return;
+			if (!hasToken(NOTFINAL) && !f.isFinal(p)) return;
+		}
 
 		matchTypeName("const", f.name, f.pos);
 	}
 
 	override public function detectableInstances():DetectableInstances {
-		var instanceInline:DetectableInstance = {
+		return [{
 			fixed: [{
 				propertyName: "tokens",
-				value: [INLINE]
+				value: [FINAL, INLINE, NOTFINAL, NOTINLINE]
 			}],
 			properties: [{
 				propertyName: "format",
@@ -58,21 +66,7 @@ class ConstantNameCheck extends NameCheckBase<ConstantNameCheckToken> {
 				propertyName: "ignoreExtern",
 				values: [true, false]
 			}]
-		};
-		var instanceNotInline:DetectableInstance = {
-			fixed: [{
-				propertyName: "tokens",
-				value: [NOTINLINE]
-			}],
-			properties: [{
-				propertyName: "format",
-				values: [UPPER_CASE, CAMEL_CASE, LOWER_CASE]
-			}, {
-				propertyName: "ignoreExtern",
-				values: [true, false]
-			}]
-		}
-		return [instanceInline, instanceNotInline];
+		}];
 	}
 }
 
@@ -80,10 +74,14 @@ class ConstantNameCheck extends NameCheckBase<ConstantNameCheckToken> {
 	supports inline and non inline constants
 	- INLINE = "static inline var"
 	- NOTINLINE = "static var"
+	- FINAL = "static final"
+	- NOTFINAL = "static var"
 **/
 enum abstract ConstantNameCheckToken(String) {
 	var INLINE = "INLINE";
 	var NOTINLINE = "NOTINLINE";
+	var FINAL = "FINAL";
+	var NOTFINAL = "NOTFINAL";
 }
 
 enum abstract ConstantNameCheckFormt(String) to String {

--- a/src/checkstyle/utils/FieldUtils.hx
+++ b/src/checkstyle/utils/FieldUtils.hx
@@ -21,6 +21,10 @@ class FieldUtils {
 		return f.access.contains(AStatic);
 	}
 
+	public static function isFinal(f:Field, p:ParentType):Bool {
+		return f.access.contains(AFinal);
+	}
+
 	public static function isAbstract(f:Field, p:ParentType):Bool {
 		return f.access.contains(AAbstract);
 	}

--- a/test/checkstyle/checks/naming/ConstantNameCheckTest.hx
+++ b/test/checkstyle/checks/naming/ConstantNameCheckTest.hx
@@ -4,8 +4,9 @@ class ConstantNameCheckTest extends CheckTestCase<ConstantNameCheckTests> {
 	@Test
 	public function testCorrectNaming() {
 		var check = new ConstantNameCheck();
+
 		assertNoMsg(check, TEST);
-		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST5);
 	}
 
 	@Test
@@ -14,6 +15,8 @@ class ConstantNameCheckTest extends CheckTestCase<ConstantNameCheckTests> {
 		var message = 'Invalid const signature: "Count" (name should be "~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/")';
 		assertMsg(check, TEST1, message);
 		assertMsg(check, TEST2, message);
+		assertMsg(check, TEST3, message);
+		assertMsg(check, TEST4, message);
 	}
 
 	@Test
@@ -25,7 +28,9 @@ class ConstantNameCheckTest extends CheckTestCase<ConstantNameCheckTests> {
 		assertNoMsg(check, TEST);
 		assertMsg(check, TEST1, message);
 		assertMsg(check, TEST2, message);
-		assertMessages(check, TEST3, [message, message]);
+		assertMsg(check, TEST3, message);
+		assertMsg(check, TEST4, message);
+		assertMessages(check, TEST5, [message, message]);
 	}
 
 	@Test
@@ -37,6 +42,8 @@ class ConstantNameCheckTest extends CheckTestCase<ConstantNameCheckTests> {
 		assertNoMsg(check, TEST1);
 		assertMsg(check, TEST2, 'Invalid const signature: "Count" (name should be "~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/")');
 		assertNoMsg(check, TEST3);
+		assertMsg(check, TEST4, 'Invalid const signature: "Count" (name should be "~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/")');
+		assertNoMsg(check, TEST5);
 	}
 
 	@Test
@@ -47,7 +54,35 @@ class ConstantNameCheckTest extends CheckTestCase<ConstantNameCheckTests> {
 		assertNoMsg(check, TEST);
 		assertMsg(check, TEST1, 'Invalid const signature: "Count" (name should be "~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/")');
 		assertNoMsg(check, TEST2);
+		assertMsg(check, TEST3, 'Invalid const signature: "Count" (name should be "~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/")');
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
+	}
+
+	@Test
+	public function testTokenFINAL() {
+		var check = new ConstantNameCheck();
+		check.tokens = [FINAL];
+
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2);
+		assertMsg(check, TEST3, 'Invalid const signature: "Count" (name should be "~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/")');
+		assertMsg(check, TEST4, 'Invalid const signature: "Count" (name should be "~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/")');
+		assertNoMsg(check, TEST5);
+	}
+
+	@Test
+	public function testTokenNOTFINAL() {
+		var check = new ConstantNameCheck();
+		check.tokens = [NOTFINAL];
+
+		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, 'Invalid const signature: "Count" (name should be "~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/")');
+		assertMsg(check, TEST2, 'Invalid const signature: "Count" (name should be "~/^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$/")');
 		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
 	}
 
 	@Test
@@ -57,7 +92,9 @@ class ConstantNameCheckTest extends CheckTestCase<ConstantNameCheckTests> {
 
 		assertMessages(check, TEST, [
 			'Invalid const signature: "COUNT" (name should be "~/^[A-Z][a-z]*$/")',
-			'Invalid const signature: "COUNT2" (name should be "~/^[A-Z][a-z]*$/")'
+			'Invalid const signature: "COUNT2" (name should be "~/^[A-Z][a-z]*$/")',
+			'Invalid const signature: "COUNT11" (name should be "~/^[A-Z][a-z]*$/")',
+			'Invalid const signature: "COUNT12" (name should be "~/^[A-Z][a-z]*$/")'
 		]);
 		assertNoMsg(check, TEST1);
 		assertNoMsg(check, TEST2);
@@ -78,10 +115,22 @@ enum abstract ConstantNameCheckTests(String) to String {
 		var count5:Int = 1;
 		var _count5:Int = 1;
 
+		static final COUNT11:Int = 1;
+		static inline final COUNT12:Int = 1;
+		final COUNT13:Int = 1;
+		final Count14:Int = 1;
+		final count15:Int = 1;
+		final _count15:Int = 1;
+
 		@SuppressWarnings('checkstyle:ConstantName')
 		static inline var count6:Int = 1;
 		@SuppressWarnings('checkstyle:ConstantName')
 		static var count7:Int = 1;
+
+		@SuppressWarnings('checkstyle:ConstantName')
+		static inline final count16:Int = 1;
+		@SuppressWarnings('checkstyle:ConstantName')
+		static final count17:Int = 1;
 	}";
 	var TEST1 = "
 	abstractAndClass Test {
@@ -97,6 +146,19 @@ enum abstract ConstantNameCheckTests(String) to String {
 		}
 	}";
 	var TEST3 = "
+	abstractAndClass Test {
+		static final Count:Int = 1;
+		public function test() {
+		}
+	}";
+	var TEST4 = "
+	abstractAndClass Test {
+		static inline final Count:Int = 1;
+		public function test() {
+			var Count:Int;
+		}
+	}";
+	var TEST5 = "
 	extern class Test {
 		static var Count:Int = 1;
 		static inline var Count:Int = 1;


### PR DESCRIPTION
Added the new `FINAL` and `NOTFINAL` tokens to the `ConstantName` rule. This essentially lets you define separate rules for `final` and non-`final` constant names.

- Without either of these tokens (or both), the rule acts as it did previously, applying filtering to any `static` constants, both `final` and `var`.
- With `FINAL`, only `final` constants will be evaluated, with `var` constants ignored.
- With `NOTFINAL`, only `var` constants will be evaluated, with `final` constants ignored.

Unit tests included.