### PR TITLE
Add a new test case to prove #520 and #528 are fixed.

### DIFF
--- a/test/checkstyle/checks/block/LeftCurlyCheckTest.hx
+++ b/test/checkstyle/checks/block/LeftCurlyCheckTest.hx
@@ -112,6 +112,27 @@ class LeftCurlyCheckTest extends CheckTestCase<LeftCurlyCheckTests> {
 	}
 
 	@Test
+	public function testIgnoreSingleline() {
+		var check = new LeftCurlyCheck();
+		check.tokens = [TYPEDEF_DEF];
+		check.option = NL;
+
+		check.ignoreSingleline = false;
+		assertNoMsg(check, TEST);
+		assertMessages(check, TYPEDEF_CUDDLED, [MSG_NL, MSG_NL]);
+		assertNoMsg(check, TYPEDEF_WIDE);
+		// Single line is NOT valid!
+		assertMessages(check, TYPEDEF_SINGLELINE, [MSG_NL, MSG_NL]);
+
+		check.ignoreSingleline = true;
+		assertNoMsg(check, TEST);
+		assertMessages(check, TYPEDEF_CUDDLED, [MSG_NL, MSG_NL]);
+		assertNoMsg(check, TYPEDEF_WIDE);
+		// Single line IS valid!
+		assertNoMsg(check, TYPEDEF_SINGLELINE);
+	}
+
+	@Test
 	public function testArrayComprehension() {
 		var check = new LeftCurlyCheck();
 		check.tokens = [ARRAY_COMPREHENSION, OBJECT_DECL];
@@ -497,4 +518,27 @@ enum abstract LeftCurlyCheckTests(String) to String {
 			addClassFields(typeName, classFields, superClass.t.get().fields.get(), pos, refs);
 		}
 	}";
+	var TYPEDEF_CUDDLED = "
+	typedef Test = {
+		x:Int,
+		y:Int,
+		z:Int,
+		point:{
+			x:Int, y:Int, z:Int
+		}
+	}";
+	var TYPEDEF_WIDE = "
+	typedef Test =
+	{
+		x:Int,
+		y:Int,
+		z:Int,
+		point:
+		{
+			x:Int, y:Int, z:Int
+		}
+	}";
+	var TYPEDEF_SINGLELINE = "
+	typedef Test = { a:Int, b:String, c: { x:Int, y:Int } };
+	";
 }

--- a/test/checkstyle/checks/modifier/ModifierOrderCheckTest.hx
+++ b/test/checkstyle/checks/modifier/ModifierOrderCheckTest.hx
@@ -41,6 +41,15 @@ class ModifierOrderCheckTest extends CheckTestCase<ModifierOrderCheckTests> {
 		check.severity = "ignore";
 		assertNoMsg(check, TEST1);
 	}
+	
+	@Test
+	public function testIssue520() {
+		var check = new ModifierOrderCheck();
+		assertNoMsg(check, TEST_ISSUE520);
+
+		check.modifiers = [OVERRIDE, PUBLIC_PRIVATE, STATIC, MACRO, INLINE, DYNAMIC];
+		assertNoMsg(check, TEST_ISSUE520);
+	}
 }
 
 enum abstract ModifierOrderCheckTests(String) to String {
@@ -80,6 +89,10 @@ enum abstract ModifierOrderCheckTests(String) to String {
 	var TEST8 = "
 	abstractAndClass Test {
 		inline public var test(default,null):String=0;
+	}";
+	var TEST_ISSUE520 = "
+	abstractAndClass Test {
+		static final _point = new Point();
 	}";
 	var TEST_FINAL = "
 	abstractAndClass Test {


### PR DESCRIPTION
See #520 and #528, which this test case proves are no longer an issue.