### PR TITLE
Add allowEqualsFalse to SimplifyBooleanExpression

### DIFF
--- a/resources/checkstyle-schema.json
+++ b/resources/checkstyle-schema.json
@@ -3961,6 +3961,11 @@
                                 "ERROR",
                                 "IGNORE"
                             ],
+                            "propertyOrder": 1
+                        },
+                        "allowEqualsFalse": {
+                            "description": "specifically allow expressions equal to false",
+                            "type": "boolean",
                             "propertyOrder": 0
                         }
                     },

--- a/src/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.hx
+++ b/src/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.hx
@@ -52,16 +52,12 @@ class SimplifyBooleanExpressionCheck extends Check {
 		}
 	}
 
-		override public function detectableInstances():DetectableInstances {
+	override public function detectableInstances():DetectableInstances {
 		return [{
 			fixed: [],
 			properties: [{
 				propertyName: "allowEqualsFalse",
 				values: [true, false]
-			},
-			{
-				propertyName: "severity",
-				values: [SeverityLevel.INFO]
 			}]
 		}];
 	}

--- a/src/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.hx
+++ b/src/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.hx
@@ -6,10 +6,17 @@ package checkstyle.checks.coding;
 @name("SimplifyBooleanExpression")
 @desc("Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.")
 class SimplifyBooleanExpressionCheck extends Check {
+	/**
+		specifically allow expressions equal to false
+	**/
+	public var allowEqualsFalse:Bool;
+
 	public function new() {
 		super(TOKEN);
 		categories = [Category.COMPLEXITY];
 		points = 3;
+
+		allowEqualsFalse = false;
 	}
 
 	override function actualRun() {
@@ -33,9 +40,29 @@ class SimplifyBooleanExpressionCheck extends Check {
 	function checkToken(token:TokenTree) {
 		var parent = token.parent;
 		switch (parent.tok) {
-			case Binop(OpEq), Binop(OpNotEq), Unop(OpNot), Binop(OpOr), Binop(OpAnd), Binop(OpBoolOr), Binop(OpBoolAnd):
+			case Binop(OpEq), Binop(OpNotEq):
+				if (allowEqualsFalse) {
+					if (token.matches(Kwd(KwdFalse))) return;
+				}
+				
+				logPos("Boolean expression can be simplified", token.pos);
+			case Unop(OpNot), Binop(OpOr), Binop(OpAnd), Binop(OpBoolOr), Binop(OpBoolAnd):
 				logPos("Boolean expression can be simplified", token.pos);
 			default:
 		}
+	}
+
+		override public function detectableInstances():DetectableInstances {
+		return [{
+			fixed: [],
+			properties: [{
+				propertyName: "allowEqualsFalse",
+				values: [true, false]
+			},
+			{
+				propertyName: "severity",
+				values: [SeverityLevel.INFO]
+			}]
+		}];
 	}
 }

--- a/test/checkstyle/checks/coding/SimplifyBooleanExpressionCheckTest.hx
+++ b/test/checkstyle/checks/coding/SimplifyBooleanExpressionCheckTest.hx
@@ -21,6 +21,19 @@ class SimplifyBooleanExpressionCheckTest extends CheckTestCase<SimplifyBooleanEx
 	public function testSuppressExpression() {
 		assertNoMsg(new SimplifyBooleanExpressionCheck(), TEST7);
 	}
+
+	@Test
+	public function testAllowEqualsFalse() {
+		var check = new SimplifyBooleanExpressionCheck();
+		
+		check.allowEqualsFalse = false;
+		assertMsg(check, TEST8, MSG_SIMPLIFY);
+		assertMsg(check, TEST9, MSG_SIMPLIFY);
+
+		check.allowEqualsFalse = true;
+		assertNoMsg(check, TEST8);
+		assertNoMsg(check, TEST9);
+	}
 }
 
 enum abstract SimplifyBooleanExpressionCheckTests(String) to String {
@@ -72,6 +85,20 @@ enum abstract SimplifyBooleanExpressionCheckTests(String) to String {
 		public static function main() {
 			var value: Null<Bool> = null;
 			trace(value == true);
+		}
+	}";
+	var TEST8 = "
+	abstractAndClass Test {
+		function test() {
+			var bvar:Bool;
+			if (bvar == false) {}
+		}
+	}";
+	var TEST9 = "
+	abstractAndClass Test {
+		function test() {
+			var bvar:Bool;
+			if (bvar != false) {}
 		}
 	}";
 }


### PR DESCRIPTION
Resolves #524 by adding the `allowEqualsFalse` parameter to SimplifyBoolanExpression.

This specifically allows for `value == false` and `value != false` to be used, without allowing `!false` or `value == true`.

Unit tests included.