### PR TITLE
Rework NeedBraces to add the ELSE and IF_WITH_ELSE tokens.

### DIFF
--- a/src/checkstyle/checks/block/NeedBracesCheck.hx
+++ b/src/checkstyle/checks/block/NeedBracesCheck.hx
@@ -39,11 +39,14 @@ class NeedBracesCheck extends Check {
 		var wantFunction = hasToken(FUNCTION);
 		var wantFor = hasToken(FOR);
 		var wantIf = hasToken(IF);
+		var wantIfWithElse = hasToken(IF_WITH_ELSE);
+		var wantElseIf = hasToken(ELSE_IF);
+		var wantElse = hasToken(ELSE);
 		var wantWhile = hasToken(WHILE);
 		var wantDoWhile = hasToken(DO_WHILE);
 		var wantCatch = hasToken(CATCH);
 
-		if (!(wantFunction || wantFor || wantIf || wantWhile || wantDoWhile || wantCatch)) return;
+		if (!(wantFunction || wantFor || wantIf || wantIfWithElse || wantElseIf || wantElse || wantWhile || wantDoWhile || wantCatch)) return;
 
 		var root:TokenTree = checker.getTokenTree();
 		var allTokens:Array<TokenTree> = root.filterCallback(function(token:TokenTree, depth:Int):FilterResult {
@@ -52,7 +55,9 @@ class NeedBracesCheck extends Check {
 					FoundGoDeeper;
 				case Kwd(KwdFor) if (wantFor):
 					FoundGoDeeper;
-				case Kwd(KwdIf) | Kwd(KwdElse) if (wantIf):
+				case Kwd(KwdIf) if (wantIf || wantIfWithElse):
+					FoundGoDeeper;
+				case Kwd(KwdElse) if (wantElseIf || wantElse):
 					FoundGoDeeper;
 				case Kwd(KwdWhile) if (wantWhile):
 					FoundGoDeeper;
@@ -69,11 +74,15 @@ class NeedBracesCheck extends Check {
 			if (isPosSuppressed(tok.pos)) continue;
 			switch (tok.tok) {
 				case Kwd(KwdIf):
+					if (wantIfWithElse && !wantIf && !hasElse(tok)) continue;
 					checkIfChild(tok);
 				case Kwd(KwdElse):
 					var firstChild = tok.getFirstChild();
 					if (firstChild == null) continue;
-					if (firstChild.matches(Kwd(KwdIf))) checkIfChild(firstChild);
+					if (firstChild.matches(Kwd(KwdIf))) {
+						if (!wantIf) continue;
+						checkIfChild(firstChild);
+					}
 					else checkLastChild(tok);
 				case Kwd(KwdFunction):
 					checkFunctionChild(tok);
@@ -85,6 +94,15 @@ class NeedBracesCheck extends Check {
 					checkLastChild(tok);
 			}
 		}
+	}
+
+	function hasElse(token:TokenTree):Bool {
+		for (child in token.children) {
+			if (child.matches(Kwd(KwdElse))) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	function checkIfChild(token:TokenTree) {
@@ -181,7 +199,9 @@ enum abstract NeedBracesCheckToken(String) {
 	var FUNCTION = "FUNCTION";
 	var FOR = "FOR";
 	var IF = "IF";
+	var IF_WITH_ELSE = "IF_WITH_ELSE";
 	var ELSE_IF = "ELSE_IF";
+	var ELSE = "ELSE";
 	var WHILE = "WHILE";
 	var DO_WHILE = "DO_WHILE";
 	var CATCH = "CATCH";

--- a/test/checkstyle/checks/block/NeedBracesCheckTest.hx
+++ b/test/checkstyle/checks/block/NeedBracesCheckTest.hx
@@ -25,6 +25,8 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 		assertNoMsg(check, TEST12);
 		assertNoMsg(check, TEST13);
 		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
 		assertNoMsg(check, INTERFACE_DEF);
 		assertNoMsg(check, ANON_FUNCTION);
 		assertNoMsg(check, ANON_FUNCTION_NO_BRACES);
@@ -35,10 +37,24 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 		var check = new NeedBracesCheck();
 		assertMsg(check, TEST1, MSG_IF);
 		assertMsg(check, TEST2, MSG_ELSE);
+		assertNoMsg(check, TEST3);
 		assertMsg(check, TEST4, MSG_IF);
+		assertNoMsg(check, TEST5);
 		assertMsg(check, TEST6, MSG_FOR);
 		assertMsg(check, TEST7, MSG_WHILE);
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+		assertNoMsg(check, TEST10);
 		assertMsg(check, TEST11, MSG_IF);
+		assertNoMsg(check, TEST12);
+		assertNoMsg(check, TEST13);
+		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
+		assertMessages(check, TEST17, [
+			MSG_IF,
+			MSG_ELSE
+		]);
 	}
 
 	@Test
@@ -71,6 +87,7 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 		assertNoMsg(check, TEST14);
 		assertNoMsg(check, INTERFACE_DEF);
 		assertMsg(check, TEST16, MSG_SAME_LINE_ELSE);
+		assertMessages(check, TEST17, [MSG_IF, MSG_ELSE]);
 	}
 
 	@Test
@@ -93,6 +110,9 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 		assertNoMsg(check, TEST12);
 		assertNoMsg(check, TEST13);
 		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
+		assertNoMsg(check, TEST17);
 
 		check.allowSingleLineStatement = false;
 		assertMsg(check, TEST, MSG_SAME_LINE_FOR);
@@ -106,7 +126,7 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 
 		assertNoMsg(check, TEST);
 		assertMsg(check, TEST1, MSG_IF);
-		assertMsg(check, TEST2, MSG_ELSE);
+		assertNoMsg(check, TEST2);
 		assertNoMsg(check, TEST3);
 		assertMsg(check, TEST4, MSG_IF);
 		assertNoMsg(check, TEST5);
@@ -119,18 +139,53 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 		assertNoMsg(check, TEST12);
 		assertNoMsg(check, TEST13);
 		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
+		assertMsg(check, TEST17, MSG_IF);
 
 		check.allowSingleLineStatement = false;
 		assertMessages(check, TEST, [
 			MSG_SAME_LINE_IF,
 			MSG_SAME_LINE_IF,
-			MSG_SAME_LINE_ELSE,
 			MSG_SAME_LINE_IF,
 			MSG_SAME_LINE_IF
 		]);
 		assertMsg(check, TEST10, MSG_SAME_LINE_IF);
-		assertMessages(check, TEST11, [MSG_IF, MSG_SAME_LINE_ELSE]);
+		assertMessages(check, TEST11, [MSG_IF]);
 		assertMsg(check, TEST13, MSG_SAME_LINE_IF);
+		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST16);
+	}
+
+	@Test
+	public function testTokenElse() {
+		var check = new NeedBracesCheck();
+		check.tokens = [ELSE];
+
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, MSG_ELSE);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
+		assertNoMsg(check, TEST6);
+		assertNoMsg(check, TEST7);
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+		assertNoMsg(check, TEST10);
+		assertNoMsg(check, TEST11);
+		assertNoMsg(check, TEST12);
+		assertNoMsg(check, TEST13);
+		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
+		assertMsg(check, TEST17, MSG_ELSE);
+
+		check.allowSingleLineStatement = false;
+		assertMsg(check, TEST, MSG_SAME_LINE_ELSE);
+		assertNoMsg(check, TEST10);
+		assertMessages(check, TEST11, [MSG_SAME_LINE_ELSE]);
+		assertNoMsg(check, TEST13);
 		assertNoMsg(check, TEST14);
 		assertMsg(check, TEST16, MSG_SAME_LINE_ELSE);
 	}
@@ -155,6 +210,12 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 		assertNoMsg(check, TEST12);
 		assertNoMsg(check, TEST13);
 		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
+		assertMessages(check, TEST17, [
+			MSG_IF,
+			MSG_ELSE
+		]);
 
 		check.allowSingleLineStatement = false;
 		assertMessages(check, TEST, [
@@ -171,6 +232,55 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 		assertNoMsg(check, TEST14);
 		assertNoMsg(check, TEST15);
 		assertMsg(check, TEST16, MSG_SAME_LINE_ELSE);
+	}
+
+	@Test
+	public function testTokenIfWithElse() {
+		var check = new NeedBracesCheck();
+		check.tokens = [IF_WITH_ELSE];
+
+		assertNoMsg(check, TEST); // allow single line
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST2); // allow single line
+		assertNoMsg(check, TEST3); // correct braces
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
+		assertNoMsg(check, TEST6);
+		assertNoMsg(check, TEST7);
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+		assertNoMsg(check, TEST10);
+		assertMsg(check, TEST11, MSG_IF); // missing braces!
+		assertNoMsg(check, TEST12); // allow single line
+		assertNoMsg(check, TEST13); // allow single line
+		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
+		assertMsg(check, TEST17, MSG_IF); // missing braces!
+
+		check.allowSingleLineStatement = false;
+
+		assertMessages(check, TEST, [
+			MSG_SAME_LINE_IF,
+			MSG_SAME_LINE_IF
+		]);
+		assertNoMsg(check, TEST1);
+		assertMsg(check, TEST2, MSG_SAME_LINE_IF);
+		assertNoMsg(check, TEST3); // correct braces
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST5);
+		assertNoMsg(check, TEST6);
+		assertNoMsg(check, TEST7);
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+		assertNoMsg(check, TEST10);
+		assertMsg(check, TEST11, MSG_IF); // missing braces!
+		assertMsg(check, TEST12, MSG_SAME_LINE_IF);
+		assertMsg(check, TEST13, MSG_SAME_LINE_IF);
+		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
+		assertMsg(check, TEST17, MSG_IF); // missing braces!
 	}
 
 	@Test
@@ -193,6 +303,9 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 		assertNoMsg(check, TEST12);
 		assertNoMsg(check, TEST13);
 		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
+		assertNoMsg(check, TEST17);
 
 		check.allowSingleLineStatement = false;
 		assertMsg(check, TEST, MSG_SAME_LINE_WHILE);
@@ -218,6 +331,9 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 		assertNoMsg(check, TEST12);
 		assertNoMsg(check, TEST13);
 		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
+		assertNoMsg(check, TEST17);
 		assertNoMsg(check, ANON_FUNCTION);
 		assertNoMsg(check, ANON_FUNCTION_NO_BRACES);
 
@@ -246,6 +362,9 @@ class NeedBracesCheckTest extends CheckTestCase<NeedBracesCheckTests> {
 		assertNoMsg(check, TEST12);
 		assertNoMsg(check, TEST13);
 		assertNoMsg(check, TEST14);
+		assertNoMsg(check, TEST15);
+		assertNoMsg(check, TEST16);
+		assertNoMsg(check, TEST17);
 		assertNoMsg(check, DO_WHILE);
 		assertNoMsg(check, DO_WHILE_NO_BRACES);
 
@@ -421,6 +540,15 @@ enum abstract NeedBracesCheckTests(String) to String {
 				return;
 			}
 			else return;
+		}
+	}";
+	var TEST17 = "
+	class Test {
+		function test() {
+			if (true)
+				return;
+			else
+				return;
 		}
 	}";
 	var INTERFACE_DEF = "


### PR DESCRIPTION
A rework to NeedBraces to allow making more specific rules with regard to `if` statements with `else` blocks.

- Added the `ELSE` token to detect specifically `else` statements.
    - `IF` tokens no longer detect `else` statements; this is a breaking change from previous versions, use `[IF, ELSE]` to achieve the same behavior `[IF]` did previously.
- Added the `IF_WITH_ELSE` token to detect specifically `if` statements with a correponding `else` statement.
    - This allows you to, for example, require braces on any `if` statement that has an `else` statement.

Unit tests included.