### PR TITLE
Implemented check: LongNumbers

### DIFF
--- a/resources/checkstyle-excludes-schema.json
+++ b/resources/checkstyle-excludes-schema.json
@@ -18,7 +18,7 @@
                 },
                 "UnusedImport": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 79
+                    "propertyOrder": 80
                 },
                 "Dynamic": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -30,15 +30,19 @@
                 },
                 "MultipleStringLiterals": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 46
+                    "propertyOrder": 47
+                },
+                "LongNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 40
                 },
                 "NeedBraces": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 48
+                    "propertyOrder": 49
                 },
                 "SeparatorWhitespace": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 65
+                    "propertyOrder": 66
                 },
                 "all": {
                     "$ref": "#/definitions/ExcludeFilterList"
@@ -49,7 +53,7 @@
                 },
                 "NestedForDepth": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 50
+                    "propertyOrder": 51
                 },
                 "Anonymous": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -57,11 +61,11 @@
                 },
                 "MultipleVariableDeclarations": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 47
+                    "propertyOrder": 48
                 },
                 "NestedTryDepth": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 52
+                    "propertyOrder": 53
                 },
                 "BlockBreakingConditional": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -81,7 +85,7 @@
                 },
                 "ReturnCount": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 63
+                    "propertyOrder": 64
                 },
                 "DefaultComesLast": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -93,7 +97,7 @@
                 },
                 "WhitespaceAfter": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 83
+                    "propertyOrder": 84
                 },
                 "ConstantName": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -109,19 +113,19 @@
                 },
                 "WhitespaceAround": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 84
+                    "propertyOrder": 85
                 },
                 "NestedIfDepth": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 51
+                    "propertyOrder": 52
                 },
                 "ParameterName": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 56
+                    "propertyOrder": 57
                 },
                 "NullableParameter": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 53
+                    "propertyOrder": 54
                 },
                 "AvoidStarImport": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -129,7 +133,7 @@
                 },
                 "SeparatorWrap": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 66
+                    "propertyOrder": 67
                 },
                 "AvoidIdentifier": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -137,7 +141,7 @@
                 },
                 "RedundantAllowMeta": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 60
+                    "propertyOrder": 61
                 },
                 "HiddenField": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -145,11 +149,11 @@
                 },
                 "UnnecessaryConstructor": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 78
+                    "propertyOrder": 79
                 },
                 "SimplifyBooleanExpression": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 67
+                    "propertyOrder": 68
                 },
                 "path": {
                     "description": "filters excludes relative to\n\t- RELATIVE_TO_PROJECT = use project root\n\t- RELATIVE_TO_SOURCE = use path(s) specified via \"-s <path>\" command line switches",
@@ -161,23 +165,23 @@
                 },
                 "MethodCount": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 42
+                    "propertyOrder": 43
                 },
                 "UnusedLocalVar": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 80
+                    "propertyOrder": 81
                 },
                 "TabForAligning": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 72
+                    "propertyOrder": 73
                 },
                 "MethodName": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 44
+                    "propertyOrder": 45
                 },
                 "RightCurly": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 64
+                    "propertyOrder": 65
                 },
                 "AvoidTernaryOperator": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -185,7 +189,7 @@
                 },
                 "ParameterNumber": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 57
+                    "propertyOrder": 58
                 },
                 "ArrowFunction": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -193,7 +197,7 @@
                 },
                 "MethodLength": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 43
+                    "propertyOrder": 44
                 },
                 "ConditionalCompilation": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -205,7 +209,7 @@
                 },
                 "MemberName": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 41
+                    "propertyOrder": 42
                 },
                 "ERegLiteral": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -213,15 +217,15 @@
                 },
                 "RedundantModifier": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 61
+                    "propertyOrder": 62
                 },
                 "Type": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 75
+                    "propertyOrder": 76
                 },
                 "TypeName": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 77
+                    "propertyOrder": 78
                 },
                 "Indentation": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -242,31 +246,31 @@
                 },
                 "Return": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 62
+                    "propertyOrder": 63
                 },
                 "SimplifyBooleanReturn": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 68
+                    "propertyOrder": 69
                 },
                 "TODOComment": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 71
+                    "propertyOrder": 72
                 },
                 "VarTypeHint": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 81
+                    "propertyOrder": 82
                 },
                 "NestedControlFlow": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 49
+                    "propertyOrder": 50
                 },
                 "OperatorWhitespace": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 54
+                    "propertyOrder": 55
                 },
                 "Spacing": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 69
+                    "propertyOrder": 70
                 },
                 "IndentationCharacter": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -274,7 +278,7 @@
                 },
                 "MagicNumber": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 40
+                    "propertyOrder": 41
                 },
                 "ArrayLiteral": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -282,11 +286,11 @@
                 },
                 "TrailingWhitespace": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 74
+                    "propertyOrder": 75
                 },
                 "VariableInitialisation": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 82
+                    "propertyOrder": 83
                 },
                 "LineLength": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -306,11 +310,11 @@
                 },
                 "StringLiteral": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 70
+                    "propertyOrder": 71
                 },
                 "Trace": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 73
+                    "propertyOrder": 74
                 },
                 "ArrayAccess": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -318,7 +322,7 @@
                 },
                 "PublicAccessor": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 58
+                    "propertyOrder": 59
                 },
                 "DocCommentStyle": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -330,7 +334,7 @@
                 },
                 "RedundantAccessMeta": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 59
+                    "propertyOrder": 60
                 },
                 "CodeSimilarity": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -338,11 +342,11 @@
                 },
                 "OperatorWrap": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 55
+                    "propertyOrder": 56
                 },
                 "TypeDocComment": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 76
+                    "propertyOrder": 77
                 },
                 "LeftCurly": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -350,7 +354,7 @@
                 },
                 "ModifierOrder": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 45
+                    "propertyOrder": 46
                 },
                 "FieldDocComment": {
                     "$ref": "#/definitions/ExcludeFilterList",

--- a/resources/checkstyle-excludes-schema.json
+++ b/resources/checkstyle-excludes-schema.json
@@ -1,199 +1,48 @@
 {
+    "$schema": "http://json-schema.org/schema#",
     "definitions": {
+        "ExcludeFilterList": {
+            "description": "list of path filters, e.g.\n\t- full type names\n\t- names of individual folder or subfolders\n\t- partial folder or type names\n\n\teach line can have an additional range specification:\n\t- \":<linenumber>\" = only matches a specific line number - valid line number start at 1\n\t- \":<start>-<end>\" = matches line numbers from <start> to <end> (including both)\n\t- \":<identifier>\" = matches any line or block that has <identifier> name (Haxe keywords currently unsupported)",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
         "ExcludeConfig": {
+            "description": "defines filters to exclude folders, types or files from all or specific checks",
+            "additionalProperties": false,
             "properties": {
                 "": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 3
                 },
-                "NestedControlFlow": {
+                "UnusedImport": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 50
+                    "propertyOrder": 80
                 },
-                "TypeDocComment": {
+                "Dynamic": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 77
+                    "propertyOrder": 20
                 },
-                "Interface": {
+                "Final": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 35
-                },
-                "InnerAssignment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 34
-                },
-                "CodeSimilarity": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 13
-                },
-                "AvoidIdentifier": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 8
-                },
-                "version": {
-                    "minimum": 1,
-                    "type": "integer",
-                    "maximum": 1
-                },
-                "ConditionalCompilation": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 15
-                },
-                "TODOComment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 72
-                },
-                "MultipleVariableDeclarations": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 48
-                },
-                "LeftCurly": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 36
-                },
-                "HiddenField": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 31
-                },
-                "Spacing": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 70
-                },
-                "PublicAccessor": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 59
-                },
-                "LineLength": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 37
-                },
-                "Indentation": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 32
-                },
-                "SeparatorWrap": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 67
-                },
-                "ListenerName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 38
-                },
-                "MagicNumber": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 41
-                },
-                "EmptyLines": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 23
-                },
-                "RedundantAccessMeta": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 60
-                },
-                "ERegLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 21
-                },
-                "LongNumber": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 40
-                },
-                "Trace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 74
-                },
-                "StringLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 71
-                },
-                "WhitespaceAround": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 85
-                },
-                "RightCurly": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 65
-                },
-                "AvoidStarImport": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 9
+                    "propertyOrder": 29
                 },
                 "MultipleStringLiterals": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 47
                 },
-                "EmptyBlock": {
+                "LongNumber": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 22
+                    "propertyOrder": 40
                 },
-                "TabForAligning": {
+                "NeedBraces": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 73
-                },
-                "DefaultComesLast": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 18
-                },
-                "path": {
-                    "description": "filters excludes relative to\n\t- RELATIVE_TO_PROJECT = use project root\n\t- RELATIVE_TO_SOURCE = use path(s) specified via \"-s <path>\" command line switches",
-                    "enum": [
-                        "RELATIVE_TO_PROJECT",
-                        "RELATIVE_TO_SOURCE"
-                    ],
-                    "type": "string"
-                },
-                "WhitespaceAfter": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 84
-                },
-                "NestedTryDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 53
-                },
-                "TypeName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 78
-                },
-                "NestedIfDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 52
-                },
-                "TrailingWhitespace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 75
-                },
-                "VariableInitialisation": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 83
-                },
-                "RedundantAllowMeta": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 61
-                },
-                "OperatorWhitespace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 55
-                },
-                "VarTypeHint": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 82
-                },
-                "BlockBreakingConditional": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 11
+                    "propertyOrder": 49
                 },
                 "SeparatorWhitespace": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 66
-                },
-                "NestedForDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 51
-                },
-                "ArrowFunction": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 7
                 },
                 "all": {
                     "$ref": "#/definitions/ExcludeFilterList"
@@ -202,105 +51,137 @@
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 39
                 },
-                "Dynamic": {
+                "NestedForDepth": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 20
-                },
-                "FileNameCase": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 28
-                },
-                "NeedBraces": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 49
+                    "propertyOrder": 51
                 },
                 "Anonymous": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 4
                 },
-                "Final": {
+                "MultipleVariableDeclarations": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 29
+                    "propertyOrder": 48
                 },
-                "MethodName": {
+                "NestedTryDepth": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 45
+                    "propertyOrder": 53
+                },
+                "BlockBreakingConditional": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 11
                 },
                 "CatchParameterName": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 12
                 },
-                "CyclomaticComplexity": {
+                "EmptyBlock": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 17
+                    "propertyOrder": 22
                 },
-                "IndentationCharacter": {
+                "ExtendedEmptyLines": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 33
-                },
-                "MethodCount": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 43
-                },
-                "SimplifyBooleanExpression": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 68
-                },
-                "MethodLength": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 44
-                },
-                "ArrayLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 6
-                },
-                "CommentedOutCode": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 14
-                },
-                "NullableParameter": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 54
-                },
-                "UnusedLocalVar": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 81
-                },
-                "SimplifyBooleanReturn": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 69
-                },
-                "ArrayAccess": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 5
+                    "propertyOrder": 25
                 },
                 "ReturnCount": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 64
                 },
-                "FileLength": {
+                "DefaultComesLast": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 27
+                    "propertyOrder": 18
                 },
-                "FieldDocComment": {
+                "HexadecimalLiteral": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 26
+                    "propertyOrder": 30
                 },
-                "UnusedImport": {
+                "WhitespaceAfter": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 80
+                    "propertyOrder": 84
                 },
-                "ModifierOrder": {
+                "ConstantName": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 46
+                    "propertyOrder": 16
                 },
-                "Type": {
+                "EmptyPackage": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 76
+                    "propertyOrder": 24
                 },
-                "OperatorWrap": {
+                "Interface": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 56
+                    "propertyOrder": 35
+                },
+                "WhitespaceAround": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 85
+                },
+                "NestedIfDepth": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 52
+                },
+                "ParameterName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 57
+                },
+                "NullableParameter": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 54
+                },
+                "AvoidStarImport": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 9
+                },
+                "SeparatorWrap": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 67
+                },
+                "AvoidIdentifier": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 8
+                },
+                "RedundantAllowMeta": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 61
+                },
+                "HiddenField": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 31
+                },
+                "UnnecessaryConstructor": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 79
+                },
+                "SimplifyBooleanExpression": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 68
+                },
+                "path": {
+                    "description": "filters excludes relative to\n\t- RELATIVE_TO_PROJECT = use project root\n\t- RELATIVE_TO_SOURCE = use path(s) specified via \"-s <path>\" command line switches",
+                    "type": "string",
+                    "enum": [
+                        "RELATIVE_TO_PROJECT",
+                        "RELATIVE_TO_SOURCE"
+                    ]
+                },
+                "MethodCount": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 43
+                },
+                "UnusedLocalVar": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 81
+                },
+                "TabForAligning": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 73
+                },
+                "MethodName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 45
+                },
+                "RightCurly": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 65
                 },
                 "AvoidTernaryOperator": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -310,60 +191,179 @@
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 58
                 },
-                "ConstantName": {
+                "ArrowFunction": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 16
+                    "propertyOrder": 7
                 },
-                "Return": {
+                "MethodLength": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 63
+                    "propertyOrder": 44
                 },
-                "EmptyPackage": {
+                "ConditionalCompilation": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 24
+                    "propertyOrder": 15
                 },
-                "DocCommentStyle": {
+                "EmptyLines": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 19
-                },
-                "ParameterName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 57
-                },
-                "RedundantModifier": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 62
+                    "propertyOrder": 23
                 },
                 "MemberName": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 42
                 },
-                "HexadecimalLiteral": {
+                "ERegLiteral": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 30
+                    "propertyOrder": 21
                 },
-                "ExtendedEmptyLines": {
+                "RedundantModifier": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 25
+                    "propertyOrder": 62
                 },
-                "UnnecessaryConstructor": {
+                "Type": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 79
+                    "propertyOrder": 76
+                },
+                "TypeName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 78
+                },
+                "Indentation": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 32
+                },
+                "FileNameCase": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 28
+                },
+                "CommentedOutCode": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 14
+                },
+                "version": {
+                    "maximum": 1,
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "Return": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 63
+                },
+                "SimplifyBooleanReturn": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 69
+                },
+                "TODOComment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 72
+                },
+                "VarTypeHint": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 82
+                },
+                "NestedControlFlow": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 50
+                },
+                "OperatorWhitespace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 55
+                },
+                "Spacing": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 70
+                },
+                "IndentationCharacter": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 33
+                },
+                "MagicNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 41
+                },
+                "ArrayLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 6
+                },
+                "TrailingWhitespace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 75
+                },
+                "VariableInitialisation": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 83
+                },
+                "LineLength": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 37
+                },
+                "ListenerName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 38
+                },
+                "FileLength": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 27
+                },
+                "CyclomaticComplexity": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 17
+                },
+                "StringLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 71
+                },
+                "Trace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 74
+                },
+                "ArrayAccess": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 5
+                },
+                "PublicAccessor": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 59
+                },
+                "DocCommentStyle": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 19
+                },
+                "InnerAssignment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 34
+                },
+                "RedundantAccessMeta": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 60
+                },
+                "CodeSimilarity": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 13
+                },
+                "OperatorWrap": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 56
+                },
+                "TypeDocComment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 77
+                },
+                "LeftCurly": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 36
+                },
+                "ModifierOrder": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 46
+                },
+                "FieldDocComment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 26
                 }
             },
-            "description": "defines filters to exclude folders, types or files from all or specific checks",
-            "additionalProperties": false,
             "type": "object"
-        },
-        "ExcludeFilterList": {
-            "description": "list of path filters, e.g.\n\t- full type names\n\t- names of individual folder or subfolders\n\t- partial folder or type names\n\n\teach line can have an additional range specification:\n\t- \":<linenumber>\" = only matches a specific line number - valid line number start at 1\n\t- \":<start>-<end>\" = matches line numbers from <start> to <end> (including both)\n\t- \":<identifier>\" = matches any line or block that has <identifier> name (Haxe keywords currently unsupported)",
-            "items": {
-                "type": "string"
-            },
-            "type": "array"
         }
     },
     "$ref": "#/definitions/ExcludeConfig",
-    "id": "https://raw.githubusercontent.com/HaxeCheckstyle/haxe-checkstyle/dev/resources/checkstyle-excludes-schema.json",
-    "$schema": "http://json-schema.org/schema#"
+    "id": "https://raw.githubusercontent.com/HaxeCheckstyle/haxe-checkstyle/dev/resources/checkstyle-excludes-schema.json"
 }

--- a/resources/checkstyle-excludes-schema.json
+++ b/resources/checkstyle-excludes-schema.json
@@ -1,288 +1,163 @@
 {
-    "$schema": "http://json-schema.org/schema#",
     "definitions": {
-        "ExcludeFilterList": {
-            "description": "list of path filters, e.g.\n\t- full type names\n\t- names of individual folder or subfolders\n\t- partial folder or type names\n\n\teach line can have an additional range specification:\n\t- \":<linenumber>\" = only matches a specific line number - valid line number start at 1\n\t- \":<start>-<end>\" = matches line numbers from <start> to <end> (including both)\n\t- \":<identifier>\" = matches any line or block that has <identifier> name (Haxe keywords currently unsupported)",
-            "items": {
-                "type": "string"
-            },
-            "type": "array"
-        },
         "ExcludeConfig": {
-            "description": "defines filters to exclude folders, types or files from all or specific checks",
-            "additionalProperties": false,
             "properties": {
                 "": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 3
                 },
-                "UnusedImport": {
+                "NestedControlFlow": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 80
+                    "propertyOrder": 50
                 },
-                "Dynamic": {
+                "TypeDocComment": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 20
-                },
-                "Final": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 29
-                },
-                "MultipleStringLiterals": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 47
-                },
-                "LongNumber": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 40
-                },
-                "NeedBraces": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 49
-                },
-                "SeparatorWhitespace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 66
-                },
-                "all": {
-                    "$ref": "#/definitions/ExcludeFilterList"
-                },
-                "LocalVariableName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 39
-                },
-                "NestedForDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 51
-                },
-                "Anonymous": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 4
-                },
-                "MultipleVariableDeclarations": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 48
-                },
-                "NestedTryDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 53
-                },
-                "BlockBreakingConditional": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 11
-                },
-                "CatchParameterName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 12
-                },
-                "EmptyBlock": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 22
-                },
-                "ExtendedEmptyLines": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 25
-                },
-                "ReturnCount": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 64
-                },
-                "DefaultComesLast": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 18
-                },
-                "HexadecimalLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 30
-                },
-                "WhitespaceAfter": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 84
-                },
-                "ConstantName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 16
-                },
-                "EmptyPackage": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 24
+                    "propertyOrder": 77
                 },
                 "Interface": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 35
                 },
-                "WhitespaceAround": {
+                "InnerAssignment": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 85
+                    "propertyOrder": 34
                 },
-                "NestedIfDepth": {
+                "CodeSimilarity": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 52
-                },
-                "ParameterName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 57
-                },
-                "NullableParameter": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 54
-                },
-                "AvoidStarImport": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 9
-                },
-                "SeparatorWrap": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 67
+                    "propertyOrder": 13
                 },
                 "AvoidIdentifier": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 8
                 },
-                "RedundantAllowMeta": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 61
-                },
-                "HiddenField": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 31
-                },
-                "UnnecessaryConstructor": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 79
-                },
-                "SimplifyBooleanExpression": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 68
-                },
-                "path": {
-                    "description": "filters excludes relative to\n\t- RELATIVE_TO_PROJECT = use project root\n\t- RELATIVE_TO_SOURCE = use path(s) specified via \"-s <path>\" command line switches",
-                    "type": "string",
-                    "enum": [
-                        "RELATIVE_TO_PROJECT",
-                        "RELATIVE_TO_SOURCE"
-                    ]
-                },
-                "MethodCount": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 43
-                },
-                "UnusedLocalVar": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 81
-                },
-                "TabForAligning": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 73
-                },
-                "MethodName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 45
-                },
-                "RightCurly": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 65
-                },
-                "AvoidTernaryOperator": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 10
-                },
-                "ParameterNumber": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 58
-                },
-                "ArrowFunction": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 7
-                },
-                "MethodLength": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 44
+                "version": {
+                    "minimum": 1,
+                    "type": "integer",
+                    "maximum": 1
                 },
                 "ConditionalCompilation": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 15
                 },
-                "EmptyLines": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 23
-                },
-                "MemberName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 42
-                },
-                "ERegLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 21
-                },
-                "RedundantModifier": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 62
-                },
-                "Type": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 76
-                },
-                "TypeName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 78
-                },
-                "Indentation": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 32
-                },
-                "FileNameCase": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 28
-                },
-                "CommentedOutCode": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 14
-                },
-                "version": {
-                    "maximum": 1,
-                    "type": "integer",
-                    "minimum": 1
-                },
-                "Return": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 63
-                },
-                "SimplifyBooleanReturn": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 69
-                },
                 "TODOComment": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 72
                 },
-                "VarTypeHint": {
+                "MultipleVariableDeclarations": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 82
+                    "propertyOrder": 48
                 },
-                "NestedControlFlow": {
+                "LeftCurly": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 50
+                    "propertyOrder": 36
                 },
-                "OperatorWhitespace": {
+                "HiddenField": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 55
+                    "propertyOrder": 31
                 },
                 "Spacing": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 70
                 },
-                "IndentationCharacter": {
+                "PublicAccessor": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 33
+                    "propertyOrder": 59
+                },
+                "LineLength": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 37
+                },
+                "Indentation": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 32
+                },
+                "SeparatorWrap": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 67
+                },
+                "ListenerName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 38
                 },
                 "MagicNumber": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 41
                 },
-                "ArrayLiteral": {
+                "EmptyLines": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 6
+                    "propertyOrder": 23
+                },
+                "RedundantAccessMeta": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 60
+                },
+                "ERegLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 21
+                },
+                "LongNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 40
+                },
+                "Trace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 74
+                },
+                "StringLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 71
+                },
+                "WhitespaceAround": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 85
+                },
+                "RightCurly": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 65
+                },
+                "AvoidStarImport": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 9
+                },
+                "MultipleStringLiterals": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 47
+                },
+                "EmptyBlock": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 22
+                },
+                "TabForAligning": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 73
+                },
+                "DefaultComesLast": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 18
+                },
+                "path": {
+                    "description": "filters excludes relative to\n\t- RELATIVE_TO_PROJECT = use project root\n\t- RELATIVE_TO_SOURCE = use path(s) specified via \"-s <path>\" command line switches",
+                    "enum": [
+                        "RELATIVE_TO_PROJECT",
+                        "RELATIVE_TO_SOURCE"
+                    ],
+                    "type": "string"
+                },
+                "WhitespaceAfter": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 84
+                },
+                "NestedTryDepth": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 53
+                },
+                "TypeName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 78
+                },
+                "NestedIfDepth": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 52
                 },
                 "TrailingWhitespace": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -292,78 +167,203 @@
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 83
                 },
-                "LineLength": {
+                "RedundantAllowMeta": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 37
+                    "propertyOrder": 61
                 },
-                "ListenerName": {
+                "OperatorWhitespace": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 38
+                    "propertyOrder": 55
                 },
-                "FileLength": {
+                "VarTypeHint": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 27
+                    "propertyOrder": 82
+                },
+                "BlockBreakingConditional": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 11
+                },
+                "SeparatorWhitespace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 66
+                },
+                "NestedForDepth": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 51
+                },
+                "ArrowFunction": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 7
+                },
+                "all": {
+                    "$ref": "#/definitions/ExcludeFilterList"
+                },
+                "LocalVariableName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 39
+                },
+                "Dynamic": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 20
+                },
+                "FileNameCase": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 28
+                },
+                "NeedBraces": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 49
+                },
+                "Anonymous": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 4
+                },
+                "Final": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 29
+                },
+                "MethodName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 45
+                },
+                "CatchParameterName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 12
                 },
                 "CyclomaticComplexity": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 17
                 },
-                "StringLiteral": {
+                "IndentationCharacter": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 71
+                    "propertyOrder": 33
                 },
-                "Trace": {
+                "MethodCount": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 74
+                    "propertyOrder": 43
+                },
+                "SimplifyBooleanExpression": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 68
+                },
+                "MethodLength": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 44
+                },
+                "ArrayLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 6
+                },
+                "CommentedOutCode": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 14
+                },
+                "NullableParameter": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 54
+                },
+                "UnusedLocalVar": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 81
+                },
+                "SimplifyBooleanReturn": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 69
                 },
                 "ArrayAccess": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 5
                 },
-                "PublicAccessor": {
+                "ReturnCount": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 59
+                    "propertyOrder": 64
                 },
-                "DocCommentStyle": {
+                "FileLength": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 19
+                    "propertyOrder": 27
                 },
-                "InnerAssignment": {
+                "FieldDocComment": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 34
+                    "propertyOrder": 26
                 },
-                "RedundantAccessMeta": {
+                "UnusedImport": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 60
-                },
-                "CodeSimilarity": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 13
-                },
-                "OperatorWrap": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 56
-                },
-                "TypeDocComment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 77
-                },
-                "LeftCurly": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 36
+                    "propertyOrder": 80
                 },
                 "ModifierOrder": {
                     "$ref": "#/definitions/ExcludeFilterList",
                     "propertyOrder": 46
                 },
-                "FieldDocComment": {
+                "Type": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 26
+                    "propertyOrder": 76
+                },
+                "OperatorWrap": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 56
+                },
+                "AvoidTernaryOperator": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 10
+                },
+                "ParameterNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 58
+                },
+                "ConstantName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 16
+                },
+                "Return": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 63
+                },
+                "EmptyPackage": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 24
+                },
+                "DocCommentStyle": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 19
+                },
+                "ParameterName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 57
+                },
+                "RedundantModifier": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 62
+                },
+                "MemberName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 42
+                },
+                "HexadecimalLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 30
+                },
+                "ExtendedEmptyLines": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 25
+                },
+                "UnnecessaryConstructor": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 79
                 }
             },
+            "description": "defines filters to exclude folders, types or files from all or specific checks",
+            "additionalProperties": false,
             "type": "object"
+        },
+        "ExcludeFilterList": {
+            "description": "list of path filters, e.g.\n\t- full type names\n\t- names of individual folder or subfolders\n\t- partial folder or type names\n\n\teach line can have an additional range specification:\n\t- \":<linenumber>\" = only matches a specific line number - valid line number start at 1\n\t- \":<start>-<end>\" = matches line numbers from <start> to <end> (including both)\n\t- \":<identifier>\" = matches any line or block that has <identifier> name (Haxe keywords currently unsupported)",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
         }
     },
     "$ref": "#/definitions/ExcludeConfig",
-    "id": "https://raw.githubusercontent.com/HaxeCheckstyle/haxe-checkstyle/dev/resources/checkstyle-excludes-schema.json"
+    "id": "https://raw.githubusercontent.com/HaxeCheckstyle/haxe-checkstyle/dev/resources/checkstyle-excludes-schema.json",
+    "$schema": "http://json-schema.org/schema#"
 }

--- a/resources/checkstyle-schema.json
+++ b/resources/checkstyle-schema.json
@@ -3040,6 +3040,46 @@
             },
             "type": "object"
         },
+        "LongNumberCheck": {
+            "description": "Checks that there are no long decimal numbers without separators.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that there are no long decimal numbers without separators.",
+                    "type": "string",
+                    "enum": [
+                        "LongNumber"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that there are no long decimal numbers without separators.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreNumbers": {
+                            "description": "list of long numbers to ignore during checks",
+                            "items": {
+                                "type": "number"
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
         "ExcludeConfig": {
             "description": "defines filters to exclude folders, types or files from all or specific checks",
             "additionalProperties": false,
@@ -3050,7 +3090,7 @@
                 },
                 "UnusedImport": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 79
+                    "propertyOrder": 80
                 },
                 "Dynamic": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3062,15 +3102,19 @@
                 },
                 "MultipleStringLiterals": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 46
+                    "propertyOrder": 47
+                },
+                "LongNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 40
                 },
                 "NeedBraces": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 48
+                    "propertyOrder": 49
                 },
                 "SeparatorWhitespace": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 65
+                    "propertyOrder": 66
                 },
                 "all": {
                     "$ref": "#/definitions/ExcludeFilterList"
@@ -3081,7 +3125,7 @@
                 },
                 "NestedForDepth": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 50
+                    "propertyOrder": 51
                 },
                 "Anonymous": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3089,11 +3133,11 @@
                 },
                 "MultipleVariableDeclarations": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 47
+                    "propertyOrder": 48
                 },
                 "NestedTryDepth": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 52
+                    "propertyOrder": 53
                 },
                 "BlockBreakingConditional": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3113,7 +3157,7 @@
                 },
                 "ReturnCount": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 63
+                    "propertyOrder": 64
                 },
                 "DefaultComesLast": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3125,7 +3169,7 @@
                 },
                 "WhitespaceAfter": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 83
+                    "propertyOrder": 84
                 },
                 "ConstantName": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3141,19 +3185,19 @@
                 },
                 "WhitespaceAround": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 84
+                    "propertyOrder": 85
                 },
                 "NestedIfDepth": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 51
+                    "propertyOrder": 52
                 },
                 "ParameterName": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 56
+                    "propertyOrder": 57
                 },
                 "NullableParameter": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 53
+                    "propertyOrder": 54
                 },
                 "AvoidStarImport": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3161,7 +3205,7 @@
                 },
                 "SeparatorWrap": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 66
+                    "propertyOrder": 67
                 },
                 "AvoidIdentifier": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3169,7 +3213,7 @@
                 },
                 "RedundantAllowMeta": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 60
+                    "propertyOrder": 61
                 },
                 "HiddenField": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3177,11 +3221,11 @@
                 },
                 "UnnecessaryConstructor": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 78
+                    "propertyOrder": 79
                 },
                 "SimplifyBooleanExpression": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 67
+                    "propertyOrder": 68
                 },
                 "path": {
                     "description": "filters excludes relative to\n\t- RELATIVE_TO_PROJECT = use project root\n\t- RELATIVE_TO_SOURCE = use path(s) specified via \"-s <path>\" command line switches",
@@ -3193,23 +3237,23 @@
                 },
                 "MethodCount": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 42
+                    "propertyOrder": 43
                 },
                 "UnusedLocalVar": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 80
+                    "propertyOrder": 81
                 },
                 "TabForAligning": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 72
+                    "propertyOrder": 73
                 },
                 "MethodName": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 44
+                    "propertyOrder": 45
                 },
                 "RightCurly": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 64
+                    "propertyOrder": 65
                 },
                 "AvoidTernaryOperator": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3217,7 +3261,7 @@
                 },
                 "ParameterNumber": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 57
+                    "propertyOrder": 58
                 },
                 "ArrowFunction": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3225,7 +3269,7 @@
                 },
                 "MethodLength": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 43
+                    "propertyOrder": 44
                 },
                 "ConditionalCompilation": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3237,7 +3281,7 @@
                 },
                 "MemberName": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 41
+                    "propertyOrder": 42
                 },
                 "ERegLiteral": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3245,15 +3289,15 @@
                 },
                 "RedundantModifier": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 61
+                    "propertyOrder": 62
                 },
                 "Type": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 75
+                    "propertyOrder": 76
                 },
                 "TypeName": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 77
+                    "propertyOrder": 78
                 },
                 "Indentation": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3274,31 +3318,31 @@
                 },
                 "Return": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 62
+                    "propertyOrder": 63
                 },
                 "SimplifyBooleanReturn": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 68
+                    "propertyOrder": 69
                 },
                 "TODOComment": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 71
+                    "propertyOrder": 72
                 },
                 "VarTypeHint": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 81
+                    "propertyOrder": 82
                 },
                 "NestedControlFlow": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 49
+                    "propertyOrder": 50
                 },
                 "OperatorWhitespace": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 54
+                    "propertyOrder": 55
                 },
                 "Spacing": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 69
+                    "propertyOrder": 70
                 },
                 "IndentationCharacter": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3306,7 +3350,7 @@
                 },
                 "MagicNumber": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 40
+                    "propertyOrder": 41
                 },
                 "ArrayLiteral": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3314,11 +3358,11 @@
                 },
                 "TrailingWhitespace": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 74
+                    "propertyOrder": 75
                 },
                 "VariableInitialisation": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 82
+                    "propertyOrder": 83
                 },
                 "LineLength": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3338,11 +3382,11 @@
                 },
                 "StringLiteral": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 70
+                    "propertyOrder": 71
                 },
                 "Trace": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 73
+                    "propertyOrder": 74
                 },
                 "ArrayAccess": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3350,7 +3394,7 @@
                 },
                 "PublicAccessor": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 58
+                    "propertyOrder": 59
                 },
                 "DocCommentStyle": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3362,7 +3406,7 @@
                 },
                 "RedundantAccessMeta": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 59
+                    "propertyOrder": 60
                 },
                 "CodeSimilarity": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3370,11 +3414,11 @@
                 },
                 "OperatorWrap": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 55
+                    "propertyOrder": 56
                 },
                 "TypeDocComment": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 76
+                    "propertyOrder": 77
                 },
                 "LeftCurly": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -3382,7 +3426,7 @@
                 },
                 "ModifierOrder": {
                     "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 45
+                    "propertyOrder": 46
                 },
                 "FieldDocComment": {
                     "$ref": "#/definitions/ExcludeFilterList",
@@ -4423,6 +4467,9 @@
                             },
                             {
                                 "$ref": "#/definitions/LocalVariableNameCheck"
+                            },
+                            {
+                                "$ref": "#/definitions/LongNumberCheck"
                             },
                             {
                                 "$ref": "#/definitions/MagicNumberCheck"

--- a/resources/checkstyle-schema.json
+++ b/resources/checkstyle-schema.json
@@ -1,177 +1,1165 @@
 {
-    "$schema": "http://json-schema.org/schema#",
     "definitions": {
-        "TrailingWhitespaceCheck": {
-            "description": "Checks if there are any trailing white spaces.",
-            "additionalProperties": false,
+        "SpacingCheck": {
             "properties": {
-                "type": {
-                    "description": "Checks if there are any trailing white spaces.",
-                    "type": "string",
-                    "enum": [
-                        "TrailingWhitespace"
-                    ]
-                },
                 "props": {
-                    "description": "Checks if there are any trailing white spaces.",
-                    "additionalProperties": false,
                     "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                        "ignoreRangeOperator": {
+                            "description": "exclude range operator \"...\" from \"spaceAroundBinop\"",
+                            "propertyOrder": 7,
+                            "type": "boolean"
+                        },
+                        "noSpaceAroundUnop": {
+                            "description": "enforce no space around Unop operators (\"++\", \"--\", \"!\", \"-\", \"~\")",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        },
+                        "spaceIfCondition": {
+                            "description": "policy for if statements (space between \"if\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
+                            "propertyOrder": 2,
                             "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
+                                "should",
+                                "should_not",
+                                "any"
                             ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "DynamicCheck": {
-            "description": "Checks for use of Dynamic type anywhere in the code.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for use of Dynamic type anywhere in the code.",
-                    "type": "string",
-                    "enum": [
-                        "Dynamic"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for use of Dynamic type anywhere in the code.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "type": "string"
+                        },
+                        "spaceSwitchCase": {
+                            "description": "policy for switch statements (space between \"switch\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
+                            "propertyOrder": 5,
                             "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
+                                "should",
+                                "should_not",
+                                "any"
                             ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "InterfaceCheck": {
-            "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
-                    "type": "string",
-                    "enum": [
-                        "Interface"
-                    ]
-                },
-                "props": {
-                    "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "allowMarkerInterfaces": {
-                            "description": "allows empty marker interfaces, or forbid their use",
-                            "type": "boolean",
-                            "propertyOrder": 0
+                            "type": "string"
+                        },
+                        "spaceCatch": {
+                            "description": "policy for catch statements (space between \"catch\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
+                            "propertyOrder": 6,
+                            "enum": [
+                                "should",
+                                "should_not",
+                                "any"
+                            ],
+                            "type": "string"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 8,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 2
+                            "type": "string"
                         },
-                        "allowProperties": {
-                            "description": "allow properties inside interface types",
-                            "type": "boolean",
-                            "propertyOrder": 1
+                        "spaceForLoop": {
+                            "description": "policy for for statements (space between \"for\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "should",
+                                "should_not",
+                                "any"
+                            ],
+                            "type": "string"
+                        },
+                        "spaceWhileLoop": {
+                            "description": "policy for while statements (space between while\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
+                            "propertyOrder": 4,
+                            "enum": [
+                                "should",
+                                "should_not",
+                                "any"
+                            ],
+                            "type": "string"
+                        },
+                        "spaceAroundBinop": {
+                            "description": "require space around Binop operators (\"+\", \"-\", \"/\", etc.)",
+                            "propertyOrder": 0,
+                            "type": "boolean"
                         }
                     },
+                    "description": "Spacing check on if, for, while, switch, try statements and around operators.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "Spacing check on if, for, while, switch, try statements and around operators.",
+                    "enum": [
+                        "Spacing"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Spacing check on if, for, while, switch, try statements and around operators.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "BlockBreakingConditionalCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for block breaking conditionals.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for block breaking conditionals.",
+                    "enum": [
+                        "BlockBreakingConditional"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for block breaking conditionals.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "TraceCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for trace calls in code.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for trace calls in code.",
+                    "enum": [
+                        "Trace"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for trace calls in code.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "InnerAssignmentCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "ignoreReturnAssignments": {
+                            "description": "ignores assignments in return statements",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
+                    "enum": [
+                        "InnerAssignment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "MethodNameCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "description": "check applies to:\n\t- PUBLIC = all public methods\n\t- PRIVATE = all private methods\n\t- STATIC = all static methods\n\t- NOTSTATIC = all non static methods\n\t- INLINE = all inline methods\n\t- NOTINLINE = all non-inline methods",
+                                "enum": [
+                                    "PUBLIC",
+                                    "PRIVATE",
+                                    "STATIC",
+                                    "NOTSTATIC",
+                                    "INLINE",
+                                    "NOTINLINE"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 1,
+                            "type": "array"
+                        },
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "propertyOrder": 2,
+                            "type": "boolean"
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "propertyOrder": 0,
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks that method names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that method names conform to a format specified by the `format` property.",
+                    "enum": [
+                        "MethodName"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that method names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "WhitespaceAfterCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "supported list of tokens:\n\t\t\",\", \";\", \"(\", \"[\", \"{\", \":\", \".\", \"=\", \"+\", \"-\", \"*\", \"/\", \"%\", \">\", \"<\", \">=\", \"<=\", \"==\", \"!=\",\n\t\t\"&\", \"|\", \"^\", \"&&\", \"||\", \"<<\", \">>\", \">>>\", \"+=\", \"-=\", \"*=\", \"/=\", \"%=\", \"<<=\", \">>=\", \">>>=\", \"|=\", \"&=\",\n\t\t\"^=\", \"...\", \"=>\", \"!\", \"++\", \"--\",",
+                            "items": {
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        },
+                        "allowTrailingComma": {
+                            "description": "no violoation for missing whitespace after trailing commas",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for whitespace after a token.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for whitespace after a token.",
+                    "enum": [
+                        "WhitespaceAfter"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for whitespace after a token.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "LocalVariableNameCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "type": "string"
+                            },
+                            "propertyOrder": 1,
+                            "type": "array"
+                        },
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "propertyOrder": 2,
+                            "type": "boolean"
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "propertyOrder": 0,
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks that the local variable names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that the local variable names conform to a format specified by the `format` property.",
+                    "enum": [
+                        "LocalVariableName"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that the local variable names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "NestedTryDepthCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of nested try/catch statemenmts allowed\n\t\tsetting \"max\" to 1 allows one inner try/catch",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
+                    "enum": [
+                        "NestedTryDepth"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "UnnecessaryConstructorCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
+                    "enum": [
+                        "UnnecessaryConstructor"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "NestedForDepthCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of nested loops allowed\n\t\tsetting \"max\" to 1 allows one inner loop",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Restricts nested loop blocks to a specified depth (default = 1).",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Restricts nested loop blocks to a specified depth (default = 1).",
+                    "enum": [
+                        "NestedForDepth"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Restricts nested loop blocks to a specified depth (default = 1).",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "HexadecimalLiteralCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "option": {
+                            "description": "policy for hexadecimal literals\n\t\t- upperCase = use uppercase for all letters\n\t\t- lowerCase = use lowercase for all letters",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "upperCase",
+                                "lowerCase"
+                            ],
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks the letter case of hexadecimal literals.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks the letter case of hexadecimal literals.",
+                    "enum": [
+                        "HexadecimalLiteral"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks the letter case of hexadecimal literals.",
+            "additionalProperties": false,
             "type": "object"
         },
         "TabForAligningCheck": {
-            "description": "Checks if there are any tabs in the middle of a line.",
-            "additionalProperties": false,
             "properties": {
-                "type": {
-                    "description": "Checks if there are any tabs in the middle of a line.",
-                    "type": "string",
-                    "enum": [
-                        "TabForAligning"
-                    ]
-                },
                 "props": {
-                    "description": "Checks if there are any tabs in the middle of a line.",
-                    "additionalProperties": false,
                     "properties": {
                         "ignorePattern": {
                             "description": "ignore linex matching regex",
-                            "type": "string",
-                            "propertyOrder": 0
+                            "propertyOrder": 0,
+                            "type": "string"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 1,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 1
+                            "type": "string"
                         }
                     },
+                    "description": "Checks if there are any tabs in the middle of a line.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "Checks if there are any tabs in the middle of a line.",
+                    "enum": [
+                        "TabForAligning"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Checks if there are any tabs in the middle of a line.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "NestedControlFlowCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of nested control flow expressions allowed",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
+                    "enum": [
+                        "NestedControlFlow"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "MethodCountCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "maxPrivate": {
+                            "description": "maximum number of private functions permitted per file (default: 100)",
+                            "propertyOrder": 1,
+                            "type": "integer"
+                        },
+                        "maxPublic": {
+                            "description": "maximum number of public functions permitted per file (default: 100)",
+                            "propertyOrder": 2,
+                            "type": "integer"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "maxTotal": {
+                            "description": "maximum number of functions permitted per file (default: 100)",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        }
+                    },
+                    "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
+                    "enum": [
+                        "MethodCount"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "DocCommentStyleCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "startStyle": {
+                            "description": "Defines how doc comments should start / end:\n\t\t- ignore = accepts any start / end\n\t\t- onestar = /*\n\t\t- twostar = /**",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "ignore",
+                                "none",
+                                "onestar",
+                                "twostars"
+                            ],
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "lineStyle": {
+                            "description": "Defines how each doc comments line should start:\n\t\t- ignore = accepts any line prefix\n\t\t- none =\n\t\t- onestar = *\n\t\t- twostar = **",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "ignore",
+                                "none",
+                                "onestar",
+                                "twostars"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks code documentation style (/**...**/ vs /*...*/)",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks code documentation style (/**...**/ vs /*...*/)",
+                    "enum": [
+                        "DocCommentStyle"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks code documentation style (/**...**/ vs /*...*/)",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ParameterNameCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "type": "string"
+                            },
+                            "propertyOrder": 1,
+                            "type": "array"
+                        },
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "propertyOrder": 2,
+                            "type": "boolean"
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "propertyOrder": 0,
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks that parameter names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that parameter names conform to a format specified by the `format` property.",
+                    "enum": [
+                        "ParameterName"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that parameter names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ExcludeConfig": {
+            "properties": {
+                "": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 3
+                },
+                "NestedControlFlow": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 50
+                },
+                "TypeDocComment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 77
+                },
+                "Interface": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 35
+                },
+                "InnerAssignment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 34
+                },
+                "CodeSimilarity": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 13
+                },
+                "AvoidIdentifier": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 8
+                },
+                "version": {
+                    "minimum": 1,
+                    "type": "integer",
+                    "maximum": 1
+                },
+                "ConditionalCompilation": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 15
+                },
+                "TODOComment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 72
+                },
+                "MultipleVariableDeclarations": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 48
+                },
+                "LeftCurly": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 36
+                },
+                "HiddenField": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 31
+                },
+                "Spacing": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 70
+                },
+                "PublicAccessor": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 59
+                },
+                "LineLength": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 37
+                },
+                "Indentation": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 32
+                },
+                "SeparatorWrap": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 67
+                },
+                "ListenerName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 38
+                },
+                "MagicNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 41
+                },
+                "EmptyLines": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 23
+                },
+                "RedundantAccessMeta": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 60
+                },
+                "ERegLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 21
+                },
+                "LongNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 40
+                },
+                "Trace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 74
+                },
+                "StringLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 71
+                },
+                "WhitespaceAround": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 85
+                },
+                "RightCurly": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 65
+                },
+                "AvoidStarImport": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 9
+                },
+                "MultipleStringLiterals": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 47
+                },
+                "EmptyBlock": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 22
+                },
+                "TabForAligning": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 73
+                },
+                "DefaultComesLast": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 18
+                },
+                "path": {
+                    "description": "filters excludes relative to\n\t- RELATIVE_TO_PROJECT = use project root\n\t- RELATIVE_TO_SOURCE = use path(s) specified via \"-s <path>\" command line switches",
+                    "enum": [
+                        "RELATIVE_TO_PROJECT",
+                        "RELATIVE_TO_SOURCE"
+                    ],
+                    "type": "string"
+                },
+                "WhitespaceAfter": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 84
+                },
+                "NestedTryDepth": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 53
+                },
+                "TypeName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 78
+                },
+                "NestedIfDepth": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 52
+                },
+                "TrailingWhitespace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 75
+                },
+                "VariableInitialisation": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 83
+                },
+                "RedundantAllowMeta": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 61
+                },
+                "OperatorWhitespace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 55
+                },
+                "VarTypeHint": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 82
+                },
+                "BlockBreakingConditional": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 11
+                },
+                "SeparatorWhitespace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 66
+                },
+                "NestedForDepth": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 51
+                },
+                "ArrowFunction": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 7
+                },
+                "all": {
+                    "$ref": "#/definitions/ExcludeFilterList"
+                },
+                "LocalVariableName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 39
+                },
+                "Dynamic": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 20
+                },
+                "FileNameCase": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 28
+                },
+                "NeedBraces": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 49
+                },
+                "Anonymous": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 4
+                },
+                "Final": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 29
+                },
+                "MethodName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 45
+                },
+                "CatchParameterName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 12
+                },
+                "CyclomaticComplexity": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 17
+                },
+                "IndentationCharacter": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 33
+                },
+                "MethodCount": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 43
+                },
+                "SimplifyBooleanExpression": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 68
+                },
+                "MethodLength": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 44
+                },
+                "ArrayLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 6
+                },
+                "CommentedOutCode": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 14
+                },
+                "NullableParameter": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 54
+                },
+                "UnusedLocalVar": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 81
+                },
+                "SimplifyBooleanReturn": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 69
+                },
+                "ArrayAccess": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 5
+                },
+                "ReturnCount": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 64
+                },
+                "FileLength": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 27
+                },
+                "FieldDocComment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 26
+                },
+                "UnusedImport": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 80
+                },
+                "ModifierOrder": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 46
+                },
+                "Type": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 76
+                },
+                "OperatorWrap": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 56
+                },
+                "AvoidTernaryOperator": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 10
+                },
+                "ParameterNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 58
+                },
+                "ConstantName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 16
+                },
+                "Return": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 63
+                },
+                "EmptyPackage": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 24
+                },
+                "DocCommentStyle": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 19
+                },
+                "ParameterName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 57
+                },
+                "RedundantModifier": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 62
+                },
+                "MemberName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 42
+                },
+                "HexadecimalLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 30
+                },
+                "ExtendedEmptyLines": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 25
+                },
+                "UnnecessaryConstructor": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 79
+                }
+            },
+            "description": "defines filters to exclude folders, types or files from all or specific checks",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "InterfaceCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "allowMarkerInterfaces": {
+                            "description": "allows empty marker interfaces, or forbid their use",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        },
+                        "allowProperties": {
+                            "description": "allow properties inside interface types",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
+                    "enum": [
+                        "Interface"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "SimplifyBooleanExpressionCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
+                    "enum": [
+                        "SimplifyBooleanExpression"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
+            "additionalProperties": false,
             "type": "object"
         },
         "IndentationCheck": {
-            "description": "Checks correct indentation",
-            "additionalProperties": false,
             "properties": {
-                "type": {
-                    "description": "Checks correct indentation",
-                    "type": "string",
-                    "enum": [
-                        "Indentation"
-                    ]
-                },
                 "props": {
-                    "description": "Checks correct indentation",
-                    "additionalProperties": false,
                     "properties": {
-                        "wrapPolicy": {
-                            "description": "indentation of wrapped statements (= continued on next line)\n\t\t- none = wrapped statements must have the same indentation as parent\n\t\t- exact = wrapped statemenmts must have a +1 indentation in relation to parent\n\t\t- larger = wrapped statements must have a +1 or larger indentation in relation to parent",
-                            "type": "string",
-                            "enum": [
-                                "none",
-                                "exact",
-                                "larger"
-                            ],
-                            "propertyOrder": 4
-                        },
                         "character": {
                             "description": "character sequence to use for indentation\n\t\t- \"tab\" for using tabs\n\t\t- a string containing as many spaces as one indentation level requires",
-                            "type": "string",
+                            "propertyOrder": 0,
                             "enum": [
                                 "tab",
                                 " ",
@@ -183,2556 +1171,232 @@
                                 "       ",
                                 "        "
                             ],
-                            "propertyOrder": 0
+                            "type": "string"
                         },
-                        "ignoreComments": {
-                            "description": "ignore indentation of comments",
-                            "type": "boolean",
-                            "propertyOrder": 3
+                        "ignoreConditionals": {
+                            "description": "ignore indentation of conditionals (same as setting conditionalPolicy to ignore)",
+                            "propertyOrder": 1,
+                            "type": "boolean"
                         },
                         "conditionalPolicy": {
                             "description": "indentation of conditional statements\n\t\t- ignore = ignores conditioonals, same as \"ignoreConditionals\"\n\t\t- fixed_zero = contitionals have to start at the beginning of a line (only where conditional is the first statement)\n\t\t- aligned = align wih surrounding code\n\t\t- aligned_increase = align wih surrounding code and increase indentation of enclosed code by +1",
-                            "type": "string",
+                            "propertyOrder": 2,
                             "enum": [
                                 "ignore",
                                 "fixed_zero",
                                 "aligned",
                                 "aligned_increase"
                             ],
-                            "propertyOrder": 2
+                            "type": "string"
                         },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                        "ignoreComments": {
+                            "description": "ignore indentation of comments",
+                            "propertyOrder": 3,
+                            "type": "boolean"
+                        },
+                        "wrapPolicy": {
+                            "description": "indentation of wrapped statements (= continued on next line)\n\t\t- none = wrapped statements must have the same indentation as parent\n\t\t- exact = wrapped statemenmts must have a +1 indentation in relation to parent\n\t\t- larger = wrapped statements must have a +1 or larger indentation in relation to parent",
+                            "propertyOrder": 4,
                             "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 5
-                        },
-                        "ignoreConditionals": {
-                            "description": "ignore indentation of conditionals (same as setting conditionalPolicy to ignore)",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ArrowFunctionCheck": {
-            "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
-                    "type": "string",
-                    "enum": [
-                        "ArrowFunction"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "allowFunction": {
-                            "description": "allow using `function` inside arrow function bodies",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        },
-                        "allowReturn": {
-                            "description": "allow using `return` inside arrow function bodies",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        },
-                        "allowSingleArgParens": {
-                            "description": "allow using parenthesis around single argument arrow function (`(arg) -> arg * 2`)",
-                            "type": "boolean",
-                            "propertyOrder": 3
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 4
-                        },
-                        "allowCurlyBody": {
-                            "description": "allow using curly block as arrow function body (`{...}`)",
-                            "type": "boolean",
-                            "propertyOrder": 2
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "UnusedLocalVarCheck": {
-            "description": "Checks for unused local variables.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for unused local variables.",
-                    "type": "string",
-                    "enum": [
-                        "UnusedLocalVar"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for unused local variables.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ModifierOrderCheck": {
-            "description": "Checks that the order of modifiers conforms to the standards.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that the order of modifiers conforms to the standards.",
-                    "type": "string",
-                    "enum": [
-                        "ModifierOrder"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that the order of modifiers conforms to the standards.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "modifiers": {
-                            "description": "order in which modifier should occur",
-                            "items": {
-                                "description": "list of modifiers\n\t- PUBLIC_PRIVATE = public / private modifier\n\t- INLINE = inline modifier\n\t- STATIC = static modifier\n\t- OVERRIDE = override modifier\n\t- MACRO = macro modifier\n\t- DYNAMIC = dynamic modifier\n\t- EXTERN = extern modifier\n\t- FINAL = final modifier",
-                                "type": "string",
-                                "enum": [
-                                    "PUBLIC_PRIVATE",
-                                    "INLINE",
-                                    "STATIC",
-                                    "OVERRIDE",
-                                    "MACRO",
-                                    "DYNAMIC",
-                                    "EXTERN",
-                                    "FINAL",
-                                    "ABSTRACT",
-                                    "OVERLOAD"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "StringLiteralCheck": {
-            "description": "Checks for single or double quote string literals.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for single or double quote string literals.",
-                    "type": "string",
-                    "enum": [
-                        "StringLiteral"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for single or double quote string literals.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "policy": {
-                            "description": "policy for string literal use\n\t\t- onlySingle = enforce single quotes\n\t\t- onlyDouble = enforce double quotes, no interpolation allowed\n\t\t- doubleAndInterpolation = enforce double quotes, allow single quotes for interpolation",
-                            "type": "string",
-                            "enum": [
-                                "onlySingle",
-                                "onlyDouble",
-                                "doubleAndInterpolation"
-                            ],
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        },
-                        "allowException": {
-                            "description": "\"allowException\" allows using single quotes in \"onlyDouble\" and \"doubleAndInterpolation\" mode, when string contains a double quote character.\n\t\tOr double quotes in \"onlySingle\" mode when string contains a single quote character, reducing the need to escape quotation marks.",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "DocCommentStyleCheck": {
-            "description": "Checks code documentation style (/**...**/ vs /*...*/)",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks code documentation style (/**...**/ vs /*...*/)",
-                    "type": "string",
-                    "enum": [
-                        "DocCommentStyle"
-                    ]
-                },
-                "props": {
-                    "description": "Checks code documentation style (/**...**/ vs /*...*/)",
-                    "additionalProperties": false,
-                    "properties": {
-                        "lineStyle": {
-                            "description": "Defines how each doc comments line should start:\n\t\t- ignore = accepts any line prefix\n\t\t- none =\n\t\t- onestar = *\n\t\t- twostar = **",
-                            "type": "string",
-                            "enum": [
-                                "ignore",
-                                "none",
-                                "onestar",
-                                "twostars"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        },
-                        "startStyle": {
-                            "description": "Defines how doc comments should start / end:\n\t\t- ignore = accepts any start / end\n\t\t- onestar = /*\n\t\t- twostar = /**",
-                            "type": "string",
-                            "enum": [
-                                "ignore",
-                                "none",
-                                "onestar",
-                                "twostars"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "DefaultComesLastCheck": {
-            "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
-                    "type": "string",
-                    "enum": [
-                        "DefaultComesLast"
-                    ]
-                },
-                "props": {
-                    "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "MethodNameCheck": {
-            "description": "Checks that method names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that method names conform to a format specified by the `format` property.",
-                    "type": "string",
-                    "enum": [
-                        "MethodName"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that method names conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "type": "boolean",
-                            "propertyOrder": 2
-                        },
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "description": "check applies to:\n\t- PUBLIC = all public methods\n\t- PRIVATE = all private methods\n\t- STATIC = all static methods\n\t- NOTSTATIC = all non static methods\n\t- INLINE = all inline methods\n\t- NOTINLINE = all non-inline methods",
-                                "type": "string",
-                                "enum": [
-                                    "PUBLIC",
-                                    "PRIVATE",
-                                    "STATIC",
-                                    "NOTSTATIC",
-                                    "INLINE",
-                                    "NOTINLINE"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "type": "string",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "WhitespaceAfterCheck": {
-            "description": "Checks for whitespace after a token.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for whitespace after a token.",
-                    "type": "string",
-                    "enum": [
-                        "WhitespaceAfter"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for whitespace after a token.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "tokens": {
-                            "description": "supported list of tokens:\n\t\t\",\", \";\", \"(\", \"[\", \"{\", \":\", \".\", \"=\", \"+\", \"-\", \"*\", \"/\", \"%\", \">\", \"<\", \">=\", \"<=\", \"==\", \"!=\",\n\t\t\"&\", \"|\", \"^\", \"&&\", \"||\", \"<<\", \">>\", \">>>\", \"+=\", \"-=\", \"*=\", \"/=\", \"%=\", \"<<=\", \">>=\", \">>>=\", \"|=\", \"&=\",\n\t\t\"^=\", \"...\", \"=>\", \"!\", \"++\", \"--\",",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        },
-                        "allowTrailingComma": {
-                            "description": "no violoation for missing whitespace after trailing commas",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "InnerAssignmentCheck": {
-            "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
-                    "type": "string",
-                    "enum": [
-                        "InnerAssignment"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreReturnAssignments": {
-                            "description": "ignores assignments in return statements",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "MagicNumberCheck": {
-            "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
-                    "type": "string",
-                    "enum": [
-                        "MagicNumber"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreNumbers": {
-                            "description": "list of magic numbers to ignore during checks",
-                            "items": {
-                                "type": "number"
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "FieldDocCommentCheck": {
-            "description": "Checks code documentation on fields",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks code documentation on fields",
-                    "type": "string",
-                    "enum": [
-                        "FieldDocComment"
-                    ]
-                },
-                "props": {
-                    "description": "Checks code documentation on fields",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreOverride": {
-                            "description": "ignores methods marked with override",
-                            "type": "boolean",
-                            "propertyOrder": 5
-                        },
-                        "requireReturn": {
-                            "description": "ignores requires a `@return` tag",
-                            "type": "boolean",
-                            "propertyOrder": 4
-                        },
-                        "requireParams": {
-                            "description": "ignores requires a `@param` tag for every parameter",
-                            "type": "boolean",
-                            "propertyOrder": 3
-                        },
-                        "tokens": {
-                            "description": "matches only comment docs for types specified in tokens list:\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "ABSTRACT_DEF",
-                                    "CLASS_DEF",
-                                    "ENUM_DEF",
-                                    "INTERFACE_DEF",
-                                    "TYPEDEF_DEF"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
-                        "modifier": {
-                            "description": "only check fields matching modifier\n\t\t- PUBLIC = only public fields\n\t\t- PRIVATE = only private fields\n\t\t- BOTH = public and private fields",
-                            "type": "string",
-                            "enum": [
-                                "PUBLIC",
-                                "PRIVATE",
-                                "BOTH"
-                            ],
-                            "propertyOrder": 2
-                        },
-                        "fieldType": {
-                            "description": "only check fields of type\n\t\t- VARS = only var fields\n\t\t- FUNCTIONS = only functions;\n\t\t- BOTH = both vars and functions;",
-                            "type": "string",
-                            "enum": [
-                                "VARS",
-                                "FUNCTIONS",
-                                "BOTH"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 7
-                        },
-                        "excludeNames": {
-                            "description": "exclude field names from check - default: [\"new\", \"toString\"]",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array",
-                            "propertyOrder": 6
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "HexadecimalLiteralCheck": {
-            "description": "Checks the letter case of hexadecimal literals.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks the letter case of hexadecimal literals.",
-                    "type": "string",
-                    "enum": [
-                        "HexadecimalLiteral"
-                    ]
-                },
-                "props": {
-                    "description": "Checks the letter case of hexadecimal literals.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "option": {
-                            "description": "policy for hexadecimal literals\n\t\t- upperCase = use uppercase for all letters\n\t\t- lowerCase = use lowercase for all letters",
-                            "type": "string",
-                            "enum": [
-                                "upperCase",
-                                "lowerCase"
-                            ],
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "LeftCurlyCheck": {
-            "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
-                    "type": "string",
-                    "enum": [
-                        "LeftCurly"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "tokens": {
-                            "description": "matches only left curlys specified in tokens list:\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- OBJECT_DECL = object declaration \"{ x: 0, y: 0, z: 0}\"\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if / else body \"if (test) {} else {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- SWITCH = switch / case body \"switch (test) { case: {} default: {} }\"\n\t\t- TRY = try body \"try {}\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"\n\t\t- REIFICATION = macro reification \"$i{}\"\n\t\t- ARRAY_COMPREHENSION = array comprehension \"[for (i in 0...10) {i * 2}]\"",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "CLASS_DEF",
-                                    "ENUM_DEF",
-                                    "ABSTRACT_DEF",
-                                    "TYPEDEF_DEF",
-                                    "INTERFACE_DEF",
-                                    "ANON_TYPE",
-                                    "OBJECT_DECL",
-                                    "FUNCTION",
-                                    "FOR",
-                                    "IF",
-                                    "WHILE",
-                                    "SWITCH",
-                                    "TRY",
-                                    "CATCH",
-                                    "REIFICATION",
-                                    "ARRAY_COMPREHENSION"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
-                        "ignoreSingleline": {
-                            "description": "allow single line blocks",
-                            "type": "boolean",
-                            "propertyOrder": 3
-                        },
-                        "option": {
-                            "description": "placement of left curly\n\t\t- eol = should occur at end of line\n\t\t- nl = should occur on a new line\n\t\t- nlow = should occur at end of line unless in wrapped code, then it should occur on a new line",
-                            "type": "string",
-                            "enum": [
-                                "eol",
-                                "nl",
-                                "nlow"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 4
-                        },
-                        "ignoreEmptySingleline": {
-                            "description": "allow empty single line blocks",
-                            "type": "boolean",
-                            "propertyOrder": 2
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "FileLengthCheck": {
-            "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
-                    "type": "string",
-                    "enum": [
-                        "FileLength"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of lines permitted per file (default: 2000)",
-                            "type": "integer",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        },
-                        "ignoreEmptyLines": {
-                            "description": "ignores or includes empty lines when counting total file length",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ConstantNameCheck": {
-            "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
-                    "type": "string",
-                    "enum": [
-                        "ConstantName"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "type": "boolean",
-                            "propertyOrder": 2
-                        },
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "description": "supports inline and non inline constants\n\t- INLINE = \"static inline var\"\n\t- NOTINLINE = \"static var\"",
-                                "type": "string",
-                                "enum": [
-                                    "INLINE",
-                                    "NOTINLINE"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "type": "string",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "LocalVariableNameCheck": {
-            "description": "Checks that the local variable names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that the local variable names conform to a format specified by the `format` property.",
-                    "type": "string",
-                    "enum": [
-                        "LocalVariableName"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that the local variable names conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "type": "boolean",
-                            "propertyOrder": 2
-                        },
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "type": "string",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ParameterNumberCheck": {
-            "description": "Checks the number of parameters of a method.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks the number of parameters of a method.",
-                    "type": "string",
-                    "enum": [
-                        "ParameterNumber"
-                    ]
-                },
-                "props": {
-                    "description": "Checks the number of parameters of a method.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreOverriddenMethods": {
-                            "description": "ignore methods with \"override\", only base class violates",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        },
-                        "max": {
-                            "description": "maximum number of parameters per method (default: 7)",
-                            "type": "integer",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ExtendedEmptyLinesCheck": {
-            "description": "Checks for consecutive empty lines.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for consecutive empty lines.",
-                    "type": "string",
-                    "enum": [
-                        "ExtendedEmptyLines"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for consecutive empty lines.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "none": {
-                            "description": "list of places where no empty line is permitted",
-                            "items": {
-                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
-                                "type": "string",
-                                "enum": [
-                                    "beforePackage",
-                                    "afterPackage",
-                                    "betweenImports",
-                                    "beforeUsing",
-                                    "afterImports",
-                                    "anywhereInFile",
-                                    "betweenTypes",
-                                    "beforeFileEnd",
-                                    "inFunction",
-                                    "afterLeftCurly",
-                                    "beforeRightCurly",
-                                    "typeDefinition",
-                                    "beginClass",
-                                    "endClass",
-                                    "afterClassStaticVars",
-                                    "afterClassVars",
-                                    "betweenClassStaticVars",
-                                    "betweenClassVars",
-                                    "betweenClassMethods",
-                                    "beginAbstract",
-                                    "endAbstract",
-                                    "afterAbstractVars",
-                                    "betweenAbstractVars",
-                                    "betweenAbstractMethods",
-                                    "beginInterface",
-                                    "endInterface",
-                                    "betweenInterfaceFields",
-                                    "beginEnum",
-                                    "endEnum",
-                                    "betweenEnumFields",
-                                    "beginTypedef",
-                                    "endTypedef",
-                                    "betweenTypedefFields",
-                                    "afterSingleLineComment",
-                                    "afterMultiLineComment",
-                                    "beforeSingleLineComment",
-                                    "beforeMultiLineComment",
-                                    "afterDocCommentField"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 4
-                        },
-                        "atleast": {
-                            "description": "list of places where at least \"max\" empty lines are required",
-                            "items": {
-                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
-                                "type": "string",
-                                "enum": [
-                                    "beforePackage",
-                                    "afterPackage",
-                                    "betweenImports",
-                                    "beforeUsing",
-                                    "afterImports",
-                                    "anywhereInFile",
-                                    "betweenTypes",
-                                    "beforeFileEnd",
-                                    "inFunction",
-                                    "afterLeftCurly",
-                                    "beforeRightCurly",
-                                    "typeDefinition",
-                                    "beginClass",
-                                    "endClass",
-                                    "afterClassStaticVars",
-                                    "afterClassVars",
-                                    "betweenClassStaticVars",
-                                    "betweenClassVars",
-                                    "betweenClassMethods",
-                                    "beginAbstract",
-                                    "endAbstract",
-                                    "afterAbstractVars",
-                                    "betweenAbstractVars",
-                                    "betweenAbstractMethods",
-                                    "beginInterface",
-                                    "endInterface",
-                                    "betweenInterfaceFields",
-                                    "beginEnum",
-                                    "endEnum",
-                                    "betweenEnumFields",
-                                    "beginTypedef",
-                                    "endTypedef",
-                                    "betweenTypedefFields",
-                                    "afterSingleLineComment",
-                                    "afterMultiLineComment",
-                                    "beforeSingleLineComment",
-                                    "beforeMultiLineComment",
-                                    "afterDocCommentField"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 7
-                        },
-                        "defaultPolicy": {
-                            "description": "\"defaultPolicy\" applies to all places not in \"ignore\", \"none\", \"exact\", \"upto\" or \"atleast\"",
-                            "type": "string",
-                            "enum": [
-                                "ignore",
                                 "none",
                                 "exact",
-                                "upto",
-                                "atleast"
+                                "larger"
                             ],
-                            "propertyOrder": 2
-                        },
-                        "exact": {
-                            "description": "list of places where exactly \"max\" empty lines are required",
-                            "items": {
-                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
-                                "type": "string",
-                                "enum": [
-                                    "beforePackage",
-                                    "afterPackage",
-                                    "betweenImports",
-                                    "beforeUsing",
-                                    "afterImports",
-                                    "anywhereInFile",
-                                    "betweenTypes",
-                                    "beforeFileEnd",
-                                    "inFunction",
-                                    "afterLeftCurly",
-                                    "beforeRightCurly",
-                                    "typeDefinition",
-                                    "beginClass",
-                                    "endClass",
-                                    "afterClassStaticVars",
-                                    "afterClassVars",
-                                    "betweenClassStaticVars",
-                                    "betweenClassVars",
-                                    "betweenClassMethods",
-                                    "beginAbstract",
-                                    "endAbstract",
-                                    "afterAbstractVars",
-                                    "betweenAbstractVars",
-                                    "betweenAbstractMethods",
-                                    "beginInterface",
-                                    "endInterface",
-                                    "betweenInterfaceFields",
-                                    "beginEnum",
-                                    "endEnum",
-                                    "betweenEnumFields",
-                                    "beginTypedef",
-                                    "endTypedef",
-                                    "betweenTypedefFields",
-                                    "afterSingleLineComment",
-                                    "afterMultiLineComment",
-                                    "beforeSingleLineComment",
-                                    "beforeMultiLineComment",
-                                    "afterDocCommentField"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 5
-                        },
-                        "ignore": {
-                            "description": "list of places to ignore",
-                            "items": {
-                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
-                                "type": "string",
-                                "enum": [
-                                    "beforePackage",
-                                    "afterPackage",
-                                    "betweenImports",
-                                    "beforeUsing",
-                                    "afterImports",
-                                    "anywhereInFile",
-                                    "betweenTypes",
-                                    "beforeFileEnd",
-                                    "inFunction",
-                                    "afterLeftCurly",
-                                    "beforeRightCurly",
-                                    "typeDefinition",
-                                    "beginClass",
-                                    "endClass",
-                                    "afterClassStaticVars",
-                                    "afterClassVars",
-                                    "betweenClassStaticVars",
-                                    "betweenClassVars",
-                                    "betweenClassMethods",
-                                    "beginAbstract",
-                                    "endAbstract",
-                                    "afterAbstractVars",
-                                    "betweenAbstractVars",
-                                    "betweenAbstractMethods",
-                                    "beginInterface",
-                                    "endInterface",
-                                    "betweenInterfaceFields",
-                                    "beginEnum",
-                                    "endEnum",
-                                    "betweenEnumFields",
-                                    "beginTypedef",
-                                    "endTypedef",
-                                    "betweenTypedefFields",
-                                    "afterSingleLineComment",
-                                    "afterMultiLineComment",
-                                    "beforeSingleLineComment",
-                                    "beforeMultiLineComment",
-                                    "afterDocCommentField"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 3
-                        },
-                        "upto": {
-                            "description": "list of places where up to \"max\" empty lines are permitted",
-                            "items": {
-                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
-                                "type": "string",
-                                "enum": [
-                                    "beforePackage",
-                                    "afterPackage",
-                                    "betweenImports",
-                                    "beforeUsing",
-                                    "afterImports",
-                                    "anywhereInFile",
-                                    "betweenTypes",
-                                    "beforeFileEnd",
-                                    "inFunction",
-                                    "afterLeftCurly",
-                                    "beforeRightCurly",
-                                    "typeDefinition",
-                                    "beginClass",
-                                    "endClass",
-                                    "afterClassStaticVars",
-                                    "afterClassVars",
-                                    "betweenClassStaticVars",
-                                    "betweenClassVars",
-                                    "betweenClassMethods",
-                                    "beginAbstract",
-                                    "endAbstract",
-                                    "afterAbstractVars",
-                                    "betweenAbstractVars",
-                                    "betweenAbstractMethods",
-                                    "beginInterface",
-                                    "endInterface",
-                                    "betweenInterfaceFields",
-                                    "beginEnum",
-                                    "endEnum",
-                                    "betweenEnumFields",
-                                    "beginTypedef",
-                                    "endTypedef",
-                                    "betweenTypedefFields",
-                                    "afterSingleLineComment",
-                                    "afterMultiLineComment",
-                                    "beforeSingleLineComment",
-                                    "beforeMultiLineComment",
-                                    "afterDocCommentField"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 6
-                        },
-                        "skipSingleLineTypes": {
-                            "description": "skips single line type definitions",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        },
-                        "max": {
-                            "description": "number of empty lines to allow / enforce (used by \"exact\", \"upto\" and \"atleast\" policies)",
-                            "type": "integer",
-                            "propertyOrder": 0
+                            "type": "string"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 5,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 8
+                            "type": "string"
                         }
                     },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "UnusedImportCheck": {
-            "description": "Checks for unused or duplicate imports.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for unused or duplicate imports.",
-                    "type": "string",
-                    "enum": [
-                        "UnusedImport"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for unused or duplicate imports.",
+                    "description": "Checks correct indentation",
                     "additionalProperties": false,
-                    "properties": {
-                        "ignoreModules": {
-                            "description": "list of module names to ignore, any module from \"ignoreModules\" won't show up as unused in any file during a run",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        },
-                        "moduleTypeMap": {
-                            "description": "modules that define multiple types may show up as unused, unless \"moduleTypeMap\" contains a mapping for it\n\t\te.g. \"haxe.macro.Expr\": [\"ExprDef\", \"ComplexType\"] - would allow \"import haxe.macro.Expr;\" even though you just use \"ComplexType\"",
-                            "type": "object",
-                            "propertyOrder": 1
-                        }
-                    },
                     "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "RedundantAllowMetaCheck": {
-            "description": "Checks for redundant @:allow metadata",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for redundant @:allow metadata",
-                    "type": "string",
-                    "enum": [
-                        "RedundantAllowMeta"
-                    ]
                 },
-                "props": {
-                    "description": "Checks for redundant @:allow metadata",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "prohibitMeta": {
-                            "description": "switches behaviour of check to\n\t\t- false = look for redundant access modifications\n\t\t- true = to discourage its use everywhere",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "IndentationCharacterCheck": {
-            "description": "Checks indentation character (tab/space, default is tab).",
-            "additionalProperties": false,
-            "properties": {
                 "type": {
-                    "description": "Checks indentation character (tab/space, default is tab).",
-                    "type": "string",
+                    "description": "Checks correct indentation",
                     "enum": [
-                        "IndentationCharacter"
-                    ]
-                },
-                "props": {
-                    "description": "Checks indentation character (tab/space, default is tab).",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignorePattern": {
-                            "description": "ignore lines that match regex",
-                            "type": "string",
-                            "propertyOrder": 1
-                        },
-                        "character": {
-                            "description": "set indentation to\n\t\t- tab = tab\n\t\t- space = space",
-                            "type": "string",
-                            "enum": [
-                                "tab",
-                                "space"
-                            ],
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "TraceCheck": {
-            "description": "Checks for trace calls in code.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for trace calls in code.",
-                    "type": "string",
-                    "enum": [
-                        "Trace"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for trace calls in code.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "OperatorWrapCheck": {
-            "description": "Checks line wrapping with operators.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks line wrapping with operators.",
-                    "type": "string",
-                    "enum": [
-                        "OperatorWrap"
-                    ]
-                },
-                "props": {
-                    "description": "Checks line wrapping with operators.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "tokens": {
-                            "description": "list mof wrapping tokens",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
-                        "option": {
-                            "description": "policy for wrapping token\n\t\t- eol = wrapping token should be at end of line\n\t\t- nl = wrapping token should start a new line",
-                            "type": "string",
-                            "enum": [
-                                "eol",
-                                "nl"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "PublicAccessorCheck": {
-            "description": "Checks for public accessors.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for public accessors.",
-                    "type": "string",
-                    "enum": [
-                        "PublicAccessor"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for public accessors.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "NestedIfDepthCheck": {
-            "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
-                    "type": "string",
-                    "enum": [
-                        "NestedIfDepth"
-                    ]
-                },
-                "props": {
-                    "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
-                    "additionalProperties": false,
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of nested if statements allowed\n\t\tsetting \"max\" to 1 allows one if inside another",
-                            "type": "integer",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "AvoidTernaryOperatorCheck": {
-            "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
-                    "type": "string",
-                    "enum": [
-                        "AvoidTernaryOperator"
-                    ]
-                },
-                "props": {
-                    "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "Threshold": {
-            "description": "threshold for code complexity",
-            "required": [
-                "severity",
-                "complexity"
-            ],
-            "additionalProperties": false,
-            "properties": {
-                "severity": {
-                    "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                    "type": "string",
-                    "enum": [
-                        "INFO",
-                        "WARNING",
-                        "ERROR",
-                        "IGNORE"
+                        "Indentation"
                     ],
-                    "propertyOrder": 0
-                },
-                "complexity": {
-                    "description": "complexity value associated with \"severity\"",
-                    "type": "integer",
-                    "propertyOrder": 1
+                    "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "CyclomaticComplexityCheck": {
-            "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
+            "description": "Checks correct indentation",
             "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
-                    "type": "string",
-                    "enum": [
-                        "CyclomaticComplexity"
-                    ]
-                },
-                "props": {
-                    "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "thresholds": {
-                            "description": "list of thresholds that define which severity level to report when complexity of method is above its limit",
-                            "items": {
-                                "$ref": "#/definitions/Threshold"
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "SimplifyBooleanReturnCheck": {
-            "description": "Checks for over-complicated boolean return statements.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for over-complicated boolean return statements.",
-                    "type": "string",
-                    "enum": [
-                        "SimplifyBooleanReturn"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for over-complicated boolean return statements.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "SpacingCheck": {
-            "description": "Spacing check on if, for, while, switch, try statements and around operators.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Spacing check on if, for, while, switch, try statements and around operators.",
-                    "type": "string",
-                    "enum": [
-                        "Spacing"
-                    ]
-                },
-                "props": {
-                    "description": "Spacing check on if, for, while, switch, try statements and around operators.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "spaceAroundBinop": {
-                            "description": "require space around Binop operators (\"+\", \"-\", \"/\", etc.)",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        },
-                        "spaceSwitchCase": {
-                            "description": "policy for switch statements (space between \"switch\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
-                            "type": "string",
-                            "enum": [
-                                "should",
-                                "should_not",
-                                "any"
-                            ],
-                            "propertyOrder": 5
-                        },
-                        "spaceWhileLoop": {
-                            "description": "policy for while statements (space between while\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
-                            "type": "string",
-                            "enum": [
-                                "should",
-                                "should_not",
-                                "any"
-                            ],
-                            "propertyOrder": 4
-                        },
-                        "spaceCatch": {
-                            "description": "policy for catch statements (space between \"catch\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
-                            "type": "string",
-                            "enum": [
-                                "should",
-                                "should_not",
-                                "any"
-                            ],
-                            "propertyOrder": 6
-                        },
-                        "ignoreRangeOperator": {
-                            "description": "exclude range operator \"...\" from \"spaceAroundBinop\"",
-                            "type": "boolean",
-                            "propertyOrder": 7
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 8
-                        },
-                        "spaceForLoop": {
-                            "description": "policy for for statements (space between \"for\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
-                            "type": "string",
-                            "enum": [
-                                "should",
-                                "should_not",
-                                "any"
-                            ],
-                            "propertyOrder": 3
-                        },
-                        "spaceIfCondition": {
-                            "description": "policy for if statements (space between \"if\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
-                            "type": "string",
-                            "enum": [
-                                "should",
-                                "should_not",
-                                "any"
-                            ],
-                            "propertyOrder": 2
-                        },
-                        "noSpaceAroundUnop": {
-                            "description": "enforce no space around Unop operators (\"++\", \"--\", \"!\", \"-\", \"~\")",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "AvoidStarImportCheck": {
-            "description": "Checks for import statements that use the * notation and using directives.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for import statements that use the * notation and using directives.",
-                    "type": "string",
-                    "enum": [
-                        "AvoidStarImport"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for import statements that use the * notation and using directives.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "HiddenFieldCheck": {
-            "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
-                    "type": "string",
-                    "enum": [
-                        "HiddenField"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreConstructorParameter": {
-                            "description": "allow constructor parameters to shadow field names",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        },
-                        "ignoreFormat": {
-                            "description": "ignore function names matching \"ignoreFormat\" regex",
-                            "type": "string",
-                            "propertyOrder": 2
-                        },
-                        "ignoreSetter": {
-                            "description": "allow setters to shadow field names",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "LineLengthCheck": {
-            "description": "Checks for long lines. Long lines are hard to read.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for long lines. Long lines are hard to read.",
-                    "type": "string",
-                    "enum": [
-                        "LineLength"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for long lines. Long lines are hard to read.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignorePattern": {
-                            "description": "ignore lines matching regex",
-                            "type": "string",
-                            "propertyOrder": 1
-                        },
-                        "max": {
-                            "description": "maximum number of characters per line (default: 160)",
-                            "type": "integer",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "RedundantAccessMetaCheck": {
-            "description": "Checks for redundant @:access metadata",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for redundant @:access metadata",
-                    "type": "string",
-                    "enum": [
-                        "RedundantAccessMeta"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for redundant @:access metadata",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "prohibitMeta": {
-                            "description": "switches behaviour of check to\n\t\t- false = look for redundant access modifications\n\t\t- true = to discourage its use everywhere",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
             "type": "object"
         },
         "ReturnCountCheck": {
-            "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
-            "additionalProperties": false,
             "properties": {
-                "type": {
-                    "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
-                    "type": "string",
-                    "enum": [
-                        "ReturnCount"
-                    ]
-                },
                 "props": {
-                    "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
-                    "additionalProperties": false,
                     "properties": {
-                        "ignoreFormat": {
-                            "description": "ignore function names matching \"ignoreFormat\" regex",
-                            "type": "string",
-                            "propertyOrder": 1
-                        },
                         "max": {
                             "description": "maximum number of return calls a function may have",
-                            "type": "integer",
-                            "propertyOrder": 0
+                            "propertyOrder": 0,
+                            "type": "integer"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 2,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 2
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "TypeDocCommentCheck": {
-            "description": "Checks code documentation on type level",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks code documentation on type level",
-                    "type": "string",
-                    "enum": [
-                        "TypeDocComment"
-                    ]
-                },
-                "props": {
-                    "description": "Checks code documentation on type level",
-                    "additionalProperties": false,
-                    "properties": {
-                        "tokens": {
-                            "description": "matches only comment docs for types specified in tokens list:\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "ABSTRACT_DEF",
-                                    "CLASS_DEF",
-                                    "ENUM_DEF",
-                                    "INTERFACE_DEF",
-                                    "TYPEDEF_DEF"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
+                            "type": "string"
                         },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
+                        "ignoreFormat": {
+                            "description": "ignore function names matching \"ignoreFormat\" regex",
+                            "propertyOrder": 1,
+                            "type": "string"
                         }
                     },
+                    "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
+                    "enum": [
+                        "ReturnCount"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
+            "additionalProperties": false,
             "type": "object"
         },
-        "FileNameCaseCheck": {
-            "description": "Checks that file names match the case of their module name.",
-            "additionalProperties": false,
+        "PublicAccessorCheck": {
             "properties": {
-                "type": {
-                    "description": "Checks that file names match the case of their module name.",
-                    "type": "string",
-                    "enum": [
-                        "FileNameCase"
-                    ]
-                },
                 "props": {
-                    "description": "Checks that file names match the case of their module name.",
-                    "additionalProperties": false,
                     "properties": {
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 0,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 0
+                            "type": "string"
                         }
                     },
+                    "description": "Checks for public accessors.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "Checks for public accessors.",
+                    "enum": [
+                        "PublicAccessor"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Checks for public accessors.",
+            "additionalProperties": false,
             "type": "object"
         },
-        "ListenerNameCheck": {
-            "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
-            "additionalProperties": false,
+        "TODOCommentCheck": {
             "properties": {
-                "type": {
-                    "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
-                    "type": "string",
-                    "enum": [
-                        "ListenerName"
-                    ]
-                },
                 "props": {
-                    "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
-                    "additionalProperties": false,
                     "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        },
                         "format": {
-                            "description": "regex name format",
-                            "type": "string",
-                            "propertyOrder": 1
-                        },
-                        "listeners": {
-                            "description": "list of function names used to register listeners",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "NestedTryDepthCheck": {
-            "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
-                    "type": "string",
-                    "enum": [
-                        "NestedTryDepth"
-                    ]
-                },
-                "props": {
-                    "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
-                    "additionalProperties": false,
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of nested try/catch statemenmts allowed\n\t\tsetting \"max\" to 1 allows one inner try/catch",
-                            "type": "integer",
-                            "propertyOrder": 0
+                            "description": "regex todo comment format, defaults to \"^\\\\s*(TODO|FIXME|HACK|XXX|BUG)\"",
+                            "propertyOrder": 0,
+                            "type": "string"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 1,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 1
+                            "type": "string"
                         }
                     },
+                    "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
+                    "enum": [
+                        "TODOComment"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
+            "additionalProperties": false,
             "type": "object"
         },
-        "CommentedOutCodeCheck": {
-            "description": "Checks sections of commented out code",
-            "additionalProperties": false,
+        "HiddenFieldCheck": {
             "properties": {
-                "type": {
-                    "description": "Checks sections of commented out code",
-                    "type": "string",
-                    "enum": [
-                        "CommentedOutCode"
-                    ]
-                },
                 "props": {
-                    "description": "Checks sections of commented out code",
-                    "additionalProperties": false,
                     "properties": {
+                        "ignoreConstructorParameter": {
+                            "description": "allow constructor parameters to shadow field names",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 3,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 0
+                            "type": "string"
+                        },
+                        "ignoreFormat": {
+                            "description": "ignore function names matching \"ignoreFormat\" regex",
+                            "propertyOrder": 2,
+                            "type": "string"
+                        },
+                        "ignoreSetter": {
+                            "description": "allow setters to shadow field names",
+                            "propertyOrder": 1,
+                            "type": "boolean"
                         }
                     },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "MultipleVariableDeclarationsCheck": {
-            "description": "Checks that each variable declaration is in its own statement and on its own line.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that each variable declaration is in its own statement and on its own line.",
-                    "type": "string",
-                    "enum": [
-                        "MultipleVariableDeclarations"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that each variable declaration is in its own statement and on its own line.",
+                    "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
                     "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
                     "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ArrayLiteralCheck": {
-            "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
-                    "type": "string",
-                    "enum": [
-                        "ArrayLiteral"
-                    ]
                 },
-                "props": {
-                    "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "EmptyPackageCheck": {
-            "description": "Checks for empty package names.",
-            "additionalProperties": false,
-            "properties": {
                 "type": {
-                    "description": "Checks for empty package names.",
-                    "type": "string",
+                    "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
                     "enum": [
-                        "EmptyPackage"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for empty package names.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "enforceEmptyPackage": {
-                            "description": "enforce using a package declaration, even if it is empty",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
+                        "HiddenField"
+                    ],
+                    "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "TypeCheck": {
-            "description": "Checks if type is specified or not for member variables.",
+            "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
             "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks if type is specified or not for member variables.",
-                    "type": "string",
-                    "enum": [
-                        "Type"
-                    ]
-                },
-                "props": {
-                    "description": "Checks if type is specified or not for member variables.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreEnumAbstractValues": {
-                            "description": "ignores fields inside abstract enums",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "RightCurlyCheck": {
-            "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
-                    "type": "string",
-                    "enum": [
-                        "RightCurly"
-                    ]
-                },
-                "props": {
-                    "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "tokens": {
-                            "description": "matches only right curlys specified in tokens list:\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- OBJECT_DECL = object declaration \"{ x: 0, y: 0, z: 0}\"\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if / else body \"if (test) {} else {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- SWITCH = switch / case body \"switch (test) { case: {} default: {} }\"\n\t\t- TRY = try body \"try {}\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"\n\t\t- REIFICATION = macro reification \"$i{}\"\n\t\t- ARRAY_COMPREHENSION = array comprehension \"[for (i in 0...10) {i * 2}]\"",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "CLASS_DEF",
-                                    "ENUM_DEF",
-                                    "ABSTRACT_DEF",
-                                    "TYPEDEF_DEF",
-                                    "INTERFACE_DEF",
-                                    "OBJECT_DECL",
-                                    "FUNCTION",
-                                    "FOR",
-                                    "IF",
-                                    "WHILE",
-                                    "SWITCH",
-                                    "TRY",
-                                    "CATCH",
-                                    "REIFICATION",
-                                    "ARRAY_COMPREHENSION"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
-                        "option": {
-                            "description": "placement of right curly\n\t\t- same = right curly must be alone on a new line, except for \"} else\" and \"} catch\"\n\t\t- alone = alone on a new line\n\t\t- aloneorsingle = right curly can occur on same line as left curly or must be alone on a new line",
-                            "type": "string",
-                            "enum": [
-                                "same",
-                                "alone",
-                                "aloneorsingle"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ExcludeFilterList": {
-            "description": "list of path filters, e.g.\n\t- full type names\n\t- names of individual folder or subfolders\n\t- partial folder or type names\n\n\teach line can have an additional range specification:\n\t- \":<linenumber>\" = only matches a specific line number - valid line number start at 1\n\t- \":<start>-<end>\" = matches line numbers from <start> to <end> (including both)\n\t- \":<identifier>\" = matches any line or block that has <identifier> name (Haxe keywords currently unsupported)",
-            "items": {
-                "type": "string"
-            },
-            "type": "array"
-        },
-        "OperatorWhitespaceCheck": {
-            "description": "Checks that whitespace is present or absent around a operators.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that whitespace is present or absent around a operators.",
-                    "type": "string",
-                    "enum": [
-                        "OperatorWhitespace"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that whitespace is present or absent around a operators.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "oldFunctionTypePolicy": {
-                            "description": "policy for old haxe function type \"Int -> Void\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 10
-                        },
-                        "boolOpPolicy": {
-                            "description": "policy for \"&&\", \"||\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 6
-                        },
-                        "newFunctionTypePolicy": {
-                            "description": "policy for new haxe function type \"(param:Int) -> Void\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 11
-                        },
-                        "ternaryOpPolicy": {
-                            "description": "policy for \"?:\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 2
-                        },
-                        "arrowPolicy": {
-                            "description": "policy for \"=>\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 8
-                        },
-                        "compareOpPolicy": {
-                            "description": "policy for \"==\", \"!=\", \"<\", \"<=\", \">\", \">=\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 4
-                        },
-                        "intervalOpPolicy": {
-                            "description": "policy for \"...\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 7
-                        },
-                        "bitwiseOpPolicy": {
-                            "description": "policy for \"&\", \"|\", \"^\", \"<<\", \">>\", \">>>\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 5
-                        },
-                        "unaryOpPolicy": {
-                            "description": "policy for \"++\", \"--\", \"!\", \"~\"\n\t\t- inner = enforce whitespace between unary operator and operand\n\t\t- none = enforce no whitespace between unary operator and operand\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "inner",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "assignOpPolicy": {
-                            "description": "policy for \"=\", \"+=\", \"-=\", \"*=\", \"/=\", \"<<=\", \">>=\", \">>>=\", \"&=\", \"|=\", \"^=\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 12
-                        },
-                        "arithmeticOpPolicy": {
-                            "description": "policy for \"+\", \"-\", \"*\", \"/\", \"%\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 3
-                        },
-                        "arrowFunctionPolicy": {
-                            "description": "policy for arrow functions \"(i) -> i + 2\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 9
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "TypeNameCheck": {
-            "description": "Checks that type names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that type names conform to a format specified by the `format` property.",
-                    "type": "string",
-                    "enum": [
-                        "TypeName"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that type names conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "type": "boolean",
-                            "propertyOrder": 2
-                        },
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "description": "check applies to:\n\t- INTERFACE = all interface types\n\t- CLASS = all class types\n\t- ENUM = all enum types\n\t- ABSTRACT = all abstract types\n\t- TYPEDEF = all typedef types",
-                                "type": "string",
-                                "enum": [
-                                    "INTERFACE",
-                                    "CLASS",
-                                    "ENUM",
-                                    "ABSTRACT",
-                                    "TYPEDEF"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "type": "string",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
             "type": "object"
         },
         "EmptyBlockCheck": {
-            "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
-            "additionalProperties": false,
             "properties": {
-                "type": {
-                    "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
-                    "type": "string",
-                    "enum": [
-                        "EmptyBlock"
-                    ]
-                },
                 "props": {
-                    "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
-                    "additionalProperties": false,
                     "properties": {
                         "tokens": {
                             "description": "matches only blocks specified in tokens list:\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- OBJECT_DECL = object declaration \"{ x: 0, y: 0, z: 0}\"\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if / else body \"if (test) {} else {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- SWITCH = switch / case body \"switch (test) { case: {} default: {} }\"\n\t\t- TRY = try body \"try {}\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"\n\t\t- REIFICATION = macro reification \"$i{}\"",
                             "items": {
-                                "type": "string",
                                 "enum": [
                                     "CLASS_DEF",
                                     "ENUM_DEF",
@@ -2748,1615 +1412,656 @@
                                     "TRY",
                                     "CATCH",
                                     "REIFICATION"
-                                ]
+                                ],
+                                "type": "string"
                             },
-                            "type": "array",
-                            "propertyOrder": 0
+                            "propertyOrder": 0,
+                            "type": "array"
                         },
                         "option": {
                             "description": "for all empty blocks matched by tokens\n\t\t- empty = allow empty blocks but enforce \"{}\" notation\n\t\t- text = must contain something apart from whitespace (comment or statement)\n\t\t- stmt = must contain at least one statement (that is not a comment)",
-                            "type": "string",
+                            "propertyOrder": 1,
                             "enum": [
                                 "empty",
                                 "text",
                                 "stmt"
                             ],
-                            "propertyOrder": 1
+                            "type": "string"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 2,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 2
+                            "type": "string"
                         }
                     },
+                    "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
+                    "enum": [
+                        "EmptyBlock"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
+            "additionalProperties": false,
             "type": "object"
         },
-        "NestedControlFlowCheck": {
-            "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
-            "additionalProperties": false,
+        "TypeNameCheck": {
             "properties": {
-                "type": {
-                    "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
-                    "type": "string",
-                    "enum": [
-                        "NestedControlFlow"
-                    ]
-                },
                 "props": {
-                    "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
-                    "additionalProperties": false,
                     "properties": {
-                        "max": {
-                            "description": "maximum number of nested control flow expressions allowed",
-                            "type": "integer",
-                            "propertyOrder": 0
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "description": "check applies to:\n\t- INTERFACE = all interface types\n\t- CLASS = all class types\n\t- ENUM = all enum types\n\t- ABSTRACT = all abstract types\n\t- TYPEDEF = all typedef types",
+                                "enum": [
+                                    "INTERFACE",
+                                    "CLASS",
+                                    "ENUM",
+                                    "ABSTRACT",
+                                    "TYPEDEF"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 1,
+                            "type": "array"
                         },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "EmptyLinesCheck": {
-            "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
-                    "type": "string",
-                    "enum": [
-                        "EmptyLines"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "requireEmptyLineAfterAbstract": {
-                            "description": "require an empty line after abstract keyword",
-                            "type": "boolean",
-                            "propertyOrder": 6
-                        },
-                        "requireEmptyLineAfterInterface": {
-                            "description": "require an empty line after interface keyword",
-                            "type": "boolean",
-                            "propertyOrder": 5
-                        },
-                        "allowEmptyLineAfterSingleLineComment": {
-                            "description": "allow empty lines after a single line comment",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        },
-                        "max": {
-                            "description": "number of empty lines to allow",
-                            "type": "integer",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 7
-                        },
-                        "requireEmptyLineAfterClass": {
-                            "description": "require an empty line after class keyword",
-                            "type": "boolean",
-                            "propertyOrder": 4
-                        },
-                        "allowEmptyLineAfterMultiLineComment": {
-                            "description": "allow empty lines after a mutli line comment",
-                            "type": "boolean",
-                            "propertyOrder": 2
-                        },
-                        "requireEmptyLineAfterPackage": {
-                            "description": "require an empty line after package definition",
-                            "type": "boolean",
-                            "propertyOrder": 3
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "NestedForDepthCheck": {
-            "description": "Restricts nested loop blocks to a specified depth (default = 1).",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Restricts nested loop blocks to a specified depth (default = 1).",
-                    "type": "string",
-                    "enum": [
-                        "NestedForDepth"
-                    ]
-                },
-                "props": {
-                    "description": "Restricts nested loop blocks to a specified depth (default = 1).",
-                    "additionalProperties": false,
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of nested loops allowed\n\t\tsetting \"max\" to 1 allows one inner loop",
-                            "type": "integer",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ArrayAccessCheck": {
-            "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
-                    "type": "string",
-                    "enum": [
-                        "ArrayAccess"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "spaceBefore": {
-                            "description": "set \"spaceBefore\" to false to detect space between array and \"[\"",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        },
-                        "spaceInside": {
-                            "description": "set to false to detect space between brackets (\"[\" + \"]\") and index",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "CatchParameterNameCheck": {
-            "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
-                    "type": "string",
-                    "enum": [
-                        "CatchParameterName"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "propertyOrder": 2,
+                            "type": "boolean"
                         },
                         "format": {
                             "description": "regex name format",
-                            "type": "string",
-                            "propertyOrder": 0
+                            "propertyOrder": 0,
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
                         }
                     },
+                    "description": "Checks that type names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "Checks that type names conform to a format specified by the `format` property.",
+                    "enum": [
+                        "TypeName"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Checks that type names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "DefaultComesLastCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
+                    "enum": [
+                        "DefaultComesLast"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "SeparatorWhitespaceCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "dotPolicy": {
+                            "description": "policy for \".\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "commaPolicy": {
+                            "description": "policy for \",\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "allowTrailingComma": {
+                            "description": "no violoation for missing whitespace after trailing commas",
+                            "propertyOrder": 2,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 4,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "semicolonPolicy": {
+                            "description": "policy for \";\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks that whitespace is present or absent around a separators.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that whitespace is present or absent around a separators.",
+                    "enum": [
+                        "SeparatorWhitespace"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that whitespace is present or absent around a separators.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "LineLengthCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of characters per line (default: 160)",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "ignorePattern": {
+                            "description": "ignore lines matching regex",
+                            "propertyOrder": 1,
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for long lines. Long lines are hard to read.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for long lines. Long lines are hard to read.",
+                    "enum": [
+                        "LineLength"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for long lines. Long lines are hard to read.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "StringLiteralCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "allowException": {
+                            "description": "\"allowException\" allows using single quotes in \"onlyDouble\" and \"doubleAndInterpolation\" mode, when string contains a double quote character.\n\t\tOr double quotes in \"onlySingle\" mode when string contains a single quote character, reducing the need to escape quotation marks.",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "policy": {
+                            "description": "policy for string literal use\n\t\t- onlySingle = enforce single quotes\n\t\t- onlyDouble = enforce double quotes, no interpolation allowed\n\t\t- doubleAndInterpolation = enforce double quotes, allow single quotes for interpolation",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "onlySingle",
+                                "onlyDouble",
+                                "doubleAndInterpolation"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for single or double quote string literals.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for single or double quote string literals.",
+                    "enum": [
+                        "StringLiteral"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for single or double quote string literals.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "CodeSimilarityCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severityIdentical": {
+                            "description": "severity level for identical code blocks",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "thresholdIdentical": {
+                            "description": "maximum number of tokens allowed before detecting identical code blocks",
+                            "propertyOrder": 1,
+                            "type": "integer"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "thresholdSimilar": {
+                            "description": "maximum number of tokens allowed before detecting similar code blocks",
+                            "propertyOrder": 2,
+                            "type": "integer"
+                        }
+                    },
+                    "description": "Checks for identical or similar code.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for identical or similar code.",
+                    "enum": [
+                        "CodeSimilarity"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for identical or similar code.",
+            "additionalProperties": false,
             "type": "object"
         },
         "WhitespaceAroundCheck": {
-            "description": "Checks that a token is surrounded by whitespace.",
-            "additionalProperties": false,
             "properties": {
-                "type": {
-                    "description": "Checks that a token is surrounded by whitespace.",
-                    "type": "string",
-                    "enum": [
-                        "WhitespaceAround"
-                    ]
-                },
                 "props": {
-                    "description": "Checks that a token is surrounded by whitespace.",
-                    "additionalProperties": false,
                     "properties": {
                         "tokens": {
                             "description": "supported list of tokens:\n\t\t\",\", \";\", \"(\", \")\", \"[\", \"]\", \"{\", \"}\", \":\", \".\", \"=\", \"+\", \"-\", \"*\", \"/\", \"%\", \">\", \"<\", \">=\", \"<=\", \"==\", \"!=\",\n\t\t\"&\", \"|\", \"^\", \"&&\", \"||\", \"<<\", \">>\", \">>>\", \"+=\", \"-=\", \"*=\", \"/=\", \"%=\", \"<<=\", \">>=\", \">>>=\", \"|=\", \"&=\",\n\t\t\"^=\", \"...\", \"=>\", \"!\", \"++\", \"--\",",
                             "items": {
                                 "type": "string"
                             },
-                            "type": "array",
-                            "propertyOrder": 0
+                            "propertyOrder": 0,
+                            "type": "array"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 1,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 1
+                            "type": "string"
                         }
                     },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "LongNumberCheck": {
-            "description": "Checks that there are no long decimal numbers without separators.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that there are no long decimal numbers without separators.",
-                    "type": "string",
-                    "enum": [
-                        "LongNumber"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that there are no long decimal numbers without separators.",
+                    "description": "Checks that a token is surrounded by whitespace.",
                     "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that a token is surrounded by whitespace.",
+                    "enum": [
+                        "WhitespaceAround"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that a token is surrounded by whitespace.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "AvoidStarImportCheck": {
+            "properties": {
+                "props": {
                     "properties": {
-                        "ignoreNumbers": {
-                            "description": "list of long numbers to ignore during checks",
-                            "items": {
-                                "type": "number"
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 0,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 1
+                            "type": "string"
                         }
                     },
+                    "description": "Checks for import statements that use the * notation and using directives.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "Checks for import statements that use the * notation and using directives.",
+                    "enum": [
+                        "AvoidStarImport"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Checks for import statements that use the * notation and using directives.",
+            "additionalProperties": false,
             "type": "object"
         },
-        "ExcludeConfig": {
-            "description": "defines filters to exclude folders, types or files from all or specific checks",
-            "additionalProperties": false,
+        "SimplifyBooleanReturnCheck": {
             "properties": {
-                "": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 3
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for over-complicated boolean return statements.",
+                    "additionalProperties": false,
+                    "type": "object"
                 },
-                "UnusedImport": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 80
-                },
-                "Dynamic": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 20
-                },
-                "Final": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 29
-                },
-                "MultipleStringLiterals": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 47
-                },
-                "LongNumber": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 40
-                },
-                "NeedBraces": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 49
-                },
-                "SeparatorWhitespace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 66
-                },
-                "all": {
-                    "$ref": "#/definitions/ExcludeFilterList"
-                },
-                "LocalVariableName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 39
-                },
-                "NestedForDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 51
-                },
-                "Anonymous": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 4
-                },
-                "MultipleVariableDeclarations": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 48
-                },
-                "NestedTryDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 53
-                },
-                "BlockBreakingConditional": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 11
-                },
-                "CatchParameterName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 12
-                },
-                "EmptyBlock": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 22
-                },
-                "ExtendedEmptyLines": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 25
-                },
-                "ReturnCount": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 64
-                },
-                "DefaultComesLast": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 18
-                },
-                "HexadecimalLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 30
-                },
-                "WhitespaceAfter": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 84
-                },
-                "ConstantName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 16
-                },
-                "EmptyPackage": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 24
-                },
-                "Interface": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 35
-                },
-                "WhitespaceAround": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 85
-                },
-                "NestedIfDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 52
-                },
-                "ParameterName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 57
-                },
-                "NullableParameter": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 54
-                },
-                "AvoidStarImport": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 9
-                },
-                "SeparatorWrap": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 67
-                },
-                "AvoidIdentifier": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 8
-                },
-                "RedundantAllowMeta": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 61
-                },
-                "HiddenField": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 31
-                },
-                "UnnecessaryConstructor": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 79
-                },
-                "SimplifyBooleanExpression": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 68
-                },
-                "path": {
-                    "description": "filters excludes relative to\n\t- RELATIVE_TO_PROJECT = use project root\n\t- RELATIVE_TO_SOURCE = use path(s) specified via \"-s <path>\" command line switches",
-                    "type": "string",
+                "type": {
+                    "description": "Checks for over-complicated boolean return statements.",
                     "enum": [
-                        "RELATIVE_TO_PROJECT",
-                        "RELATIVE_TO_SOURCE"
-                    ]
-                },
-                "MethodCount": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 43
-                },
-                "UnusedLocalVar": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 81
-                },
-                "TabForAligning": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 73
-                },
-                "MethodName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 45
-                },
-                "RightCurly": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 65
-                },
-                "AvoidTernaryOperator": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 10
-                },
-                "ParameterNumber": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 58
-                },
-                "ArrowFunction": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 7
-                },
-                "MethodLength": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 44
-                },
-                "ConditionalCompilation": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 15
-                },
-                "EmptyLines": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 23
-                },
-                "MemberName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 42
-                },
-                "ERegLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 21
-                },
-                "RedundantModifier": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 62
-                },
-                "Type": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 76
-                },
-                "TypeName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 78
-                },
-                "Indentation": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 32
-                },
-                "FileNameCase": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 28
-                },
-                "CommentedOutCode": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 14
-                },
-                "version": {
-                    "maximum": 1,
-                    "type": "integer",
-                    "minimum": 1
-                },
-                "Return": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 63
-                },
-                "SimplifyBooleanReturn": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 69
-                },
-                "TODOComment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 72
-                },
-                "VarTypeHint": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 82
-                },
-                "NestedControlFlow": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 50
-                },
-                "OperatorWhitespace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 55
-                },
-                "Spacing": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 70
-                },
-                "IndentationCharacter": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 33
-                },
-                "MagicNumber": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 41
-                },
-                "ArrayLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 6
-                },
-                "TrailingWhitespace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 75
-                },
-                "VariableInitialisation": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 83
-                },
-                "LineLength": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 37
-                },
-                "ListenerName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 38
-                },
-                "FileLength": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 27
-                },
-                "CyclomaticComplexity": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 17
-                },
-                "StringLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 71
-                },
-                "Trace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 74
-                },
-                "ArrayAccess": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 5
-                },
-                "PublicAccessor": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 59
-                },
-                "DocCommentStyle": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 19
-                },
-                "InnerAssignment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 34
-                },
-                "RedundantAccessMeta": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 60
-                },
-                "CodeSimilarity": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 13
-                },
-                "OperatorWrap": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 56
-                },
-                "TypeDocComment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 77
-                },
-                "LeftCurly": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 36
-                },
-                "ModifierOrder": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 46
-                },
-                "FieldDocComment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 26
+                        "SimplifyBooleanReturn"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Checks for over-complicated boolean return statements.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "VariableInitialisationCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "allowFinal": {
+                            "description": "final fields must be initialised either immediately or in constructor\n\t\twhen allowFinal is true then VariableInitialisation won't complain about initialisation at class level for final fields",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for instance variables that are initialised at class level.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for instance variables that are initialised at class level.",
+                    "enum": [
+                        "VariableInitialisation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for instance variables that are initialised at class level.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "MultipleVariableDeclarationsCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks that each variable declaration is in its own statement and on its own line.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that each variable declaration is in its own statement and on its own line.",
+                    "enum": [
+                        "MultipleVariableDeclarations"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that each variable declaration is in its own statement and on its own line.",
+            "additionalProperties": false,
             "type": "object"
         },
         "RedundantModifierCheck": {
-            "description": "Checks for redundant modifiers.",
-            "additionalProperties": false,
             "properties": {
-                "type": {
-                    "description": "Checks for redundant modifiers.",
-                    "type": "string",
-                    "enum": [
-                        "RedundantModifier"
-                    ]
-                },
                 "props": {
-                    "description": "Checks for redundant modifiers.",
-                    "additionalProperties": false,
                     "properties": {
-                        "enforcePrivate": {
-                            "description": "enforce use of \"private\" modifiers",
-                            "type": "boolean",
-                            "propertyOrder": 2
+                        "enforcePublic": {
+                            "description": "enforce use of \"public\" modifiers",
+                            "propertyOrder": 1,
+                            "type": "boolean"
                         },
                         "enforcePublicPrivate": {
                             "description": "enforce use of \"public\" and \"private\" modifiers\n\t\timplies enforcePublic and enforcePrivate",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        },
-                        "enforcePublic": {
-                            "description": "enforce use of \"public\" modifiers",
-                            "type": "boolean",
-                            "propertyOrder": 1
+                            "propertyOrder": 0,
+                            "type": "boolean"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 3,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 3
+                            "type": "string"
+                        },
+                        "enforcePrivate": {
+                            "description": "enforce use of \"private\" modifiers",
+                            "propertyOrder": 2,
+                            "type": "boolean"
                         }
                     },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "TODOCommentCheck": {
-            "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
-                    "type": "string",
-                    "enum": [
-                        "TODOComment"
-                    ]
-                },
-                "props": {
-                    "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
+                    "description": "Checks for redundant modifiers.",
                     "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "format": {
-                            "description": "regex todo comment format, defaults to \"^\\\\s*(TODO|FIXME|HACK|XXX|BUG)\"",
-                            "type": "string",
-                            "propertyOrder": 0
-                        }
-                    },
                     "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "BlockBreakingConditionalCheck": {
-            "description": "Checks for block breaking conditionals.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for block breaking conditionals.",
-                    "type": "string",
-                    "enum": [
-                        "BlockBreakingConditional"
-                    ]
                 },
-                "props": {
-                    "description": "Checks for block breaking conditionals.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
+                "type": {
+                    "description": "Checks for redundant modifiers.",
+                    "enum": [
+                        "RedundantModifier"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Checks for redundant modifiers.",
+            "additionalProperties": false,
             "type": "object"
         },
         "VarTypeHintCheck": {
-            "description": "Checks type hints of variables.",
-            "additionalProperties": false,
             "properties": {
-                "type": {
-                    "description": "Checks type hints of variables.",
-                    "type": "string",
-                    "enum": [
-                        "VarTypeHint"
-                    ]
-                },
                 "props": {
-                    "description": "Checks type hints of variables.",
-                    "additionalProperties": false,
                     "properties": {
-                        "ignoreEnumAbstractValues": {
-                            "description": "ignores fields inside abstract enums",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        },
                         "typeHintPolicy": {
                             "description": "policy for type hints on var and final",
-                            "type": "string",
+                            "propertyOrder": 0,
                             "enum": [
                                 "enforce_all",
                                 "infer_new_or_const",
                                 "infer_all"
                             ],
-                            "propertyOrder": 0
+                            "type": "string"
+                        },
+                        "ignoreEnumAbstractValues": {
+                            "description": "ignores fields inside abstract enums",
+                            "propertyOrder": 1,
+                            "type": "boolean"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 2,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 2
+                            "type": "string"
                         }
                     },
+                    "description": "Checks type hints of variables.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "Checks type hints of variables.",
+                    "enum": [
+                        "VarTypeHint"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Checks type hints of variables.",
+            "additionalProperties": false,
             "type": "object"
         },
-        "CodeSimilarityCheck": {
-            "description": "Checks for identical or similar code.",
-            "additionalProperties": false,
+        "FileNameCaseCheck": {
             "properties": {
-                "type": {
-                    "description": "Checks for identical or similar code.",
-                    "type": "string",
-                    "enum": [
-                        "CodeSimilarity"
-                    ]
-                },
                 "props": {
-                    "description": "Checks for identical or similar code.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "thresholdSimilar": {
-                            "description": "maximum number of tokens allowed before detecting similar code blocks",
-                            "type": "integer",
-                            "propertyOrder": 2
-                        },
-                        "thresholdIdentical": {
-                            "description": "maximum number of tokens allowed before detecting identical code blocks",
-                            "type": "integer",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        },
-                        "severityIdentical": {
-                            "description": "severity level for identical code blocks",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "UnnecessaryConstructorCheck": {
-            "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
-                    "type": "string",
-                    "enum": [
-                        "UnnecessaryConstructor"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
-                    "additionalProperties": false,
                     "properties": {
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 0,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 0
+                            "type": "string"
                         }
                     },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ParameterNameCheck": {
-            "description": "Checks that parameter names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that parameter names conform to a format specified by the `format` property.",
-                    "type": "string",
-                    "enum": [
-                        "ParameterName"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that parameter names conform to a format specified by the `format` property.",
+                    "description": "Checks that file names match the case of their module name.",
                     "additionalProperties": false,
-                    "properties": {
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "type": "boolean",
-                            "propertyOrder": 2
-                        },
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "type": "string",
-                            "propertyOrder": 0
-                        }
-                    },
                     "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "AnonymousCheck": {
-            "description": "Check to find any anonymous type structures used.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Check to find any anonymous type structures used.",
-                    "type": "string",
-                    "enum": [
-                        "Anonymous"
-                    ]
                 },
-                "props": {
-                    "description": "Check to find any anonymous type structures used.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "MethodCountCheck": {
-            "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
-            "additionalProperties": false,
-            "properties": {
                 "type": {
-                    "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
-                    "type": "string",
+                    "description": "Checks that file names match the case of their module name.",
                     "enum": [
-                        "MethodCount"
-                    ]
-                },
-                "props": {
-                    "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "maxTotal": {
-                            "description": "maximum number of functions permitted per file (default: 100)",
-                            "type": "integer",
-                            "propertyOrder": 0
-                        },
-                        "maxPublic": {
-                            "description": "maximum number of public functions permitted per file (default: 100)",
-                            "type": "integer",
-                            "propertyOrder": 2
-                        },
-                        "maxPrivate": {
-                            "description": "maximum number of private functions permitted per file (default: 100)",
-                            "type": "integer",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        }
-                    },
-                    "type": "object"
+                        "FileNameCase"
+                    ],
+                    "type": "string"
                 }
             },
-            "type": "object"
-        },
-        "FinalCheck": {
-            "description": "Checks for places that use var instead of final (Haxe 4+).",
+            "description": "Checks that file names match the case of their module name.",
             "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for places that use var instead of final (Haxe 4+).",
-                    "type": "string",
-                    "enum": [
-                        "Final"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for places that use var instead of final (Haxe 4+).",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ConditionalCompilationCheck": {
-            "description": "Checks placement and indentation of conditional compilation flags.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks placement and indentation of conditional compilation flags.",
-                    "type": "string",
-                    "enum": [
-                        "ConditionalCompilation"
-                    ]
-                },
-                "props": {
-                    "description": "Checks placement and indentation of conditional compilation flags.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "allowSingleline": {
-                            "description": "allows or prevents using single line conditional compilation flags.",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        },
-                        "policy": {
-                            "description": "indentation of conditional statements\n\t\t- startOfLine = #if, #else, #elseif and #end must start at beginning of line\n\t\t- aligned = indentation of #if, #else, #elseif and #end must match surrounding code\n\n\t\tBoth \"aligned\" and \"startOfLine\" will produce a message if conditional compilation flags are not on a separate line.\n\t\tAll #else, #elseif and #end flags must have the same indentation as their corresponding #if.",
-                            "type": "string",
-                            "enum": [
-                                "startOfLine",
-                                "aligned"
-                            ],
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "MemberNameCheck": {
-            "description": "Checks that instance variable names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks that instance variable names conform to a format specified by the `format` property.",
-                    "type": "string",
-                    "enum": [
-                        "MemberName"
-                    ]
-                },
-                "props": {
-                    "description": "Checks that instance variable names conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "type": "boolean",
-                            "propertyOrder": 2
-                        },
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "description": "check applies to:\n\t- PUBLIC = all public fields\n\t- PRIVATE = all private fields\n\t- ENUM = all enum fields\n\t- CLASS = all class fields, use in combination with PUBLIC and PRIVATE to only match public/private class fields\n\t- ABSTRACT = all abstract fields, use in combination with PUBLIC and PRIVATE to only match public/private abstract fields\n\t- TYPEDEF = all typedef fields",
-                                "type": "string",
-                                "enum": [
-                                    "PUBLIC",
-                                    "PRIVATE",
-                                    "ENUM",
-                                    "CLASS",
-                                    "ABSTRACT",
-                                    "TYPEDEF"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "type": "string",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ERegLiteralCheck": {
-            "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
-                    "type": "string",
-                    "enum": [
-                        "ERegLiteral"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "SimplifyBooleanExpressionCheck": {
-            "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
-                    "type": "string",
-                    "enum": [
-                        "SimplifyBooleanExpression"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "VariableInitialisationCheck": {
-            "description": "Checks for instance variables that are initialised at class level.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for instance variables that are initialised at class level.",
-                    "type": "string",
-                    "enum": [
-                        "VariableInitialisation"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for instance variables that are initialised at class level.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "allowFinal": {
-                            "description": "final fields must be initialised either immediately or in constructor\n\t\twhen allowFinal is true then VariableInitialisation won't complain about initialisation at class level for final fields",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "MethodLengthCheck": {
-            "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
-                    "type": "string",
-                    "enum": [
-                        "MethodLength"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of lines per method (default: 50)",
-                            "type": "integer",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        },
-                        "ignoreEmptyLines": {
-                            "description": "ignores or includes empty lines when counting method length",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "AvoidIdentifierCheck": {
-            "description": "Checks for identifiers to avoid.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for identifiers to avoid.",
-                    "type": "string",
-                    "enum": [
-                        "AvoidIdentifier"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for identifiers to avoid.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "avoidIdentifiers": {
-                            "description": "list of identifiers to avoid",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "NeedBracesCheck": {
-            "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
-                    "type": "string",
-                    "enum": [
-                        "NeedBraces"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "tokens": {
-                            "description": "matches only statements specified in tokens list:\n\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if body \"if (test) {} else {}\"\n\t\t- ELSE_IF = if body \"if (test) {} else if {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- DO_WHILE = do…while body \"do {} while (test)\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "FUNCTION",
-                                    "FOR",
-                                    "IF",
-                                    "ELSE_IF",
-                                    "WHILE",
-                                    "DO_WHILE",
-                                    "CATCH"
-                                ]
-                            },
-                            "type": "array",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 2
-                        },
-                        "allowSingleLineStatement": {
-                            "description": "allow / disallow use of single line statements without braces",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "NullableParameterCheck": {
-            "description": "Enforces a style for nullable parameters.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Enforces a style for nullable parameters.",
-                    "type": "string",
-                    "enum": [
-                        "NullableParameter"
-                    ]
-                },
-                "props": {
-                    "description": "Enforces a style for nullable parameters.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "option": {
-                            "description": "nullable style to enforece\n\t\t- questionMark = nullable parameters should use \"?name:Type\"\n\t\t- nullDefault = nullable parameters should use \"name:Type = null\"",
-                            "type": "string",
-                            "enum": [
-                                "questionMark",
-                                "nullDefault"
-                            ],
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 1
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ReturnCheck": {
-            "description": "Warns if Void is used for return or if return type is not specified when returning.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Warns if Void is used for return or if return type is not specified when returning.",
-                    "type": "string",
-                    "enum": [
-                        "Return"
-                    ]
-                },
-                "props": {
-                    "description": "Warns if Void is used for return or if return type is not specified when returning.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "enforceReturnType": {
-                            "description": "enforces return type for every function",
-                            "type": "boolean",
-                            "propertyOrder": 1
-                        },
-                        "enforceReturnTypeForAnonymous": {
-                            "description": "enforces return type for anonymous functions",
-                            "type": "boolean",
-                            "propertyOrder": 2
-                        },
-                        "allowEmptyReturn": {
-                            "description": "allows empty return which is mostly used to exit functions.",
-                            "type": "boolean",
-                            "propertyOrder": 0
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "MultipleStringLiteralsCheck": {
-            "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
-                    "type": "string",
-                    "enum": [
-                        "MultipleStringLiterals"
-                    ]
-                },
-                "props": {
-                    "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignore": {
-                            "description": "ignore string literals matching regex",
-                            "type": "string",
-                            "propertyOrder": 2
-                        },
-                        "minLength": {
-                            "description": "string literals must be \"minLength\" or more characters before including them",
-                            "type": "integer",
-                            "propertyOrder": 1
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "propertyOrder": 3
-                        },
-                        "allowDuplicates": {
-                            "description": "number of occurrences to allow",
-                            "type": "integer",
-                            "propertyOrder": 0
-                        }
-                    },
-                    "type": "object"
-                }
-            },
             "type": "object"
         },
         "Config": {
-            "additionalProperties": false,
             "properties": {
-                "baseDefines": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "defineCombinations": {
-                    "items": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "type": "array"
-                },
-                "defaultSeverity": {
-                    "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                    "type": "string",
-                    "enum": [
-                        "INFO",
-                        "WARNING",
-                        "ERROR",
-                        "IGNORE"
-                    ]
-                },
-                "extendsConfigPath": {
-                    "type": "string"
-                },
-                "version": {
-                    "maximum": 1,
-                    "type": "integer",
-                    "minimum": 1
-                },
                 "checks": {
                     "items": {
                         "anyOf": [
@@ -4610,119 +2315,1293 @@
                     },
                     "type": "array"
                 },
+                "version": {
+                    "minimum": 1,
+                    "type": "integer",
+                    "maximum": 1
+                },
+                "numberOfCheckerThreads": {
+                    "minimum": 1,
+                    "type": "integer",
+                    "maximum": 15
+                },
                 "exclude": {
                     "$ref": "#/definitions/ExcludeConfig"
                 },
-                "numberOfCheckerThreads": {
-                    "maximum": 15,
-                    "type": "integer",
-                    "minimum": 1
+                "baseDefines": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "defineCombinations": {
+                    "items": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "type": "array"
+                },
+                "extendsConfigPath": {
+                    "type": "string"
+                },
+                "defaultSeverity": {
+                    "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                    "enum": [
+                        "INFO",
+                        "WARNING",
+                        "ERROR",
+                        "IGNORE"
+                    ],
+                    "type": "string"
                 }
             },
+            "additionalProperties": false,
             "type": "object"
         },
-        "SeparatorWrapCheck": {
-            "description": "Checks line wrapping with separators.",
-            "additionalProperties": false,
+        "ConditionalCompilationCheck": {
             "properties": {
-                "type": {
-                    "description": "Checks line wrapping with separators.",
-                    "type": "string",
-                    "enum": [
-                        "SeparatorWrap"
-                    ]
-                },
                 "props": {
-                    "description": "Checks line wrapping with separators.",
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "policy": {
+                            "description": "indentation of conditional statements\n\t\t- startOfLine = #if, #else, #elseif and #end must start at beginning of line\n\t\t- aligned = indentation of #if, #else, #elseif and #end must match surrounding code\n\n\t\tBoth \"aligned\" and \"startOfLine\" will produce a message if conditional compilation flags are not on a separate line.\n\t\tAll #else, #elseif and #end flags must have the same indentation as their corresponding #if.",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "startOfLine",
+                                "aligned"
+                            ],
+                            "type": "string"
+                        },
+                        "allowSingleline": {
+                            "description": "allows or prevents using single line conditional compilation flags.",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        }
+                    },
+                    "description": "Checks placement and indentation of conditional compilation flags.",
                     "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks placement and indentation of conditional compilation flags.",
+                    "enum": [
+                        "ConditionalCompilation"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks placement and indentation of conditional compilation flags.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "TypeCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "ignoreEnumAbstractValues": {
+                            "description": "ignores fields inside abstract enums",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks if type is specified or not for member variables.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks if type is specified or not for member variables.",
+                    "enum": [
+                        "Type"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks if type is specified or not for member variables.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "IndentationCharacterCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "character": {
+                            "description": "set indentation to\n\t\t- tab = tab\n\t\t- space = space",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "tab",
+                                "space"
+                            ],
+                            "type": "string"
+                        },
+                        "ignorePattern": {
+                            "description": "ignore lines that match regex",
+                            "propertyOrder": 1,
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks indentation character (tab/space, default is tab).",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks indentation character (tab/space, default is tab).",
+                    "enum": [
+                        "IndentationCharacter"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks indentation character (tab/space, default is tab).",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "RightCurlyCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "matches only right curlys specified in tokens list:\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- OBJECT_DECL = object declaration \"{ x: 0, y: 0, z: 0}\"\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if / else body \"if (test) {} else {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- SWITCH = switch / case body \"switch (test) { case: {} default: {} }\"\n\t\t- TRY = try body \"try {}\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"\n\t\t- REIFICATION = macro reification \"$i{}\"\n\t\t- ARRAY_COMPREHENSION = array comprehension \"[for (i in 0...10) {i * 2}]\"",
+                            "items": {
+                                "enum": [
+                                    "CLASS_DEF",
+                                    "ENUM_DEF",
+                                    "ABSTRACT_DEF",
+                                    "TYPEDEF_DEF",
+                                    "INTERFACE_DEF",
+                                    "OBJECT_DECL",
+                                    "FUNCTION",
+                                    "FOR",
+                                    "IF",
+                                    "WHILE",
+                                    "SWITCH",
+                                    "TRY",
+                                    "CATCH",
+                                    "REIFICATION",
+                                    "ARRAY_COMPREHENSION"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        },
+                        "option": {
+                            "description": "placement of right curly\n\t\t- same = right curly must be alone on a new line, except for \"} else\" and \"} catch\"\n\t\t- alone = alone on a new line\n\t\t- aloneorsingle = right curly can occur on same line as left curly or must be alone on a new line",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "same",
+                                "alone",
+                                "aloneorsingle"
+                            ],
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
+                    "enum": [
+                        "RightCurly"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "NullableParameterCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "option": {
+                            "description": "nullable style to enforece\n\t\t- questionMark = nullable parameters should use \"?name:Type\"\n\t\t- nullDefault = nullable parameters should use \"name:Type = null\"",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "questionMark",
+                                "nullDefault"
+                            ],
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Enforces a style for nullable parameters.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Enforces a style for nullable parameters.",
+                    "enum": [
+                        "NullableParameter"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Enforces a style for nullable parameters.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "OperatorWrapCheck": {
+            "properties": {
+                "props": {
                     "properties": {
                         "tokens": {
                             "description": "list mof wrapping tokens",
                             "items": {
                                 "type": "string"
                             },
-                            "type": "array",
-                            "propertyOrder": 0
+                            "propertyOrder": 0,
+                            "type": "array"
                         },
                         "option": {
                             "description": "policy for wrapping token\n\t\t- eol = wrapping token should be at end of line\n\t\t- nl = wrapping token should start a new line",
-                            "type": "string",
+                            "propertyOrder": 1,
                             "enum": [
                                 "eol",
                                 "nl"
                             ],
-                            "propertyOrder": 1
+                            "type": "string"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 2,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 2
+                            "type": "string"
                         }
                     },
+                    "description": "Checks line wrapping with operators.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "Checks line wrapping with operators.",
+                    "enum": [
+                        "OperatorWrap"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Checks line wrapping with operators.",
+            "additionalProperties": false,
             "type": "object"
         },
-        "SeparatorWhitespaceCheck": {
-            "description": "Checks that whitespace is present or absent around a separators.",
-            "additionalProperties": false,
+        "Threshold": {
             "properties": {
-                "type": {
-                    "description": "Checks that whitespace is present or absent around a separators.",
-                    "type": "string",
+                "severity": {
+                    "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                    "propertyOrder": 0,
                     "enum": [
-                        "SeparatorWhitespace"
-                    ]
+                        "INFO",
+                        "WARNING",
+                        "ERROR",
+                        "IGNORE"
+                    ],
+                    "type": "string"
                 },
+                "complexity": {
+                    "description": "complexity value associated with \"severity\"",
+                    "propertyOrder": 1,
+                    "type": "integer"
+                }
+            },
+            "description": "threshold for code complexity",
+            "additionalProperties": false,
+            "required": [
+                "severity",
+                "complexity"
+            ],
+            "type": "object"
+        },
+        "MagicNumberCheck": {
+            "properties": {
                 "props": {
-                    "description": "Checks that whitespace is present or absent around a separators.",
-                    "additionalProperties": false,
                     "properties": {
-                        "commaPolicy": {
-                            "description": "policy for \",\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 1
-                        },
-                        "semicolonPolicy": {
-                            "description": "policy for \";\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "propertyOrder": 3
+                        "ignoreNumbers": {
+                            "description": "list of magic numbers to ignore during checks",
+                            "items": {
+                                "type": "number"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "type": "string",
+                            "propertyOrder": 1,
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 4
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
+                    "enum": [
+                        "MagicNumber"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ArrayLiteralCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
+                    "enum": [
+                        "ArrayLiteral"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ReturnCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "enforceReturnType": {
+                            "description": "enforces return type for every function",
+                            "propertyOrder": 1,
+                            "type": "boolean"
                         },
-                        "dotPolicy": {
-                            "description": "policy for \".\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "type": "string",
+                        "allowEmptyReturn": {
+                            "description": "allows empty return which is mostly used to exit functions.",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "enforceReturnTypeForAnonymous": {
+                            "description": "enforces return type for anonymous functions",
+                            "propertyOrder": 2,
+                            "type": "boolean"
+                        }
+                    },
+                    "description": "Warns if Void is used for return or if return type is not specified when returning.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Warns if Void is used for return or if return type is not specified when returning.",
+                    "enum": [
+                        "Return"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Warns if Void is used for return or if return type is not specified when returning.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "RedundantAccessMetaCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "prohibitMeta": {
+                            "description": "switches behaviour of check to\n\t\t- false = look for redundant access modifications\n\t\t- true = to discourage its use everywhere",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        }
+                    },
+                    "description": "Checks for redundant @:access metadata",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for redundant @:access metadata",
+                    "enum": [
+                        "RedundantAccessMeta"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for redundant @:access metadata",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "FieldDocCommentCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "matches only comment docs for types specified in tokens list:\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"",
+                            "items": {
+                                "enum": [
+                                    "ABSTRACT_DEF",
+                                    "CLASS_DEF",
+                                    "ENUM_DEF",
+                                    "INTERFACE_DEF",
+                                    "TYPEDEF_DEF"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        },
+                        "ignoreOverride": {
+                            "description": "ignores methods marked with override",
+                            "propertyOrder": 5,
+                            "type": "boolean"
+                        },
+                        "modifier": {
+                            "description": "only check fields matching modifier\n\t\t- PUBLIC = only public fields\n\t\t- PRIVATE = only private fields\n\t\t- BOTH = public and private fields",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "PUBLIC",
+                                "PRIVATE",
+                                "BOTH"
+                            ],
+                            "type": "string"
+                        },
+                        "excludeNames": {
+                            "description": "exclude field names from check - default: [\"new\", \"toString\"]",
+                            "items": {
+                                "type": "string"
+                            },
+                            "propertyOrder": 6,
+                            "type": "array"
+                        },
+                        "requireReturn": {
+                            "description": "ignores requires a `@return` tag",
+                            "propertyOrder": 4,
+                            "type": "boolean"
+                        },
+                        "requireParams": {
+                            "description": "ignores requires a `@param` tag for every parameter",
+                            "propertyOrder": 3,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 7,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "fieldType": {
+                            "description": "only check fields of type\n\t\t- VARS = only var fields\n\t\t- FUNCTIONS = only functions;\n\t\t- BOTH = both vars and functions;",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "VARS",
+                                "FUNCTIONS",
+                                "BOTH"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks code documentation on fields",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks code documentation on fields",
+                    "enum": [
+                        "FieldDocComment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks code documentation on fields",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ArrayAccessCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "spaceBefore": {
+                            "description": "set \"spaceBefore\" to false to detect space between array and \"[\"",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        },
+                        "spaceInside": {
+                            "description": "set to false to detect space between brackets (\"[\" + \"]\") and index",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
+                    "enum": [
+                        "ArrayAccess"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "FinalCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for places that use var instead of final (Haxe 4+).",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for places that use var instead of final (Haxe 4+).",
+                    "enum": [
+                        "Final"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for places that use var instead of final (Haxe 4+).",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ConstantNameCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "description": "supports inline and non inline constants\n\t- INLINE = \"static inline var\"\n\t- NOTINLINE = \"static var\"",
+                                "enum": [
+                                    "INLINE",
+                                    "NOTINLINE"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 1,
+                            "type": "array"
+                        },
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "propertyOrder": 2,
+                            "type": "boolean"
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "propertyOrder": 0,
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
+                    "enum": [
+                        "ConstantName"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "AnonymousCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Check to find any anonymous type structures used.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Check to find any anonymous type structures used.",
+                    "enum": [
+                        "Anonymous"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Check to find any anonymous type structures used.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "CyclomaticComplexityCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "thresholds": {
+                            "description": "list of thresholds that define which severity level to report when complexity of method is above its limit",
+                            "items": {
+                                "$ref": "#/definitions/Threshold"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
+                    "enum": [
+                        "CyclomaticComplexity"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "RedundantAllowMetaCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "prohibitMeta": {
+                            "description": "switches behaviour of check to\n\t\t- false = look for redundant access modifications\n\t\t- true = to discourage its use everywhere",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        }
+                    },
+                    "description": "Checks for redundant @:allow metadata",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for redundant @:allow metadata",
+                    "enum": [
+                        "RedundantAllowMeta"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for redundant @:allow metadata",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "CommentedOutCodeCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks sections of commented out code",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks sections of commented out code",
+                    "enum": [
+                        "CommentedOutCode"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks sections of commented out code",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "NestedIfDepthCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of nested if statements allowed\n\t\tsetting \"max\" to 1 allows one if inside another",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
+                    "enum": [
+                        "NestedIfDepth"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "TypeDocCommentCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "matches only comment docs for types specified in tokens list:\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"",
+                            "items": {
+                                "enum": [
+                                    "ABSTRACT_DEF",
+                                    "CLASS_DEF",
+                                    "ENUM_DEF",
+                                    "INTERFACE_DEF",
+                                    "TYPEDEF_DEF"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks code documentation on type level",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks code documentation on type level",
+                    "enum": [
+                        "TypeDocComment"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks code documentation on type level",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "FileLengthCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of lines permitted per file (default: 2000)",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "ignoreEmptyLines": {
+                            "description": "ignores or includes empty lines when counting total file length",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
+                    "enum": [
+                        "FileLength"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "EmptyPackageCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "enforceEmptyPackage": {
+                            "description": "enforce using a package declaration, even if it is empty",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for empty package names.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for empty package names.",
+                    "enum": [
+                        "EmptyPackage"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for empty package names.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "MemberNameCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "description": "check applies to:\n\t- PUBLIC = all public fields\n\t- PRIVATE = all private fields\n\t- ENUM = all enum fields\n\t- CLASS = all class fields, use in combination with PUBLIC and PRIVATE to only match public/private class fields\n\t- ABSTRACT = all abstract fields, use in combination with PUBLIC and PRIVATE to only match public/private abstract fields\n\t- TYPEDEF = all typedef fields",
+                                "enum": [
+                                    "PUBLIC",
+                                    "PRIVATE",
+                                    "ENUM",
+                                    "CLASS",
+                                    "ABSTRACT",
+                                    "TYPEDEF"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 1,
+                            "type": "array"
+                        },
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "propertyOrder": 2,
+                            "type": "boolean"
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "propertyOrder": 0,
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks that instance variable names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that instance variable names conform to a format specified by the `format` property.",
+                    "enum": [
+                        "MemberName"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that instance variable names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "LeftCurlyCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "matches only left curlys specified in tokens list:\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- OBJECT_DECL = object declaration \"{ x: 0, y: 0, z: 0}\"\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if / else body \"if (test) {} else {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- SWITCH = switch / case body \"switch (test) { case: {} default: {} }\"\n\t\t- TRY = try body \"try {}\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"\n\t\t- REIFICATION = macro reification \"$i{}\"\n\t\t- ARRAY_COMPREHENSION = array comprehension \"[for (i in 0...10) {i * 2}]\"",
+                            "items": {
+                                "enum": [
+                                    "CLASS_DEF",
+                                    "ENUM_DEF",
+                                    "ABSTRACT_DEF",
+                                    "TYPEDEF_DEF",
+                                    "INTERFACE_DEF",
+                                    "ANON_TYPE",
+                                    "OBJECT_DECL",
+                                    "FUNCTION",
+                                    "FOR",
+                                    "IF",
+                                    "WHILE",
+                                    "SWITCH",
+                                    "TRY",
+                                    "CATCH",
+                                    "REIFICATION",
+                                    "ARRAY_COMPREHENSION"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        },
+                        "option": {
+                            "description": "placement of left curly\n\t\t- eol = should occur at end of line\n\t\t- nl = should occur on a new line\n\t\t- nlow = should occur at end of line unless in wrapped code, then it should occur on a new line",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "eol",
+                                "nl",
+                                "nlow"
+                            ],
+                            "type": "string"
+                        },
+                        "ignoreEmptySingleline": {
+                            "description": "allow empty single line blocks",
+                            "propertyOrder": 2,
+                            "type": "boolean"
+                        },
+                        "ignoreSingleline": {
+                            "description": "allow single line blocks",
+                            "propertyOrder": 3,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 4,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
+                    "enum": [
+                        "LeftCurly"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ERegLiteralCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
+                    "enum": [
+                        "ERegLiteral"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "TrailingWhitespaceCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks if there are any trailing white spaces.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks if there are any trailing white spaces.",
+                    "enum": [
+                        "TrailingWhitespace"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks if there are any trailing white spaces.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ParameterNumberCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of parameters per method (default: 7)",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "ignoreOverriddenMethods": {
+                            "description": "ignore methods with \"override\", only base class violates",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        }
+                    },
+                    "description": "Checks the number of parameters of a method.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks the number of parameters of a method.",
+                    "enum": [
+                        "ParameterNumber"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks the number of parameters of a method.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "OperatorWhitespaceCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "oldFunctionTypePolicy": {
+                            "description": "policy for old haxe function type \"Int -> Void\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 10,
                             "enum": [
                                 "before",
                                 "after",
@@ -4730,20 +3609,1154 @@
                                 "none",
                                 "ignore"
                             ],
-                            "propertyOrder": 0
+                            "type": "string"
                         },
-                        "allowTrailingComma": {
-                            "description": "no violoation for missing whitespace after trailing commas",
-                            "type": "boolean",
-                            "propertyOrder": 2
+                        "bitwiseOpPolicy": {
+                            "description": "policy for \"&\", \"|\", \"^\", \"<<\", \">>\", \">>>\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 5,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "assignOpPolicy": {
+                            "description": "policy for \"=\", \"+=\", \"-=\", \"*=\", \"/=\", \"<<=\", \">>=\", \">>>=\", \"&=\", \"|=\", \"^=\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "arrowPolicy": {
+                            "description": "policy for \"=>\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 8,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "compareOpPolicy": {
+                            "description": "policy for \"==\", \"!=\", \"<\", \"<=\", \">\", \">=\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 4,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "unaryOpPolicy": {
+                            "description": "policy for \"++\", \"--\", \"!\", \"~\"\n\t\t- inner = enforce whitespace between unary operator and operand\n\t\t- none = enforce no whitespace between unary operator and operand\n\t\t- ignore = skip checks",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "inner",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "newFunctionTypePolicy": {
+                            "description": "policy for new haxe function type \"(param:Int) -> Void\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 11,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "intervalOpPolicy": {
+                            "description": "policy for \"...\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 7,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 12,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "boolOpPolicy": {
+                            "description": "policy for \"&&\", \"||\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 6,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "arithmeticOpPolicy": {
+                            "description": "policy for \"+\", \"-\", \"*\", \"/\", \"%\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "ternaryOpPolicy": {
+                            "description": "policy for \"?:\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
+                        },
+                        "arrowFunctionPolicy": {
+                            "description": "policy for arrow functions \"(i) -> i + 2\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "propertyOrder": 9,
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "type": "string"
                         }
                     },
+                    "description": "Checks that whitespace is present or absent around a operators.",
+                    "additionalProperties": false,
                     "type": "object"
+                },
+                "type": {
+                    "description": "Checks that whitespace is present or absent around a operators.",
+                    "enum": [
+                        "OperatorWhitespace"
+                    ],
+                    "type": "string"
                 }
             },
+            "description": "Checks that whitespace is present or absent around a operators.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "SeparatorWrapCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "tokens": {
+                            "description": "list mof wrapping tokens",
+                            "items": {
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        },
+                        "option": {
+                            "description": "policy for wrapping token\n\t\t- eol = wrapping token should be at end of line\n\t\t- nl = wrapping token should start a new line",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "eol",
+                                "nl"
+                            ],
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks line wrapping with separators.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks line wrapping with separators.",
+                    "enum": [
+                        "SeparatorWrap"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks line wrapping with separators.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "UnusedImportCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "ignoreModules": {
+                            "description": "list of module names to ignore, any module from \"ignoreModules\" won't show up as unused in any file during a run",
+                            "items": {
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        },
+                        "moduleTypeMap": {
+                            "description": "modules that define multiple types may show up as unused, unless \"moduleTypeMap\" contains a mapping for it\n\t\te.g. \"haxe.macro.Expr\": [\"ExprDef\", \"ComplexType\"] - would allow \"import haxe.macro.Expr;\" even though you just use \"ComplexType\"",
+                            "propertyOrder": 1,
+                            "type": "object"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for unused or duplicate imports.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for unused or duplicate imports.",
+                    "enum": [
+                        "UnusedImport"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for unused or duplicate imports.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "AvoidTernaryOperatorCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
+                    "enum": [
+                        "AvoidTernaryOperator"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "CatchParameterNameCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "format": {
+                            "description": "regex name format",
+                            "propertyOrder": 0,
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
+                    "enum": [
+                        "CatchParameterName"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "DynamicCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for use of Dynamic type anywhere in the code.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for use of Dynamic type anywhere in the code.",
+                    "enum": [
+                        "Dynamic"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for use of Dynamic type anywhere in the code.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "AvoidIdentifierCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "avoidIdentifiers": {
+                            "description": "list of identifiers to avoid",
+                            "items": {
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for identifiers to avoid.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for identifiers to avoid.",
+                    "enum": [
+                        "AvoidIdentifier"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for identifiers to avoid.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "EmptyLinesCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "max": {
+                            "description": "number of empty lines to allow",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "requireEmptyLineAfterClass": {
+                            "description": "require an empty line after class keyword",
+                            "propertyOrder": 4,
+                            "type": "boolean"
+                        },
+                        "requireEmptyLineAfterPackage": {
+                            "description": "require an empty line after package definition",
+                            "propertyOrder": 3,
+                            "type": "boolean"
+                        },
+                        "requireEmptyLineAfterInterface": {
+                            "description": "require an empty line after interface keyword",
+                            "propertyOrder": 5,
+                            "type": "boolean"
+                        },
+                        "allowEmptyLineAfterMultiLineComment": {
+                            "description": "allow empty lines after a mutli line comment",
+                            "propertyOrder": 2,
+                            "type": "boolean"
+                        },
+                        "allowEmptyLineAfterSingleLineComment": {
+                            "description": "allow empty lines after a single line comment",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 7,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "requireEmptyLineAfterAbstract": {
+                            "description": "require an empty line after abstract keyword",
+                            "propertyOrder": 6,
+                            "type": "boolean"
+                        }
+                    },
+                    "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
+                    "enum": [
+                        "EmptyLines"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "MethodLengthCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of lines per method (default: 50)",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "ignoreEmptyLines": {
+                            "description": "ignores or includes empty lines when counting method length",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
+                    "enum": [
+                        "MethodLength"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ExcludeFilterList": {
+            "description": "list of path filters, e.g.\n\t- full type names\n\t- names of individual folder or subfolders\n\t- partial folder or type names\n\n\teach line can have an additional range specification:\n\t- \":<linenumber>\" = only matches a specific line number - valid line number start at 1\n\t- \":<start>-<end>\" = matches line numbers from <start> to <end> (including both)\n\t- \":<identifier>\" = matches any line or block that has <identifier> name (Haxe keywords currently unsupported)",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "ArrowFunctionCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "allowSingleArgParens": {
+                            "description": "allow using parenthesis around single argument arrow function (`(arg) -> arg * 2`)",
+                            "propertyOrder": 3,
+                            "type": "boolean"
+                        },
+                        "allowFunction": {
+                            "description": "allow using `function` inside arrow function bodies",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        },
+                        "allowReturn": {
+                            "description": "allow using `return` inside arrow function bodies",
+                            "propertyOrder": 0,
+                            "type": "boolean"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 4,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "allowCurlyBody": {
+                            "description": "allow using curly block as arrow function body (`{...}`)",
+                            "propertyOrder": 2,
+                            "type": "boolean"
+                        }
+                    },
+                    "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
+                    "enum": [
+                        "ArrowFunction"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ModifierOrderCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 1,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "description": "order in which modifier should occur",
+                            "items": {
+                                "description": "list of modifiers\n\t- PUBLIC_PRIVATE = public / private modifier\n\t- INLINE = inline modifier\n\t- STATIC = static modifier\n\t- OVERRIDE = override modifier\n\t- MACRO = macro modifier\n\t- DYNAMIC = dynamic modifier\n\t- EXTERN = extern modifier\n\t- FINAL = final modifier",
+                                "enum": [
+                                    "PUBLIC_PRIVATE",
+                                    "INLINE",
+                                    "STATIC",
+                                    "OVERRIDE",
+                                    "MACRO",
+                                    "DYNAMIC",
+                                    "EXTERN",
+                                    "FINAL",
+                                    "ABSTRACT",
+                                    "OVERLOAD",
+                                    "ENUM"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        }
+                    },
+                    "description": "Checks that the order of modifiers conforms to the standards.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that the order of modifiers conforms to the standards.",
+                    "enum": [
+                        "ModifierOrder"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that the order of modifiers conforms to the standards.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "UnusedLocalVarCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 0,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for unused local variables.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for unused local variables.",
+                    "enum": [
+                        "UnusedLocalVar"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for unused local variables.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "MultipleStringLiteralsCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "ignore": {
+                            "description": "ignore string literals matching regex",
+                            "propertyOrder": 2,
+                            "type": "string"
+                        },
+                        "minLength": {
+                            "description": "string literals must be \"minLength\" or more characters before including them",
+                            "propertyOrder": 1,
+                            "type": "integer"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 3,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "allowDuplicates": {
+                            "description": "number of occurrences to allow",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        }
+                    },
+                    "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
+                    "enum": [
+                        "MultipleStringLiterals"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ListenerNameCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "format": {
+                            "description": "regex name format",
+                            "propertyOrder": 1,
+                            "type": "string"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "listeners": {
+                            "description": "list of function names used to register listeners",
+                            "items": {
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        }
+                    },
+                    "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
+                    "enum": [
+                        "ListenerName"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "LongNumberCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "decimalGroupSize": {
+                            "description": "for decimal numbers, the number of consecutive digits before it's a long number\n\t\tdefaults to `3`, where `1000` is a long number but `1_000` is valid\n\t\tuse `-1` to disable the check entirely",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "fractionalGroupSize": {
+                            "description": "for floating point decimal numbers, the number of consecutive digits after the decimal pointbefore it's a long number\n\t\tfor example, where `1000` is a long number but `1_000` is valid\n\t\tdefaults to `-1` to disable the check\n\t\tuse `-1` to disable the check entirely",
+                            "propertyOrder": 1,
+                            "type": "integer"
+                        },
+                        "binaryGroupSize": {
+                            "description": "for binary numbers, the number of consecutive digits before it's a long number\n\t\tdefaults to `8`, where `0b101010101` is a long number but `0b1_01010101` is valid\n\t\tuse `-1` to disable the check entirely",
+                            "propertyOrder": 3,
+                            "type": "integer"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 4,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "hexadecimalGroupSize": {
+                            "description": "for hexadecimal numbers, the number of consecutive digits before it's a long number\n\t\tdefaults to `8`, where `0x123456789` is a long number but `0x1_2345678` is valid\n\t\tuse `-1` to disable the check entirely",
+                            "propertyOrder": 2,
+                            "type": "integer"
+                        }
+                    },
+                    "description": "Checks that there are no long decimal numbers without separators.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks that there are no long decimal numbers without separators.",
+                    "enum": [
+                        "LongNumber"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks that there are no long decimal numbers without separators.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ExtendedEmptyLinesCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "exact": {
+                            "description": "list of places where exactly \"max\" empty lines are required",
+                            "items": {
+                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
+                                "enum": [
+                                    "beforePackage",
+                                    "afterPackage",
+                                    "betweenImports",
+                                    "beforeUsing",
+                                    "afterImports",
+                                    "anywhereInFile",
+                                    "betweenTypes",
+                                    "beforeFileEnd",
+                                    "inFunction",
+                                    "afterLeftCurly",
+                                    "beforeRightCurly",
+                                    "typeDefinition",
+                                    "beginClass",
+                                    "endClass",
+                                    "afterClassStaticVars",
+                                    "afterClassVars",
+                                    "betweenClassStaticVars",
+                                    "betweenClassVars",
+                                    "betweenClassMethods",
+                                    "beginAbstract",
+                                    "endAbstract",
+                                    "afterAbstractVars",
+                                    "betweenAbstractVars",
+                                    "betweenAbstractMethods",
+                                    "beginInterface",
+                                    "endInterface",
+                                    "betweenInterfaceFields",
+                                    "beginEnum",
+                                    "endEnum",
+                                    "betweenEnumFields",
+                                    "beginTypedef",
+                                    "endTypedef",
+                                    "betweenTypedefFields",
+                                    "afterSingleLineComment",
+                                    "afterMultiLineComment",
+                                    "beforeSingleLineComment",
+                                    "beforeMultiLineComment",
+                                    "afterDocCommentField"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 5,
+                            "type": "array"
+                        },
+                        "defaultPolicy": {
+                            "description": "\"defaultPolicy\" applies to all places not in \"ignore\", \"none\", \"exact\", \"upto\" or \"atleast\"",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "ignore",
+                                "none",
+                                "exact",
+                                "upto",
+                                "atleast"
+                            ],
+                            "type": "string"
+                        },
+                        "upto": {
+                            "description": "list of places where up to \"max\" empty lines are permitted",
+                            "items": {
+                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
+                                "enum": [
+                                    "beforePackage",
+                                    "afterPackage",
+                                    "betweenImports",
+                                    "beforeUsing",
+                                    "afterImports",
+                                    "anywhereInFile",
+                                    "betweenTypes",
+                                    "beforeFileEnd",
+                                    "inFunction",
+                                    "afterLeftCurly",
+                                    "beforeRightCurly",
+                                    "typeDefinition",
+                                    "beginClass",
+                                    "endClass",
+                                    "afterClassStaticVars",
+                                    "afterClassVars",
+                                    "betweenClassStaticVars",
+                                    "betweenClassVars",
+                                    "betweenClassMethods",
+                                    "beginAbstract",
+                                    "endAbstract",
+                                    "afterAbstractVars",
+                                    "betweenAbstractVars",
+                                    "betweenAbstractMethods",
+                                    "beginInterface",
+                                    "endInterface",
+                                    "betweenInterfaceFields",
+                                    "beginEnum",
+                                    "endEnum",
+                                    "betweenEnumFields",
+                                    "beginTypedef",
+                                    "endTypedef",
+                                    "betweenTypedefFields",
+                                    "afterSingleLineComment",
+                                    "afterMultiLineComment",
+                                    "beforeSingleLineComment",
+                                    "beforeMultiLineComment",
+                                    "afterDocCommentField"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 6,
+                            "type": "array"
+                        },
+                        "max": {
+                            "description": "number of empty lines to allow / enforce (used by \"exact\", \"upto\" and \"atleast\" policies)",
+                            "propertyOrder": 0,
+                            "type": "integer"
+                        },
+                        "none": {
+                            "description": "list of places where no empty line is permitted",
+                            "items": {
+                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
+                                "enum": [
+                                    "beforePackage",
+                                    "afterPackage",
+                                    "betweenImports",
+                                    "beforeUsing",
+                                    "afterImports",
+                                    "anywhereInFile",
+                                    "betweenTypes",
+                                    "beforeFileEnd",
+                                    "inFunction",
+                                    "afterLeftCurly",
+                                    "beforeRightCurly",
+                                    "typeDefinition",
+                                    "beginClass",
+                                    "endClass",
+                                    "afterClassStaticVars",
+                                    "afterClassVars",
+                                    "betweenClassStaticVars",
+                                    "betweenClassVars",
+                                    "betweenClassMethods",
+                                    "beginAbstract",
+                                    "endAbstract",
+                                    "afterAbstractVars",
+                                    "betweenAbstractVars",
+                                    "betweenAbstractMethods",
+                                    "beginInterface",
+                                    "endInterface",
+                                    "betweenInterfaceFields",
+                                    "beginEnum",
+                                    "endEnum",
+                                    "betweenEnumFields",
+                                    "beginTypedef",
+                                    "endTypedef",
+                                    "betweenTypedefFields",
+                                    "afterSingleLineComment",
+                                    "afterMultiLineComment",
+                                    "beforeSingleLineComment",
+                                    "beforeMultiLineComment",
+                                    "afterDocCommentField"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 4,
+                            "type": "array"
+                        },
+                        "ignore": {
+                            "description": "list of places to ignore",
+                            "items": {
+                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
+                                "enum": [
+                                    "beforePackage",
+                                    "afterPackage",
+                                    "betweenImports",
+                                    "beforeUsing",
+                                    "afterImports",
+                                    "anywhereInFile",
+                                    "betweenTypes",
+                                    "beforeFileEnd",
+                                    "inFunction",
+                                    "afterLeftCurly",
+                                    "beforeRightCurly",
+                                    "typeDefinition",
+                                    "beginClass",
+                                    "endClass",
+                                    "afterClassStaticVars",
+                                    "afterClassVars",
+                                    "betweenClassStaticVars",
+                                    "betweenClassVars",
+                                    "betweenClassMethods",
+                                    "beginAbstract",
+                                    "endAbstract",
+                                    "afterAbstractVars",
+                                    "betweenAbstractVars",
+                                    "betweenAbstractMethods",
+                                    "beginInterface",
+                                    "endInterface",
+                                    "betweenInterfaceFields",
+                                    "beginEnum",
+                                    "endEnum",
+                                    "betweenEnumFields",
+                                    "beginTypedef",
+                                    "endTypedef",
+                                    "betweenTypedefFields",
+                                    "afterSingleLineComment",
+                                    "afterMultiLineComment",
+                                    "beforeSingleLineComment",
+                                    "beforeMultiLineComment",
+                                    "afterDocCommentField"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 3,
+                            "type": "array"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 8,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        },
+                        "atleast": {
+                            "description": "list of places where at least \"max\" empty lines are required",
+                            "items": {
+                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
+                                "enum": [
+                                    "beforePackage",
+                                    "afterPackage",
+                                    "betweenImports",
+                                    "beforeUsing",
+                                    "afterImports",
+                                    "anywhereInFile",
+                                    "betweenTypes",
+                                    "beforeFileEnd",
+                                    "inFunction",
+                                    "afterLeftCurly",
+                                    "beforeRightCurly",
+                                    "typeDefinition",
+                                    "beginClass",
+                                    "endClass",
+                                    "afterClassStaticVars",
+                                    "afterClassVars",
+                                    "betweenClassStaticVars",
+                                    "betweenClassVars",
+                                    "betweenClassMethods",
+                                    "beginAbstract",
+                                    "endAbstract",
+                                    "afterAbstractVars",
+                                    "betweenAbstractVars",
+                                    "betweenAbstractMethods",
+                                    "beginInterface",
+                                    "endInterface",
+                                    "betweenInterfaceFields",
+                                    "beginEnum",
+                                    "endEnum",
+                                    "betweenEnumFields",
+                                    "beginTypedef",
+                                    "endTypedef",
+                                    "betweenTypedefFields",
+                                    "afterSingleLineComment",
+                                    "afterMultiLineComment",
+                                    "beforeSingleLineComment",
+                                    "beforeMultiLineComment",
+                                    "afterDocCommentField"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 7,
+                            "type": "array"
+                        },
+                        "skipSingleLineTypes": {
+                            "description": "skips single line type definitions",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        }
+                    },
+                    "description": "Checks for consecutive empty lines.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for consecutive empty lines.",
+                    "enum": [
+                        "ExtendedEmptyLines"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for consecutive empty lines.",
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "NeedBracesCheck": {
+            "properties": {
+                "props": {
+                    "properties": {
+                        "allowSingleLineStatement": {
+                            "description": "allow / disallow use of single line statements without braces",
+                            "propertyOrder": 1,
+                            "type": "boolean"
+                        },
+                        "tokens": {
+                            "description": "matches only statements specified in tokens list:\n\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if body \"if (test) {} else {}\"\n\t\t- ELSE_IF = if body \"if (test) {} else if {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- DO_WHILE = do…while body \"do {} while (test)\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"",
+                            "items": {
+                                "enum": [
+                                    "FUNCTION",
+                                    "FOR",
+                                    "IF",
+                                    "ELSE_IF",
+                                    "WHILE",
+                                    "DO_WHILE",
+                                    "CATCH"
+                                ],
+                                "type": "string"
+                            },
+                            "propertyOrder": 0,
+                            "type": "array"
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "propertyOrder": 2,
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
+                    "additionalProperties": false,
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
+                    "enum": [
+                        "NeedBraces"
+                    ],
+                    "type": "string"
+                }
+            },
+            "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
+            "additionalProperties": false,
             "type": "object"
         }
     },
     "$ref": "#/definitions/Config",
-    "id": "https://raw.githubusercontent.com/HaxeCheckstyle/haxe-checkstyle/dev/resources/checkstyle-schema.json"
+    "id": "https://raw.githubusercontent.com/HaxeCheckstyle/haxe-checkstyle/dev/resources/checkstyle-schema.json",
+    "$schema": "http://json-schema.org/schema#"
 }

--- a/resources/checkstyle-schema.json
+++ b/resources/checkstyle-schema.json
@@ -1,1165 +1,177 @@
 {
+    "$schema": "http://json-schema.org/schema#",
     "definitions": {
-        "SpacingCheck": {
+        "TrailingWhitespaceCheck": {
+            "description": "Checks if there are any trailing white spaces.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks if there are any trailing white spaces.",
+                    "type": "string",
+                    "enum": [
+                        "TrailingWhitespace"
+                    ]
+                },
                 "props": {
+                    "description": "Checks if there are any trailing white spaces.",
+                    "additionalProperties": false,
                     "properties": {
-                        "ignoreRangeOperator": {
-                            "description": "exclude range operator \"...\" from \"spaceAroundBinop\"",
-                            "propertyOrder": 7,
-                            "type": "boolean"
-                        },
-                        "noSpaceAroundUnop": {
-                            "description": "enforce no space around Unop operators (\"++\", \"--\", \"!\", \"-\", \"~\")",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        },
-                        "spaceIfCondition": {
-                            "description": "policy for if statements (space between \"if\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "should",
-                                "should_not",
-                                "any"
-                            ],
-                            "type": "string"
-                        },
-                        "spaceSwitchCase": {
-                            "description": "policy for switch statements (space between \"switch\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
-                            "propertyOrder": 5,
-                            "enum": [
-                                "should",
-                                "should_not",
-                                "any"
-                            ],
-                            "type": "string"
-                        },
-                        "spaceCatch": {
-                            "description": "policy for catch statements (space between \"catch\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
-                            "propertyOrder": 6,
-                            "enum": [
-                                "should",
-                                "should_not",
-                                "any"
-                            ],
-                            "type": "string"
-                        },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 8,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
-                        },
-                        "spaceForLoop": {
-                            "description": "policy for for statements (space between \"for\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "should",
-                                "should_not",
-                                "any"
-                            ],
-                            "type": "string"
-                        },
-                        "spaceWhileLoop": {
-                            "description": "policy for while statements (space between while\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
-                            "propertyOrder": 4,
-                            "enum": [
-                                "should",
-                                "should_not",
-                                "any"
-                            ],
-                            "type": "string"
-                        },
-                        "spaceAroundBinop": {
-                            "description": "require space around Binop operators (\"+\", \"-\", \"/\", etc.)",
-                            "propertyOrder": 0,
-                            "type": "boolean"
+                            "propertyOrder": 0
                         }
                     },
-                    "description": "Spacing check on if, for, while, switch, try statements and around operators.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Spacing check on if, for, while, switch, try statements and around operators.",
-                    "enum": [
-                        "Spacing"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Spacing check on if, for, while, switch, try statements and around operators.",
-            "additionalProperties": false,
             "type": "object"
         },
-        "BlockBreakingConditionalCheck": {
+        "DynamicCheck": {
+            "description": "Checks for use of Dynamic type anywhere in the code.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks for use of Dynamic type anywhere in the code.",
+                    "type": "string",
+                    "enum": [
+                        "Dynamic"
+                    ]
+                },
                 "props": {
+                    "description": "Checks for use of Dynamic type anywhere in the code.",
+                    "additionalProperties": false,
                     "properties": {
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 0
                         }
                     },
-                    "description": "Checks for block breaking conditionals.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks for block breaking conditionals.",
-                    "enum": [
-                        "BlockBreakingConditional"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks for block breaking conditionals.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "TraceCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for trace calls in code.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for trace calls in code.",
-                    "enum": [
-                        "Trace"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for trace calls in code.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "InnerAssignmentCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "ignoreReturnAssignments": {
-                            "description": "ignores assignments in return statements",
-                            "propertyOrder": 0,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
-                    "enum": [
-                        "InnerAssignment"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "MethodNameCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "description": "check applies to:\n\t- PUBLIC = all public methods\n\t- PRIVATE = all private methods\n\t- STATIC = all static methods\n\t- NOTSTATIC = all non static methods\n\t- INLINE = all inline methods\n\t- NOTINLINE = all non-inline methods",
-                                "enum": [
-                                    "PUBLIC",
-                                    "PRIVATE",
-                                    "STATIC",
-                                    "NOTSTATIC",
-                                    "INLINE",
-                                    "NOTINLINE"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 1,
-                            "type": "array"
-                        },
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "propertyOrder": 2,
-                            "type": "boolean"
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "propertyOrder": 0,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks that method names conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that method names conform to a format specified by the `format` property.",
-                    "enum": [
-                        "MethodName"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that method names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "WhitespaceAfterCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "supported list of tokens:\n\t\t\",\", \";\", \"(\", \"[\", \"{\", \":\", \".\", \"=\", \"+\", \"-\", \"*\", \"/\", \"%\", \">\", \"<\", \">=\", \"<=\", \"==\", \"!=\",\n\t\t\"&\", \"|\", \"^\", \"&&\", \"||\", \"<<\", \">>\", \">>>\", \"+=\", \"-=\", \"*=\", \"/=\", \"%=\", \"<<=\", \">>=\", \">>>=\", \"|=\", \"&=\",\n\t\t\"^=\", \"...\", \"=>\", \"!\", \"++\", \"--\",",
-                            "items": {
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "allowTrailingComma": {
-                            "description": "no violoation for missing whitespace after trailing commas",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for whitespace after a token.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for whitespace after a token.",
-                    "enum": [
-                        "WhitespaceAfter"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for whitespace after a token.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "LocalVariableNameCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "type": "string"
-                            },
-                            "propertyOrder": 1,
-                            "type": "array"
-                        },
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "propertyOrder": 2,
-                            "type": "boolean"
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "propertyOrder": 0,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks that the local variable names conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that the local variable names conform to a format specified by the `format` property.",
-                    "enum": [
-                        "LocalVariableName"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that the local variable names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "NestedTryDepthCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of nested try/catch statemenmts allowed\n\t\tsetting \"max\" to 1 allows one inner try/catch",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
-                    "enum": [
-                        "NestedTryDepth"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "UnnecessaryConstructorCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
-                    "enum": [
-                        "UnnecessaryConstructor"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "NestedForDepthCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of nested loops allowed\n\t\tsetting \"max\" to 1 allows one inner loop",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Restricts nested loop blocks to a specified depth (default = 1).",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Restricts nested loop blocks to a specified depth (default = 1).",
-                    "enum": [
-                        "NestedForDepth"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Restricts nested loop blocks to a specified depth (default = 1).",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "HexadecimalLiteralCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "option": {
-                            "description": "policy for hexadecimal literals\n\t\t- upperCase = use uppercase for all letters\n\t\t- lowerCase = use lowercase for all letters",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "upperCase",
-                                "lowerCase"
-                            ],
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks the letter case of hexadecimal literals.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks the letter case of hexadecimal literals.",
-                    "enum": [
-                        "HexadecimalLiteral"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks the letter case of hexadecimal literals.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "TabForAligningCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "ignorePattern": {
-                            "description": "ignore linex matching regex",
-                            "propertyOrder": 0,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks if there are any tabs in the middle of a line.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks if there are any tabs in the middle of a line.",
-                    "enum": [
-                        "TabForAligning"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks if there are any tabs in the middle of a line.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "NestedControlFlowCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of nested control flow expressions allowed",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
-                    "enum": [
-                        "NestedControlFlow"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "MethodCountCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "maxPrivate": {
-                            "description": "maximum number of private functions permitted per file (default: 100)",
-                            "propertyOrder": 1,
-                            "type": "integer"
-                        },
-                        "maxPublic": {
-                            "description": "maximum number of public functions permitted per file (default: 100)",
-                            "propertyOrder": 2,
-                            "type": "integer"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "maxTotal": {
-                            "description": "maximum number of functions permitted per file (default: 100)",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        }
-                    },
-                    "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
-                    "enum": [
-                        "MethodCount"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "DocCommentStyleCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "startStyle": {
-                            "description": "Defines how doc comments should start / end:\n\t\t- ignore = accepts any start / end\n\t\t- onestar = /*\n\t\t- twostar = /**",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "ignore",
-                                "none",
-                                "onestar",
-                                "twostars"
-                            ],
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "lineStyle": {
-                            "description": "Defines how each doc comments line should start:\n\t\t- ignore = accepts any line prefix\n\t\t- none =\n\t\t- onestar = *\n\t\t- twostar = **",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "ignore",
-                                "none",
-                                "onestar",
-                                "twostars"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks code documentation style (/**...**/ vs /*...*/)",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks code documentation style (/**...**/ vs /*...*/)",
-                    "enum": [
-                        "DocCommentStyle"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks code documentation style (/**...**/ vs /*...*/)",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ParameterNameCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "type": "string"
-                            },
-                            "propertyOrder": 1,
-                            "type": "array"
-                        },
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "propertyOrder": 2,
-                            "type": "boolean"
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "propertyOrder": 0,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks that parameter names conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that parameter names conform to a format specified by the `format` property.",
-                    "enum": [
-                        "ParameterName"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that parameter names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ExcludeConfig": {
-            "properties": {
-                "": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 3
-                },
-                "NestedControlFlow": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 50
-                },
-                "TypeDocComment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 77
-                },
-                "Interface": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 35
-                },
-                "InnerAssignment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 34
-                },
-                "CodeSimilarity": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 13
-                },
-                "AvoidIdentifier": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 8
-                },
-                "version": {
-                    "minimum": 1,
-                    "type": "integer",
-                    "maximum": 1
-                },
-                "ConditionalCompilation": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 15
-                },
-                "TODOComment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 72
-                },
-                "MultipleVariableDeclarations": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 48
-                },
-                "LeftCurly": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 36
-                },
-                "HiddenField": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 31
-                },
-                "Spacing": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 70
-                },
-                "PublicAccessor": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 59
-                },
-                "LineLength": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 37
-                },
-                "Indentation": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 32
-                },
-                "SeparatorWrap": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 67
-                },
-                "ListenerName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 38
-                },
-                "MagicNumber": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 41
-                },
-                "EmptyLines": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 23
-                },
-                "RedundantAccessMeta": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 60
-                },
-                "ERegLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 21
-                },
-                "LongNumber": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 40
-                },
-                "Trace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 74
-                },
-                "StringLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 71
-                },
-                "WhitespaceAround": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 85
-                },
-                "RightCurly": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 65
-                },
-                "AvoidStarImport": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 9
-                },
-                "MultipleStringLiterals": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 47
-                },
-                "EmptyBlock": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 22
-                },
-                "TabForAligning": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 73
-                },
-                "DefaultComesLast": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 18
-                },
-                "path": {
-                    "description": "filters excludes relative to\n\t- RELATIVE_TO_PROJECT = use project root\n\t- RELATIVE_TO_SOURCE = use path(s) specified via \"-s <path>\" command line switches",
-                    "enum": [
-                        "RELATIVE_TO_PROJECT",
-                        "RELATIVE_TO_SOURCE"
-                    ],
-                    "type": "string"
-                },
-                "WhitespaceAfter": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 84
-                },
-                "NestedTryDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 53
-                },
-                "TypeName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 78
-                },
-                "NestedIfDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 52
-                },
-                "TrailingWhitespace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 75
-                },
-                "VariableInitialisation": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 83
-                },
-                "RedundantAllowMeta": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 61
-                },
-                "OperatorWhitespace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 55
-                },
-                "VarTypeHint": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 82
-                },
-                "BlockBreakingConditional": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 11
-                },
-                "SeparatorWhitespace": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 66
-                },
-                "NestedForDepth": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 51
-                },
-                "ArrowFunction": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 7
-                },
-                "all": {
-                    "$ref": "#/definitions/ExcludeFilterList"
-                },
-                "LocalVariableName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 39
-                },
-                "Dynamic": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 20
-                },
-                "FileNameCase": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 28
-                },
-                "NeedBraces": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 49
-                },
-                "Anonymous": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 4
-                },
-                "Final": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 29
-                },
-                "MethodName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 45
-                },
-                "CatchParameterName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 12
-                },
-                "CyclomaticComplexity": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 17
-                },
-                "IndentationCharacter": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 33
-                },
-                "MethodCount": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 43
-                },
-                "SimplifyBooleanExpression": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 68
-                },
-                "MethodLength": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 44
-                },
-                "ArrayLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 6
-                },
-                "CommentedOutCode": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 14
-                },
-                "NullableParameter": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 54
-                },
-                "UnusedLocalVar": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 81
-                },
-                "SimplifyBooleanReturn": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 69
-                },
-                "ArrayAccess": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 5
-                },
-                "ReturnCount": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 64
-                },
-                "FileLength": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 27
-                },
-                "FieldDocComment": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 26
-                },
-                "UnusedImport": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 80
-                },
-                "ModifierOrder": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 46
-                },
-                "Type": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 76
-                },
-                "OperatorWrap": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 56
-                },
-                "AvoidTernaryOperator": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 10
-                },
-                "ParameterNumber": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 58
-                },
-                "ConstantName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 16
-                },
-                "Return": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 63
-                },
-                "EmptyPackage": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 24
-                },
-                "DocCommentStyle": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 19
-                },
-                "ParameterName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 57
-                },
-                "RedundantModifier": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 62
-                },
-                "MemberName": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 42
-                },
-                "HexadecimalLiteral": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 30
-                },
-                "ExtendedEmptyLines": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 25
-                },
-                "UnnecessaryConstructor": {
-                    "$ref": "#/definitions/ExcludeFilterList",
-                    "propertyOrder": 79
-                }
-            },
-            "description": "defines filters to exclude folders, types or files from all or specific checks",
-            "additionalProperties": false,
             "type": "object"
         },
         "InterfaceCheck": {
+            "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
+                    "type": "string",
+                    "enum": [
+                        "Interface"
+                    ]
+                },
                 "props": {
+                    "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
+                    "additionalProperties": false,
                     "properties": {
                         "allowMarkerInterfaces": {
                             "description": "allows empty marker interfaces, or forbid their use",
-                            "propertyOrder": 0,
-                            "type": "boolean"
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
                         },
                         "allowProperties": {
                             "description": "allow properties inside interface types",
-                            "propertyOrder": 1,
-                            "type": "boolean"
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "TabForAligningCheck": {
+            "description": "Checks if there are any tabs in the middle of a line.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks if there are any tabs in the middle of a line.",
+                    "type": "string",
+                    "enum": [
+                        "TabForAligning"
+                    ]
+                },
+                "props": {
+                    "description": "Checks if there are any tabs in the middle of a line.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignorePattern": {
+                            "description": "ignore linex matching regex",
+                            "type": "string",
+                            "propertyOrder": 0
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 1
                         }
                     },
-                    "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
-                    "enum": [
-                        "Interface"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks and enforces interface style. Either to allow properties and methods or just methods. Has an option to `allowMarkerInterfaces`.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "SimplifyBooleanExpressionCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
-                    "enum": [
-                        "SimplifyBooleanExpression"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
-            "additionalProperties": false,
             "type": "object"
         },
         "IndentationCheck": {
+            "description": "Checks correct indentation",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks correct indentation",
+                    "type": "string",
+                    "enum": [
+                        "Indentation"
+                    ]
+                },
                 "props": {
+                    "description": "Checks correct indentation",
+                    "additionalProperties": false,
                     "properties": {
+                        "wrapPolicy": {
+                            "description": "indentation of wrapped statements (= continued on next line)\n\t\t- none = wrapped statements must have the same indentation as parent\n\t\t- exact = wrapped statemenmts must have a +1 indentation in relation to parent\n\t\t- larger = wrapped statements must have a +1 or larger indentation in relation to parent",
+                            "type": "string",
+                            "enum": [
+                                "none",
+                                "exact",
+                                "larger"
+                            ],
+                            "propertyOrder": 4
+                        },
                         "character": {
                             "description": "character sequence to use for indentation\n\t\t- \"tab\" for using tabs\n\t\t- a string containing as many spaces as one indentation level requires",
-                            "propertyOrder": 0,
+                            "type": "string",
                             "enum": [
                                 "tab",
                                 " ",
@@ -1171,232 +183,2556 @@
                                 "       ",
                                 "        "
                             ],
-                            "type": "string"
+                            "propertyOrder": 0
                         },
-                        "ignoreConditionals": {
-                            "description": "ignore indentation of conditionals (same as setting conditionalPolicy to ignore)",
-                            "propertyOrder": 1,
-                            "type": "boolean"
+                        "ignoreComments": {
+                            "description": "ignore indentation of comments",
+                            "type": "boolean",
+                            "propertyOrder": 3
                         },
                         "conditionalPolicy": {
                             "description": "indentation of conditional statements\n\t\t- ignore = ignores conditioonals, same as \"ignoreConditionals\"\n\t\t- fixed_zero = contitionals have to start at the beginning of a line (only where conditional is the first statement)\n\t\t- aligned = align wih surrounding code\n\t\t- aligned_increase = align wih surrounding code and increase indentation of enclosed code by +1",
-                            "propertyOrder": 2,
+                            "type": "string",
                             "enum": [
                                 "ignore",
                                 "fixed_zero",
                                 "aligned",
                                 "aligned_increase"
                             ],
-                            "type": "string"
-                        },
-                        "ignoreComments": {
-                            "description": "ignore indentation of comments",
-                            "propertyOrder": 3,
-                            "type": "boolean"
-                        },
-                        "wrapPolicy": {
-                            "description": "indentation of wrapped statements (= continued on next line)\n\t\t- none = wrapped statements must have the same indentation as parent\n\t\t- exact = wrapped statemenmts must have a +1 indentation in relation to parent\n\t\t- larger = wrapped statements must have a +1 or larger indentation in relation to parent",
-                            "propertyOrder": 4,
-                            "enum": [
-                                "none",
-                                "exact",
-                                "larger"
-                            ],
-                            "type": "string"
+                            "propertyOrder": 2
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 5,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 5
+                        },
+                        "ignoreConditionals": {
+                            "description": "ignore indentation of conditionals (same as setting conditionalPolicy to ignore)",
+                            "type": "boolean",
+                            "propertyOrder": 1
                         }
                     },
-                    "description": "Checks correct indentation",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks correct indentation",
-                    "enum": [
-                        "Indentation"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks correct indentation",
-            "additionalProperties": false,
             "type": "object"
         },
-        "ReturnCountCheck": {
+        "ArrowFunctionCheck": {
+            "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
+                    "type": "string",
+                    "enum": [
+                        "ArrowFunction"
+                    ]
+                },
                 "props": {
+                    "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
+                    "additionalProperties": false,
                     "properties": {
-                        "max": {
-                            "description": "maximum number of return calls a function may have",
-                            "propertyOrder": 0,
-                            "type": "integer"
+                        "allowFunction": {
+                            "description": "allow using `function` inside arrow function bodies",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        },
+                        "allowReturn": {
+                            "description": "allow using `return` inside arrow function bodies",
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        },
+                        "allowSingleArgParens": {
+                            "description": "allow using parenthesis around single argument arrow function (`(arg) -> arg * 2`)",
+                            "type": "boolean",
+                            "propertyOrder": 3
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 4
                         },
-                        "ignoreFormat": {
-                            "description": "ignore function names matching \"ignoreFormat\" regex",
-                            "propertyOrder": 1,
-                            "type": "string"
+                        "allowCurlyBody": {
+                            "description": "allow using curly block as arrow function body (`{...}`)",
+                            "type": "boolean",
+                            "propertyOrder": 2
                         }
                     },
-                    "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
-                    "enum": [
-                        "ReturnCount"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
+            "type": "object"
+        },
+        "UnusedLocalVarCheck": {
+            "description": "Checks for unused local variables.",
             "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for unused local variables.",
+                    "type": "string",
+                    "enum": [
+                        "UnusedLocalVar"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for unused local variables.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ModifierOrderCheck": {
+            "description": "Checks that the order of modifiers conforms to the standards.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that the order of modifiers conforms to the standards.",
+                    "type": "string",
+                    "enum": [
+                        "ModifierOrder"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that the order of modifiers conforms to the standards.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "modifiers": {
+                            "description": "order in which modifier should occur",
+                            "items": {
+                                "description": "list of modifiers\n\t- PUBLIC_PRIVATE = public / private modifier\n\t- INLINE = inline modifier\n\t- STATIC = static modifier\n\t- OVERRIDE = override modifier\n\t- MACRO = macro modifier\n\t- DYNAMIC = dynamic modifier\n\t- EXTERN = extern modifier\n\t- FINAL = final modifier",
+                                "type": "string",
+                                "enum": [
+                                    "PUBLIC_PRIVATE",
+                                    "INLINE",
+                                    "STATIC",
+                                    "OVERRIDE",
+                                    "MACRO",
+                                    "DYNAMIC",
+                                    "EXTERN",
+                                    "FINAL",
+                                    "ABSTRACT",
+                                    "OVERLOAD"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "StringLiteralCheck": {
+            "description": "Checks for single or double quote string literals.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for single or double quote string literals.",
+                    "type": "string",
+                    "enum": [
+                        "StringLiteral"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for single or double quote string literals.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "policy": {
+                            "description": "policy for string literal use\n\t\t- onlySingle = enforce single quotes\n\t\t- onlyDouble = enforce double quotes, no interpolation allowed\n\t\t- doubleAndInterpolation = enforce double quotes, allow single quotes for interpolation",
+                            "type": "string",
+                            "enum": [
+                                "onlySingle",
+                                "onlyDouble",
+                                "doubleAndInterpolation"
+                            ],
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "allowException": {
+                            "description": "\"allowException\" allows using single quotes in \"onlyDouble\" and \"doubleAndInterpolation\" mode, when string contains a double quote character.\n\t\tOr double quotes in \"onlySingle\" mode when string contains a single quote character, reducing the need to escape quotation marks.",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "DocCommentStyleCheck": {
+            "description": "Checks code documentation style (/**...**/ vs /*...*/)",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks code documentation style (/**...**/ vs /*...*/)",
+                    "type": "string",
+                    "enum": [
+                        "DocCommentStyle"
+                    ]
+                },
+                "props": {
+                    "description": "Checks code documentation style (/**...**/ vs /*...*/)",
+                    "additionalProperties": false,
+                    "properties": {
+                        "lineStyle": {
+                            "description": "Defines how each doc comments line should start:\n\t\t- ignore = accepts any line prefix\n\t\t- none =\n\t\t- onestar = *\n\t\t- twostar = **",
+                            "type": "string",
+                            "enum": [
+                                "ignore",
+                                "none",
+                                "onestar",
+                                "twostars"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "startStyle": {
+                            "description": "Defines how doc comments should start / end:\n\t\t- ignore = accepts any start / end\n\t\t- onestar = /*\n\t\t- twostar = /**",
+                            "type": "string",
+                            "enum": [
+                                "ignore",
+                                "none",
+                                "onestar",
+                                "twostars"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "DefaultComesLastCheck": {
+            "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
+                    "type": "string",
+                    "enum": [
+                        "DefaultComesLast"
+                    ]
+                },
+                "props": {
+                    "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "MethodNameCheck": {
+            "description": "Checks that method names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that method names conform to a format specified by the `format` property.",
+                    "type": "string",
+                    "enum": [
+                        "MethodName"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that method names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "type": "boolean",
+                            "propertyOrder": 2
+                        },
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "description": "check applies to:\n\t- PUBLIC = all public methods\n\t- PRIVATE = all private methods\n\t- STATIC = all static methods\n\t- NOTSTATIC = all non static methods\n\t- INLINE = all inline methods\n\t- NOTINLINE = all non-inline methods",
+                                "type": "string",
+                                "enum": [
+                                    "PUBLIC",
+                                    "PRIVATE",
+                                    "STATIC",
+                                    "NOTSTATIC",
+                                    "INLINE",
+                                    "NOTINLINE"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 3
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "type": "string",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "WhitespaceAfterCheck": {
+            "description": "Checks for whitespace after a token.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for whitespace after a token.",
+                    "type": "string",
+                    "enum": [
+                        "WhitespaceAfter"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for whitespace after a token.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "tokens": {
+                            "description": "supported list of tokens:\n\t\t\",\", \";\", \"(\", \"[\", \"{\", \":\", \".\", \"=\", \"+\", \"-\", \"*\", \"/\", \"%\", \">\", \"<\", \">=\", \"<=\", \"==\", \"!=\",\n\t\t\"&\", \"|\", \"^\", \"&&\", \"||\", \"<<\", \">>\", \">>>\", \"+=\", \"-=\", \"*=\", \"/=\", \"%=\", \"<<=\", \">>=\", \">>>=\", \"|=\", \"&=\",\n\t\t\"^=\", \"...\", \"=>\", \"!\", \"++\", \"--\",",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "allowTrailingComma": {
+                            "description": "no violoation for missing whitespace after trailing commas",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "InnerAssignmentCheck": {
+            "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
+                    "type": "string",
+                    "enum": [
+                        "InnerAssignment"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for assignments in subexpressions, such as in `if ((a=b) > 0) return;`.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreReturnAssignments": {
+                            "description": "ignores assignments in return statements",
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "MagicNumberCheck": {
+            "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
+                    "type": "string",
+                    "enum": [
+                        "MagicNumber"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreNumbers": {
+                            "description": "list of magic numbers to ignore during checks",
+                            "items": {
+                                "type": "number"
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "FieldDocCommentCheck": {
+            "description": "Checks code documentation on fields",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks code documentation on fields",
+                    "type": "string",
+                    "enum": [
+                        "FieldDocComment"
+                    ]
+                },
+                "props": {
+                    "description": "Checks code documentation on fields",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreOverride": {
+                            "description": "ignores methods marked with override",
+                            "type": "boolean",
+                            "propertyOrder": 5
+                        },
+                        "requireReturn": {
+                            "description": "ignores requires a `@return` tag",
+                            "type": "boolean",
+                            "propertyOrder": 4
+                        },
+                        "requireParams": {
+                            "description": "ignores requires a `@param` tag for every parameter",
+                            "type": "boolean",
+                            "propertyOrder": 3
+                        },
+                        "tokens": {
+                            "description": "matches only comment docs for types specified in tokens list:\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "ABSTRACT_DEF",
+                                    "CLASS_DEF",
+                                    "ENUM_DEF",
+                                    "INTERFACE_DEF",
+                                    "TYPEDEF_DEF"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "modifier": {
+                            "description": "only check fields matching modifier\n\t\t- PUBLIC = only public fields\n\t\t- PRIVATE = only private fields\n\t\t- BOTH = public and private fields",
+                            "type": "string",
+                            "enum": [
+                                "PUBLIC",
+                                "PRIVATE",
+                                "BOTH"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "fieldType": {
+                            "description": "only check fields of type\n\t\t- VARS = only var fields\n\t\t- FUNCTIONS = only functions;\n\t\t- BOTH = both vars and functions;",
+                            "type": "string",
+                            "enum": [
+                                "VARS",
+                                "FUNCTIONS",
+                                "BOTH"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 7
+                        },
+                        "excludeNames": {
+                            "description": "exclude field names from check - default: [\"new\", \"toString\"]",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "propertyOrder": 6
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "HexadecimalLiteralCheck": {
+            "description": "Checks the letter case of hexadecimal literals.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks the letter case of hexadecimal literals.",
+                    "type": "string",
+                    "enum": [
+                        "HexadecimalLiteral"
+                    ]
+                },
+                "props": {
+                    "description": "Checks the letter case of hexadecimal literals.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "option": {
+                            "description": "policy for hexadecimal literals\n\t\t- upperCase = use uppercase for all letters\n\t\t- lowerCase = use lowercase for all letters",
+                            "type": "string",
+                            "enum": [
+                                "upperCase",
+                                "lowerCase"
+                            ],
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "LeftCurlyCheck": {
+            "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
+                    "type": "string",
+                    "enum": [
+                        "LeftCurly"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "tokens": {
+                            "description": "matches only left curlys specified in tokens list:\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- OBJECT_DECL = object declaration \"{ x: 0, y: 0, z: 0}\"\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if / else body \"if (test) {} else {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- SWITCH = switch / case body \"switch (test) { case: {} default: {} }\"\n\t\t- TRY = try body \"try {}\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"\n\t\t- REIFICATION = macro reification \"$i{}\"\n\t\t- ARRAY_COMPREHENSION = array comprehension \"[for (i in 0...10) {i * 2}]\"",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "CLASS_DEF",
+                                    "ENUM_DEF",
+                                    "ABSTRACT_DEF",
+                                    "TYPEDEF_DEF",
+                                    "INTERFACE_DEF",
+                                    "ANON_TYPE",
+                                    "OBJECT_DECL",
+                                    "FUNCTION",
+                                    "FOR",
+                                    "IF",
+                                    "WHILE",
+                                    "SWITCH",
+                                    "TRY",
+                                    "CATCH",
+                                    "REIFICATION",
+                                    "ARRAY_COMPREHENSION"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "ignoreSingleline": {
+                            "description": "allow single line blocks",
+                            "type": "boolean",
+                            "propertyOrder": 3
+                        },
+                        "option": {
+                            "description": "placement of left curly\n\t\t- eol = should occur at end of line\n\t\t- nl = should occur on a new line\n\t\t- nlow = should occur at end of line unless in wrapped code, then it should occur on a new line",
+                            "type": "string",
+                            "enum": [
+                                "eol",
+                                "nl",
+                                "nlow"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 4
+                        },
+                        "ignoreEmptySingleline": {
+                            "description": "allow empty single line blocks",
+                            "type": "boolean",
+                            "propertyOrder": 2
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "FileLengthCheck": {
+            "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
+                    "type": "string",
+                    "enum": [
+                        "FileLength"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of lines permitted per file (default: 2000)",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "ignoreEmptyLines": {
+                            "description": "ignores or includes empty lines when counting total file length",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ConstantNameCheck": {
+            "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
+                    "type": "string",
+                    "enum": [
+                        "ConstantName"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "type": "boolean",
+                            "propertyOrder": 2
+                        },
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "description": "supports inline and non inline constants\n\t- INLINE = \"static inline var\"\n\t- NOTINLINE = \"static var\"",
+                                "type": "string",
+                                "enum": [
+                                    "INLINE",
+                                    "NOTINLINE"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 3
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "type": "string",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "LocalVariableNameCheck": {
+            "description": "Checks that the local variable names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that the local variable names conform to a format specified by the `format` property.",
+                    "type": "string",
+                    "enum": [
+                        "LocalVariableName"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that the local variable names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "type": "boolean",
+                            "propertyOrder": 2
+                        },
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 3
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "type": "string",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ParameterNumberCheck": {
+            "description": "Checks the number of parameters of a method.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks the number of parameters of a method.",
+                    "type": "string",
+                    "enum": [
+                        "ParameterNumber"
+                    ]
+                },
+                "props": {
+                    "description": "Checks the number of parameters of a method.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreOverriddenMethods": {
+                            "description": "ignore methods with \"override\", only base class violates",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        },
+                        "max": {
+                            "description": "maximum number of parameters per method (default: 7)",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ExtendedEmptyLinesCheck": {
+            "description": "Checks for consecutive empty lines.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for consecutive empty lines.",
+                    "type": "string",
+                    "enum": [
+                        "ExtendedEmptyLines"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for consecutive empty lines.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "none": {
+                            "description": "list of places where no empty line is permitted",
+                            "items": {
+                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
+                                "type": "string",
+                                "enum": [
+                                    "beforePackage",
+                                    "afterPackage",
+                                    "betweenImports",
+                                    "beforeUsing",
+                                    "afterImports",
+                                    "anywhereInFile",
+                                    "betweenTypes",
+                                    "beforeFileEnd",
+                                    "inFunction",
+                                    "afterLeftCurly",
+                                    "beforeRightCurly",
+                                    "typeDefinition",
+                                    "beginClass",
+                                    "endClass",
+                                    "afterClassStaticVars",
+                                    "afterClassVars",
+                                    "betweenClassStaticVars",
+                                    "betweenClassVars",
+                                    "betweenClassMethods",
+                                    "beginAbstract",
+                                    "endAbstract",
+                                    "afterAbstractVars",
+                                    "betweenAbstractVars",
+                                    "betweenAbstractMethods",
+                                    "beginInterface",
+                                    "endInterface",
+                                    "betweenInterfaceFields",
+                                    "beginEnum",
+                                    "endEnum",
+                                    "betweenEnumFields",
+                                    "beginTypedef",
+                                    "endTypedef",
+                                    "betweenTypedefFields",
+                                    "afterSingleLineComment",
+                                    "afterMultiLineComment",
+                                    "beforeSingleLineComment",
+                                    "beforeMultiLineComment",
+                                    "afterDocCommentField"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 4
+                        },
+                        "atleast": {
+                            "description": "list of places where at least \"max\" empty lines are required",
+                            "items": {
+                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
+                                "type": "string",
+                                "enum": [
+                                    "beforePackage",
+                                    "afterPackage",
+                                    "betweenImports",
+                                    "beforeUsing",
+                                    "afterImports",
+                                    "anywhereInFile",
+                                    "betweenTypes",
+                                    "beforeFileEnd",
+                                    "inFunction",
+                                    "afterLeftCurly",
+                                    "beforeRightCurly",
+                                    "typeDefinition",
+                                    "beginClass",
+                                    "endClass",
+                                    "afterClassStaticVars",
+                                    "afterClassVars",
+                                    "betweenClassStaticVars",
+                                    "betweenClassVars",
+                                    "betweenClassMethods",
+                                    "beginAbstract",
+                                    "endAbstract",
+                                    "afterAbstractVars",
+                                    "betweenAbstractVars",
+                                    "betweenAbstractMethods",
+                                    "beginInterface",
+                                    "endInterface",
+                                    "betweenInterfaceFields",
+                                    "beginEnum",
+                                    "endEnum",
+                                    "betweenEnumFields",
+                                    "beginTypedef",
+                                    "endTypedef",
+                                    "betweenTypedefFields",
+                                    "afterSingleLineComment",
+                                    "afterMultiLineComment",
+                                    "beforeSingleLineComment",
+                                    "beforeMultiLineComment",
+                                    "afterDocCommentField"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 7
+                        },
+                        "defaultPolicy": {
+                            "description": "\"defaultPolicy\" applies to all places not in \"ignore\", \"none\", \"exact\", \"upto\" or \"atleast\"",
+                            "type": "string",
+                            "enum": [
+                                "ignore",
+                                "none",
+                                "exact",
+                                "upto",
+                                "atleast"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "exact": {
+                            "description": "list of places where exactly \"max\" empty lines are required",
+                            "items": {
+                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
+                                "type": "string",
+                                "enum": [
+                                    "beforePackage",
+                                    "afterPackage",
+                                    "betweenImports",
+                                    "beforeUsing",
+                                    "afterImports",
+                                    "anywhereInFile",
+                                    "betweenTypes",
+                                    "beforeFileEnd",
+                                    "inFunction",
+                                    "afterLeftCurly",
+                                    "beforeRightCurly",
+                                    "typeDefinition",
+                                    "beginClass",
+                                    "endClass",
+                                    "afterClassStaticVars",
+                                    "afterClassVars",
+                                    "betweenClassStaticVars",
+                                    "betweenClassVars",
+                                    "betweenClassMethods",
+                                    "beginAbstract",
+                                    "endAbstract",
+                                    "afterAbstractVars",
+                                    "betweenAbstractVars",
+                                    "betweenAbstractMethods",
+                                    "beginInterface",
+                                    "endInterface",
+                                    "betweenInterfaceFields",
+                                    "beginEnum",
+                                    "endEnum",
+                                    "betweenEnumFields",
+                                    "beginTypedef",
+                                    "endTypedef",
+                                    "betweenTypedefFields",
+                                    "afterSingleLineComment",
+                                    "afterMultiLineComment",
+                                    "beforeSingleLineComment",
+                                    "beforeMultiLineComment",
+                                    "afterDocCommentField"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 5
+                        },
+                        "ignore": {
+                            "description": "list of places to ignore",
+                            "items": {
+                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
+                                "type": "string",
+                                "enum": [
+                                    "beforePackage",
+                                    "afterPackage",
+                                    "betweenImports",
+                                    "beforeUsing",
+                                    "afterImports",
+                                    "anywhereInFile",
+                                    "betweenTypes",
+                                    "beforeFileEnd",
+                                    "inFunction",
+                                    "afterLeftCurly",
+                                    "beforeRightCurly",
+                                    "typeDefinition",
+                                    "beginClass",
+                                    "endClass",
+                                    "afterClassStaticVars",
+                                    "afterClassVars",
+                                    "betweenClassStaticVars",
+                                    "betweenClassVars",
+                                    "betweenClassMethods",
+                                    "beginAbstract",
+                                    "endAbstract",
+                                    "afterAbstractVars",
+                                    "betweenAbstractVars",
+                                    "betweenAbstractMethods",
+                                    "beginInterface",
+                                    "endInterface",
+                                    "betweenInterfaceFields",
+                                    "beginEnum",
+                                    "endEnum",
+                                    "betweenEnumFields",
+                                    "beginTypedef",
+                                    "endTypedef",
+                                    "betweenTypedefFields",
+                                    "afterSingleLineComment",
+                                    "afterMultiLineComment",
+                                    "beforeSingleLineComment",
+                                    "beforeMultiLineComment",
+                                    "afterDocCommentField"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 3
+                        },
+                        "upto": {
+                            "description": "list of places where up to \"max\" empty lines are permitted",
+                            "items": {
+                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
+                                "type": "string",
+                                "enum": [
+                                    "beforePackage",
+                                    "afterPackage",
+                                    "betweenImports",
+                                    "beforeUsing",
+                                    "afterImports",
+                                    "anywhereInFile",
+                                    "betweenTypes",
+                                    "beforeFileEnd",
+                                    "inFunction",
+                                    "afterLeftCurly",
+                                    "beforeRightCurly",
+                                    "typeDefinition",
+                                    "beginClass",
+                                    "endClass",
+                                    "afterClassStaticVars",
+                                    "afterClassVars",
+                                    "betweenClassStaticVars",
+                                    "betweenClassVars",
+                                    "betweenClassMethods",
+                                    "beginAbstract",
+                                    "endAbstract",
+                                    "afterAbstractVars",
+                                    "betweenAbstractVars",
+                                    "betweenAbstractMethods",
+                                    "beginInterface",
+                                    "endInterface",
+                                    "betweenInterfaceFields",
+                                    "beginEnum",
+                                    "endEnum",
+                                    "betweenEnumFields",
+                                    "beginTypedef",
+                                    "endTypedef",
+                                    "betweenTypedefFields",
+                                    "afterSingleLineComment",
+                                    "afterMultiLineComment",
+                                    "beforeSingleLineComment",
+                                    "beforeMultiLineComment",
+                                    "afterDocCommentField"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 6
+                        },
+                        "skipSingleLineTypes": {
+                            "description": "skips single line type definitions",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        },
+                        "max": {
+                            "description": "number of empty lines to allow / enforce (used by \"exact\", \"upto\" and \"atleast\" policies)",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 8
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "UnusedImportCheck": {
+            "description": "Checks for unused or duplicate imports.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for unused or duplicate imports.",
+                    "type": "string",
+                    "enum": [
+                        "UnusedImport"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for unused or duplicate imports.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreModules": {
+                            "description": "list of module names to ignore, any module from \"ignoreModules\" won't show up as unused in any file during a run",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "moduleTypeMap": {
+                            "description": "modules that define multiple types may show up as unused, unless \"moduleTypeMap\" contains a mapping for it\n\t\te.g. \"haxe.macro.Expr\": [\"ExprDef\", \"ComplexType\"] - would allow \"import haxe.macro.Expr;\" even though you just use \"ComplexType\"",
+                            "type": "object",
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "RedundantAllowMetaCheck": {
+            "description": "Checks for redundant @:allow metadata",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for redundant @:allow metadata",
+                    "type": "string",
+                    "enum": [
+                        "RedundantAllowMeta"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for redundant @:allow metadata",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "prohibitMeta": {
+                            "description": "switches behaviour of check to\n\t\t- false = look for redundant access modifications\n\t\t- true = to discourage its use everywhere",
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "IndentationCharacterCheck": {
+            "description": "Checks indentation character (tab/space, default is tab).",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks indentation character (tab/space, default is tab).",
+                    "type": "string",
+                    "enum": [
+                        "IndentationCharacter"
+                    ]
+                },
+                "props": {
+                    "description": "Checks indentation character (tab/space, default is tab).",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignorePattern": {
+                            "description": "ignore lines that match regex",
+                            "type": "string",
+                            "propertyOrder": 1
+                        },
+                        "character": {
+                            "description": "set indentation to\n\t\t- tab = tab\n\t\t- space = space",
+                            "type": "string",
+                            "enum": [
+                                "tab",
+                                "space"
+                            ],
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "TraceCheck": {
+            "description": "Checks for trace calls in code.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for trace calls in code.",
+                    "type": "string",
+                    "enum": [
+                        "Trace"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for trace calls in code.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "OperatorWrapCheck": {
+            "description": "Checks line wrapping with operators.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks line wrapping with operators.",
+                    "type": "string",
+                    "enum": [
+                        "OperatorWrap"
+                    ]
+                },
+                "props": {
+                    "description": "Checks line wrapping with operators.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "tokens": {
+                            "description": "list mof wrapping tokens",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "option": {
+                            "description": "policy for wrapping token\n\t\t- eol = wrapping token should be at end of line\n\t\t- nl = wrapping token should start a new line",
+                            "type": "string",
+                            "enum": [
+                                "eol",
+                                "nl"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        }
+                    },
+                    "type": "object"
+                }
+            },
             "type": "object"
         },
         "PublicAccessorCheck": {
+            "description": "Checks for public accessors.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks for public accessors.",
+                    "type": "string",
+                    "enum": [
+                        "PublicAccessor"
+                    ]
+                },
                 "props": {
+                    "description": "Checks for public accessors.",
+                    "additionalProperties": false,
                     "properties": {
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 0
                         }
                     },
-                    "description": "Checks for public accessors.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks for public accessors.",
-                    "enum": [
-                        "PublicAccessor"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks for public accessors.",
-            "additionalProperties": false,
             "type": "object"
         },
-        "TODOCommentCheck": {
+        "NestedIfDepthCheck": {
+            "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
+                    "type": "string",
+                    "enum": [
+                        "NestedIfDepth"
+                    ]
+                },
                 "props": {
+                    "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
+                    "additionalProperties": false,
                     "properties": {
-                        "format": {
-                            "description": "regex todo comment format, defaults to \"^\\\\s*(TODO|FIXME|HACK|XXX|BUG)\"",
-                            "propertyOrder": 0,
-                            "type": "string"
+                        "max": {
+                            "description": "maximum number of nested if statements allowed\n\t\tsetting \"max\" to 1 allows one if inside another",
+                            "type": "integer",
+                            "propertyOrder": 0
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 1
                         }
                     },
-                    "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
-                    "enum": [
-                        "TODOComment"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
+            "type": "object"
+        },
+        "AvoidTernaryOperatorCheck": {
+            "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
             "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
+                    "type": "string",
+                    "enum": [
+                        "AvoidTernaryOperator"
+                    ]
+                },
+                "props": {
+                    "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "Threshold": {
+            "description": "threshold for code complexity",
+            "required": [
+                "severity",
+                "complexity"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "severity": {
+                    "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                    "type": "string",
+                    "enum": [
+                        "INFO",
+                        "WARNING",
+                        "ERROR",
+                        "IGNORE"
+                    ],
+                    "propertyOrder": 0
+                },
+                "complexity": {
+                    "description": "complexity value associated with \"severity\"",
+                    "type": "integer",
+                    "propertyOrder": 1
+                }
+            },
+            "type": "object"
+        },
+        "CyclomaticComplexityCheck": {
+            "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
+                    "type": "string",
+                    "enum": [
+                        "CyclomaticComplexity"
+                    ]
+                },
+                "props": {
+                    "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "thresholds": {
+                            "description": "list of thresholds that define which severity level to report when complexity of method is above its limit",
+                            "items": {
+                                "$ref": "#/definitions/Threshold"
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "SimplifyBooleanReturnCheck": {
+            "description": "Checks for over-complicated boolean return statements.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for over-complicated boolean return statements.",
+                    "type": "string",
+                    "enum": [
+                        "SimplifyBooleanReturn"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for over-complicated boolean return statements.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "SpacingCheck": {
+            "description": "Spacing check on if, for, while, switch, try statements and around operators.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Spacing check on if, for, while, switch, try statements and around operators.",
+                    "type": "string",
+                    "enum": [
+                        "Spacing"
+                    ]
+                },
+                "props": {
+                    "description": "Spacing check on if, for, while, switch, try statements and around operators.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "spaceAroundBinop": {
+                            "description": "require space around Binop operators (\"+\", \"-\", \"/\", etc.)",
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        },
+                        "spaceSwitchCase": {
+                            "description": "policy for switch statements (space between \"switch\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
+                            "type": "string",
+                            "enum": [
+                                "should",
+                                "should_not",
+                                "any"
+                            ],
+                            "propertyOrder": 5
+                        },
+                        "spaceWhileLoop": {
+                            "description": "policy for while statements (space between while\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
+                            "type": "string",
+                            "enum": [
+                                "should",
+                                "should_not",
+                                "any"
+                            ],
+                            "propertyOrder": 4
+                        },
+                        "spaceCatch": {
+                            "description": "policy for catch statements (space between \"catch\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
+                            "type": "string",
+                            "enum": [
+                                "should",
+                                "should_not",
+                                "any"
+                            ],
+                            "propertyOrder": 6
+                        },
+                        "ignoreRangeOperator": {
+                            "description": "exclude range operator \"...\" from \"spaceAroundBinop\"",
+                            "type": "boolean",
+                            "propertyOrder": 7
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 8
+                        },
+                        "spaceForLoop": {
+                            "description": "policy for for statements (space between \"for\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
+                            "type": "string",
+                            "enum": [
+                                "should",
+                                "should_not",
+                                "any"
+                            ],
+                            "propertyOrder": 3
+                        },
+                        "spaceIfCondition": {
+                            "description": "policy for if statements (space between \"if\" and \"(\")\n\t\t- should = require space between statement and condition\n\t\t- shouldNot = no space should between statement and condition\n\t\t- any = ignored by space check",
+                            "type": "string",
+                            "enum": [
+                                "should",
+                                "should_not",
+                                "any"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "noSpaceAroundUnop": {
+                            "description": "enforce no space around Unop operators (\"++\", \"--\", \"!\", \"-\", \"~\")",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "AvoidStarImportCheck": {
+            "description": "Checks for import statements that use the * notation and using directives.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for import statements that use the * notation and using directives.",
+                    "type": "string",
+                    "enum": [
+                        "AvoidStarImport"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for import statements that use the * notation and using directives.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
             "type": "object"
         },
         "HiddenFieldCheck": {
+            "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
+                    "type": "string",
+                    "enum": [
+                        "HiddenField"
+                    ]
+                },
                 "props": {
+                    "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
+                    "additionalProperties": false,
                     "properties": {
                         "ignoreConstructorParameter": {
                             "description": "allow constructor parameters to shadow field names",
-                            "propertyOrder": 0,
-                            "type": "boolean"
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        },
+                        "ignoreFormat": {
+                            "description": "ignore function names matching \"ignoreFormat\" regex",
+                            "type": "string",
+                            "propertyOrder": 2
+                        },
+                        "ignoreSetter": {
+                            "description": "allow setters to shadow field names",
+                            "type": "boolean",
+                            "propertyOrder": 1
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
-                        },
-                        "ignoreFormat": {
-                            "description": "ignore function names matching \"ignoreFormat\" regex",
-                            "propertyOrder": 2,
-                            "type": "string"
-                        },
-                        "ignoreSetter": {
-                            "description": "allow setters to shadow field names",
-                            "propertyOrder": 1,
-                            "type": "boolean"
+                            "propertyOrder": 3
                         }
                     },
-                    "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
-                    "enum": [
-                        "HiddenField"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks that a local variable or a parameter does not shadow a field that is defined in the same class.",
+            "type": "object"
+        },
+        "LineLengthCheck": {
+            "description": "Checks for long lines. Long lines are hard to read.",
             "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for long lines. Long lines are hard to read.",
+                    "type": "string",
+                    "enum": [
+                        "LineLength"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for long lines. Long lines are hard to read.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignorePattern": {
+                            "description": "ignore lines matching regex",
+                            "type": "string",
+                            "propertyOrder": 1
+                        },
+                        "max": {
+                            "description": "maximum number of characters per line (default: 160)",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "RedundantAccessMetaCheck": {
+            "description": "Checks for redundant @:access metadata",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for redundant @:access metadata",
+                    "type": "string",
+                    "enum": [
+                        "RedundantAccessMeta"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for redundant @:access metadata",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "prohibitMeta": {
+                            "description": "switches behaviour of check to\n\t\t- false = look for redundant access modifications\n\t\t- true = to discourage its use everywhere",
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ReturnCountCheck": {
+            "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
+                    "type": "string",
+                    "enum": [
+                        "ReturnCount"
+                    ]
+                },
+                "props": {
+                    "description": "Restricts the number of return statements in methods (2 by default). Ignores methods that matches `ignoreFormat` regex property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreFormat": {
+                            "description": "ignore function names matching \"ignoreFormat\" regex",
+                            "type": "string",
+                            "propertyOrder": 1
+                        },
+                        "max": {
+                            "description": "maximum number of return calls a function may have",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "TypeDocCommentCheck": {
+            "description": "Checks code documentation on type level",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks code documentation on type level",
+                    "type": "string",
+                    "enum": [
+                        "TypeDocComment"
+                    ]
+                },
+                "props": {
+                    "description": "Checks code documentation on type level",
+                    "additionalProperties": false,
+                    "properties": {
+                        "tokens": {
+                            "description": "matches only comment docs for types specified in tokens list:\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "ABSTRACT_DEF",
+                                    "CLASS_DEF",
+                                    "ENUM_DEF",
+                                    "INTERFACE_DEF",
+                                    "TYPEDEF_DEF"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "FileNameCaseCheck": {
+            "description": "Checks that file names match the case of their module name.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that file names match the case of their module name.",
+                    "type": "string",
+                    "enum": [
+                        "FileNameCase"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that file names match the case of their module name.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ListenerNameCheck": {
+            "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
+                    "type": "string",
+                    "enum": [
+                        "ListenerName"
+                    ]
+                },
+                "props": {
+                    "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "type": "string",
+                            "propertyOrder": 1
+                        },
+                        "listeners": {
+                            "description": "list of function names used to register listeners",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "NestedTryDepthCheck": {
+            "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
+                    "type": "string",
+                    "enum": [
+                        "NestedTryDepth"
+                    ]
+                },
+                "props": {
+                    "description": "Restricts nested `try` blocks to a specified depth (default = 1).",
+                    "additionalProperties": false,
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of nested try/catch statemenmts allowed\n\t\tsetting \"max\" to 1 allows one inner try/catch",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "CommentedOutCodeCheck": {
+            "description": "Checks sections of commented out code",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks sections of commented out code",
+                    "type": "string",
+                    "enum": [
+                        "CommentedOutCode"
+                    ]
+                },
+                "props": {
+                    "description": "Checks sections of commented out code",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "MultipleVariableDeclarationsCheck": {
+            "description": "Checks that each variable declaration is in its own statement and on its own line.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that each variable declaration is in its own statement and on its own line.",
+                    "type": "string",
+                    "enum": [
+                        "MultipleVariableDeclarations"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that each variable declaration is in its own statement and on its own line.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ArrayLiteralCheck": {
+            "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
+                    "type": "string",
+                    "enum": [
+                        "ArrayLiteral"
+                    ]
+                },
+                "props": {
+                    "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "EmptyPackageCheck": {
+            "description": "Checks for empty package names.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for empty package names.",
+                    "type": "string",
+                    "enum": [
+                        "EmptyPackage"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for empty package names.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "enforceEmptyPackage": {
+                            "description": "enforce using a package declaration, even if it is empty",
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "TypeCheck": {
+            "description": "Checks if type is specified or not for member variables.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks if type is specified or not for member variables.",
+                    "type": "string",
+                    "enum": [
+                        "Type"
+                    ]
+                },
+                "props": {
+                    "description": "Checks if type is specified or not for member variables.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreEnumAbstractValues": {
+                            "description": "ignores fields inside abstract enums",
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "RightCurlyCheck": {
+            "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
+                    "type": "string",
+                    "enum": [
+                        "RightCurly"
+                    ]
+                },
+                "props": {
+                    "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "tokens": {
+                            "description": "matches only right curlys specified in tokens list:\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- OBJECT_DECL = object declaration \"{ x: 0, y: 0, z: 0}\"\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if / else body \"if (test) {} else {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- SWITCH = switch / case body \"switch (test) { case: {} default: {} }\"\n\t\t- TRY = try body \"try {}\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"\n\t\t- REIFICATION = macro reification \"$i{}\"\n\t\t- ARRAY_COMPREHENSION = array comprehension \"[for (i in 0...10) {i * 2}]\"",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "CLASS_DEF",
+                                    "ENUM_DEF",
+                                    "ABSTRACT_DEF",
+                                    "TYPEDEF_DEF",
+                                    "INTERFACE_DEF",
+                                    "OBJECT_DECL",
+                                    "FUNCTION",
+                                    "FOR",
+                                    "IF",
+                                    "WHILE",
+                                    "SWITCH",
+                                    "TRY",
+                                    "CATCH",
+                                    "REIFICATION",
+                                    "ARRAY_COMPREHENSION"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "option": {
+                            "description": "placement of right curly\n\t\t- same = right curly must be alone on a new line, except for \"} else\" and \"} catch\"\n\t\t- alone = alone on a new line\n\t\t- aloneorsingle = right curly can occur on same line as left curly or must be alone on a new line",
+                            "type": "string",
+                            "enum": [
+                                "same",
+                                "alone",
+                                "aloneorsingle"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ExcludeFilterList": {
+            "description": "list of path filters, e.g.\n\t- full type names\n\t- names of individual folder or subfolders\n\t- partial folder or type names\n\n\teach line can have an additional range specification:\n\t- \":<linenumber>\" = only matches a specific line number - valid line number start at 1\n\t- \":<start>-<end>\" = matches line numbers from <start> to <end> (including both)\n\t- \":<identifier>\" = matches any line or block that has <identifier> name (Haxe keywords currently unsupported)",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "OperatorWhitespaceCheck": {
+            "description": "Checks that whitespace is present or absent around a operators.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that whitespace is present or absent around a operators.",
+                    "type": "string",
+                    "enum": [
+                        "OperatorWhitespace"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that whitespace is present or absent around a operators.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "oldFunctionTypePolicy": {
+                            "description": "policy for old haxe function type \"Int -> Void\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 10
+                        },
+                        "boolOpPolicy": {
+                            "description": "policy for \"&&\", \"||\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 6
+                        },
+                        "newFunctionTypePolicy": {
+                            "description": "policy for new haxe function type \"(param:Int) -> Void\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 11
+                        },
+                        "ternaryOpPolicy": {
+                            "description": "policy for \"?:\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "arrowPolicy": {
+                            "description": "policy for \"=>\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 8
+                        },
+                        "compareOpPolicy": {
+                            "description": "policy for \"==\", \"!=\", \"<\", \"<=\", \">\", \">=\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 4
+                        },
+                        "intervalOpPolicy": {
+                            "description": "policy for \"...\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 7
+                        },
+                        "bitwiseOpPolicy": {
+                            "description": "policy for \"&\", \"|\", \"^\", \"<<\", \">>\", \">>>\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 5
+                        },
+                        "unaryOpPolicy": {
+                            "description": "policy for \"++\", \"--\", \"!\", \"~\"\n\t\t- inner = enforce whitespace between unary operator and operand\n\t\t- none = enforce no whitespace between unary operator and operand\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "inner",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "assignOpPolicy": {
+                            "description": "policy for \"=\", \"+=\", \"-=\", \"*=\", \"/=\", \"<<=\", \">>=\", \">>>=\", \"&=\", \"|=\", \"^=\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 12
+                        },
+                        "arithmeticOpPolicy": {
+                            "description": "policy for \"+\", \"-\", \"*\", \"/\", \"%\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 3
+                        },
+                        "arrowFunctionPolicy": {
+                            "description": "policy for arrow functions \"(i) -> i + 2\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 9
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "TypeNameCheck": {
+            "description": "Checks that type names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that type names conform to a format specified by the `format` property.",
+                    "type": "string",
+                    "enum": [
+                        "TypeName"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that type names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "type": "boolean",
+                            "propertyOrder": 2
+                        },
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "description": "check applies to:\n\t- INTERFACE = all interface types\n\t- CLASS = all class types\n\t- ENUM = all enum types\n\t- ABSTRACT = all abstract types\n\t- TYPEDEF = all typedef types",
+                                "type": "string",
+                                "enum": [
+                                    "INTERFACE",
+                                    "CLASS",
+                                    "ENUM",
+                                    "ABSTRACT",
+                                    "TYPEDEF"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 3
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "type": "string",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
             "type": "object"
         },
         "EmptyBlockCheck": {
+            "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
+                    "type": "string",
+                    "enum": [
+                        "EmptyBlock"
+                    ]
+                },
                 "props": {
+                    "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
+                    "additionalProperties": false,
                     "properties": {
                         "tokens": {
                             "description": "matches only blocks specified in tokens list:\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- OBJECT_DECL = object declaration \"{ x: 0, y: 0, z: 0}\"\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if / else body \"if (test) {} else {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- SWITCH = switch / case body \"switch (test) { case: {} default: {} }\"\n\t\t- TRY = try body \"try {}\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"\n\t\t- REIFICATION = macro reification \"$i{}\"",
                             "items": {
+                                "type": "string",
                                 "enum": [
                                     "CLASS_DEF",
                                     "ENUM_DEF",
@@ -1412,656 +2748,1637 @@
                                     "TRY",
                                     "CATCH",
                                     "REIFICATION"
-                                ],
-                                "type": "string"
+                                ]
                             },
-                            "propertyOrder": 0,
-                            "type": "array"
+                            "type": "array",
+                            "propertyOrder": 0
                         },
                         "option": {
                             "description": "for all empty blocks matched by tokens\n\t\t- empty = allow empty blocks but enforce \"{}\" notation\n\t\t- text = must contain something apart from whitespace (comment or statement)\n\t\t- stmt = must contain at least one statement (that is not a comment)",
-                            "propertyOrder": 1,
+                            "type": "string",
                             "enum": [
                                 "empty",
                                 "text",
                                 "stmt"
                             ],
-                            "type": "string"
+                            "propertyOrder": 1
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 2
                         }
                     },
-                    "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
-                    "enum": [
-                        "EmptyBlock"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks for empty blocks. The policy to verify is specified using the property `option`.",
-            "additionalProperties": false,
             "type": "object"
         },
-        "TypeNameCheck": {
+        "NestedControlFlowCheck": {
+            "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
+                    "type": "string",
+                    "enum": [
+                        "NestedControlFlow"
+                    ]
+                },
                 "props": {
+                    "description": "Checks for maximium nesting depth of control flow expressions (`if`, `for`, `while`, `do/while`, `switch` and `try`).",
+                    "additionalProperties": false,
                     "properties": {
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "description": "check applies to:\n\t- INTERFACE = all interface types\n\t- CLASS = all class types\n\t- ENUM = all enum types\n\t- ABSTRACT = all abstract types\n\t- TYPEDEF = all typedef types",
-                                "enum": [
-                                    "INTERFACE",
-                                    "CLASS",
-                                    "ENUM",
-                                    "ABSTRACT",
-                                    "TYPEDEF"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 1,
-                            "type": "array"
+                        "max": {
+                            "description": "maximum number of nested control flow expressions allowed",
+                            "type": "integer",
+                            "propertyOrder": 0
                         },
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "propertyOrder": 2,
-                            "type": "boolean"
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "EmptyLinesCheck": {
+            "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
+                    "type": "string",
+                    "enum": [
+                        "EmptyLines"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "requireEmptyLineAfterAbstract": {
+                            "description": "require an empty line after abstract keyword",
+                            "type": "boolean",
+                            "propertyOrder": 6
+                        },
+                        "requireEmptyLineAfterInterface": {
+                            "description": "require an empty line after interface keyword",
+                            "type": "boolean",
+                            "propertyOrder": 5
+                        },
+                        "allowEmptyLineAfterSingleLineComment": {
+                            "description": "allow empty lines after a single line comment",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        },
+                        "max": {
+                            "description": "number of empty lines to allow",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 7
+                        },
+                        "requireEmptyLineAfterClass": {
+                            "description": "require an empty line after class keyword",
+                            "type": "boolean",
+                            "propertyOrder": 4
+                        },
+                        "allowEmptyLineAfterMultiLineComment": {
+                            "description": "allow empty lines after a mutli line comment",
+                            "type": "boolean",
+                            "propertyOrder": 2
+                        },
+                        "requireEmptyLineAfterPackage": {
+                            "description": "require an empty line after package definition",
+                            "type": "boolean",
+                            "propertyOrder": 3
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "NestedForDepthCheck": {
+            "description": "Restricts nested loop blocks to a specified depth (default = 1).",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Restricts nested loop blocks to a specified depth (default = 1).",
+                    "type": "string",
+                    "enum": [
+                        "NestedForDepth"
+                    ]
+                },
+                "props": {
+                    "description": "Restricts nested loop blocks to a specified depth (default = 1).",
+                    "additionalProperties": false,
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of nested loops allowed\n\t\tsetting \"max\" to 1 allows one inner loop",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ArrayAccessCheck": {
+            "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
+                    "type": "string",
+                    "enum": [
+                        "ArrayAccess"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "spaceBefore": {
+                            "description": "set \"spaceBefore\" to false to detect space between array and \"[\"",
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        },
+                        "spaceInside": {
+                            "description": "set to false to detect space between brackets (\"[\" + \"]\") and index",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "CatchParameterNameCheck": {
+            "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
+                    "type": "string",
+                    "enum": [
+                        "CatchParameterName"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
                         },
                         "format": {
                             "description": "regex name format",
-                            "propertyOrder": 0,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
+                            "type": "string",
+                            "propertyOrder": 0
                         }
                     },
-                    "description": "Checks that type names conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks that type names conform to a format specified by the `format` property.",
-                    "enum": [
-                        "TypeName"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks that type names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "DefaultComesLastCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
-                    "enum": [
-                        "DefaultComesLast"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Check that the `default` is after all the cases in a `switch` statement. Haxe allows `default` anywhere within the `switch` statement. But it is more readable if it comes after the last `case`.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "SeparatorWhitespaceCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "dotPolicy": {
-                            "description": "policy for \".\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "commaPolicy": {
-                            "description": "policy for \",\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "allowTrailingComma": {
-                            "description": "no violoation for missing whitespace after trailing commas",
-                            "propertyOrder": 2,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 4,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "semicolonPolicy": {
-                            "description": "policy for \";\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks that whitespace is present or absent around a separators.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that whitespace is present or absent around a separators.",
-                    "enum": [
-                        "SeparatorWhitespace"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that whitespace is present or absent around a separators.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "LineLengthCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of characters per line (default: 160)",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "ignorePattern": {
-                            "description": "ignore lines matching regex",
-                            "propertyOrder": 1,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for long lines. Long lines are hard to read.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for long lines. Long lines are hard to read.",
-                    "enum": [
-                        "LineLength"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for long lines. Long lines are hard to read.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "StringLiteralCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "allowException": {
-                            "description": "\"allowException\" allows using single quotes in \"onlyDouble\" and \"doubleAndInterpolation\" mode, when string contains a double quote character.\n\t\tOr double quotes in \"onlySingle\" mode when string contains a single quote character, reducing the need to escape quotation marks.",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "policy": {
-                            "description": "policy for string literal use\n\t\t- onlySingle = enforce single quotes\n\t\t- onlyDouble = enforce double quotes, no interpolation allowed\n\t\t- doubleAndInterpolation = enforce double quotes, allow single quotes for interpolation",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "onlySingle",
-                                "onlyDouble",
-                                "doubleAndInterpolation"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for single or double quote string literals.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for single or double quote string literals.",
-                    "enum": [
-                        "StringLiteral"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for single or double quote string literals.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "CodeSimilarityCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severityIdentical": {
-                            "description": "severity level for identical code blocks",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "thresholdIdentical": {
-                            "description": "maximum number of tokens allowed before detecting identical code blocks",
-                            "propertyOrder": 1,
-                            "type": "integer"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "thresholdSimilar": {
-                            "description": "maximum number of tokens allowed before detecting similar code blocks",
-                            "propertyOrder": 2,
-                            "type": "integer"
-                        }
-                    },
-                    "description": "Checks for identical or similar code.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for identical or similar code.",
-                    "enum": [
-                        "CodeSimilarity"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for identical or similar code.",
-            "additionalProperties": false,
             "type": "object"
         },
         "WhitespaceAroundCheck": {
+            "description": "Checks that a token is surrounded by whitespace.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks that a token is surrounded by whitespace.",
+                    "type": "string",
+                    "enum": [
+                        "WhitespaceAround"
+                    ]
+                },
                 "props": {
+                    "description": "Checks that a token is surrounded by whitespace.",
+                    "additionalProperties": false,
                     "properties": {
                         "tokens": {
                             "description": "supported list of tokens:\n\t\t\",\", \";\", \"(\", \")\", \"[\", \"]\", \"{\", \"}\", \":\", \".\", \"=\", \"+\", \"-\", \"*\", \"/\", \"%\", \">\", \"<\", \">=\", \"<=\", \"==\", \"!=\",\n\t\t\"&\", \"|\", \"^\", \"&&\", \"||\", \"<<\", \">>\", \">>>\", \"+=\", \"-=\", \"*=\", \"/=\", \"%=\", \"<<=\", \">>=\", \">>>=\", \"|=\", \"&=\",\n\t\t\"^=\", \"...\", \"=>\", \"!\", \"++\", \"--\",",
                             "items": {
                                 "type": "string"
                             },
-                            "propertyOrder": 0,
-                            "type": "array"
+                            "type": "array",
+                            "propertyOrder": 0
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 1
                         }
                     },
-                    "description": "Checks that a token is surrounded by whitespace.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks that a token is surrounded by whitespace.",
-                    "enum": [
-                        "WhitespaceAround"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks that a token is surrounded by whitespace.",
-            "additionalProperties": false,
             "type": "object"
         },
-        "AvoidStarImportCheck": {
+        "LongNumberCheck": {
+            "description": "Checks that there are no long decimal numbers without separators.",
+            "additionalProperties": false,
             "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for import statements that use the * notation and using directives.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
                 "type": {
-                    "description": "Checks for import statements that use the * notation and using directives.",
+                    "description": "Checks that there are no long decimal numbers without separators.",
+                    "type": "string",
                     "enum": [
-                        "AvoidStarImport"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for import statements that use the * notation and using directives.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "SimplifyBooleanReturnCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for over-complicated boolean return statements.",
-                    "additionalProperties": false,
-                    "type": "object"
+                        "LongNumber"
+                    ]
                 },
-                "type": {
-                    "description": "Checks for over-complicated boolean return statements.",
-                    "enum": [
-                        "SimplifyBooleanReturn"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for over-complicated boolean return statements.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "VariableInitialisationCheck": {
-            "properties": {
                 "props": {
+                    "description": "Checks that there are no long decimal numbers without separators.",
+                    "additionalProperties": false,
                     "properties": {
-                        "allowFinal": {
-                            "description": "final fields must be initialised either immediately or in constructor\n\t\twhen allowFinal is true then VariableInitialisation won't complain about initialisation at class level for final fields",
-                            "propertyOrder": 0,
-                            "type": "boolean"
+                        "binaryGroupSize": {
+                            "description": "for binary numbers, the number of consecutive digits before it's a long number\n\t\tdefaults to `8`, where `0b101010101` is a long number but `0b1_01010101` is valid\n\t\tuse `-1` to disable the check entirely",
+                            "type": "integer",
+                            "propertyOrder": 5
+                        },
+                        "hexadecimalGroupSize": {
+                            "description": "for hexadecimal numbers, the number of consecutive digits before it's a long number\n\t\tdefaults to `8`, where `0x123456789` is a long number but `0x1_2345678` is valid\n\t\tuse `-1` to disable the check entirely",
+                            "type": "integer",
+                            "propertyOrder": 3
+                        },
+                        "decimalGroupSize": {
+                            "description": "for decimal numbers, the number of consecutive digits before it's a long number\n\t\tdefaults to `3`, where `1000` is a long number but `1_000` is valid\n\t\tuse `-1` to disable the check entirely",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "decimalMinimum": {
+                            "description": "for decimal numbers, the minimum quantity before it's a long number\n\t\tfor example, if set to `1000000`, `999999` requires no separators but `1_000_000` does\n\t\tdefaults to `0` to disable the check",
+                            "type": "integer",
+                            "propertyOrder": 1
+                        },
+                        "fractionalGroupSize": {
+                            "description": "for floating point decimal numbers, the number of consecutive digits after the decimal pointbefore it's a long number\n\t\tfor example, where `1000` is a long number but `1_000` is valid\n\t\tdefaults to `-1` to disable the check\n\t\tuse `-1` to disable the check entirely",
+                            "type": "integer",
+                            "propertyOrder": 2
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 6
+                        },
+                        "hexadecimalMinimum": {
+                            "description": "for hexadecimal numbers, the minimum quantity before it's a long number\n\t\tfor example, if set to `0x1000000000`, `0x123456789` requires no separators but `0x12_34567890` does\n\t\tdefaults to `0` to disable the check",
+                            "type": "integer",
+                            "propertyOrder": 4
                         }
                     },
-                    "description": "Checks for instance variables that are initialised at class level.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks for instance variables that are initialised at class level.",
-                    "enum": [
-                        "VariableInitialisation"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks for instance variables that are initialised at class level.",
-            "additionalProperties": false,
             "type": "object"
         },
-        "MultipleVariableDeclarationsCheck": {
+        "ExcludeConfig": {
+            "description": "defines filters to exclude folders, types or files from all or specific checks",
+            "additionalProperties": false,
             "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks that each variable declaration is in its own statement and on its own line.",
-                    "additionalProperties": false,
-                    "type": "object"
+                "": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 3
                 },
-                "type": {
-                    "description": "Checks that each variable declaration is in its own statement and on its own line.",
+                "UnusedImport": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 80
+                },
+                "Dynamic": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 20
+                },
+                "Final": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 29
+                },
+                "MultipleStringLiterals": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 47
+                },
+                "LongNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 40
+                },
+                "NeedBraces": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 49
+                },
+                "SeparatorWhitespace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 66
+                },
+                "all": {
+                    "$ref": "#/definitions/ExcludeFilterList"
+                },
+                "LocalVariableName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 39
+                },
+                "NestedForDepth": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 51
+                },
+                "Anonymous": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 4
+                },
+                "MultipleVariableDeclarations": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 48
+                },
+                "NestedTryDepth": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 53
+                },
+                "BlockBreakingConditional": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 11
+                },
+                "CatchParameterName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 12
+                },
+                "EmptyBlock": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 22
+                },
+                "ExtendedEmptyLines": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 25
+                },
+                "ReturnCount": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 64
+                },
+                "DefaultComesLast": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 18
+                },
+                "HexadecimalLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 30
+                },
+                "WhitespaceAfter": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 84
+                },
+                "ConstantName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 16
+                },
+                "EmptyPackage": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 24
+                },
+                "Interface": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 35
+                },
+                "WhitespaceAround": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 85
+                },
+                "NestedIfDepth": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 52
+                },
+                "ParameterName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 57
+                },
+                "NullableParameter": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 54
+                },
+                "AvoidStarImport": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 9
+                },
+                "SeparatorWrap": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 67
+                },
+                "AvoidIdentifier": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 8
+                },
+                "RedundantAllowMeta": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 61
+                },
+                "HiddenField": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 31
+                },
+                "UnnecessaryConstructor": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 79
+                },
+                "SimplifyBooleanExpression": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 68
+                },
+                "path": {
+                    "description": "filters excludes relative to\n\t- RELATIVE_TO_PROJECT = use project root\n\t- RELATIVE_TO_SOURCE = use path(s) specified via \"-s <path>\" command line switches",
+                    "type": "string",
                     "enum": [
-                        "MultipleVariableDeclarations"
-                    ],
-                    "type": "string"
+                        "RELATIVE_TO_PROJECT",
+                        "RELATIVE_TO_SOURCE"
+                    ]
+                },
+                "MethodCount": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 43
+                },
+                "UnusedLocalVar": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 81
+                },
+                "TabForAligning": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 73
+                },
+                "MethodName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 45
+                },
+                "RightCurly": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 65
+                },
+                "AvoidTernaryOperator": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 10
+                },
+                "ParameterNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 58
+                },
+                "ArrowFunction": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 7
+                },
+                "MethodLength": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 44
+                },
+                "ConditionalCompilation": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 15
+                },
+                "EmptyLines": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 23
+                },
+                "MemberName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 42
+                },
+                "ERegLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 21
+                },
+                "RedundantModifier": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 62
+                },
+                "Type": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 76
+                },
+                "TypeName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 78
+                },
+                "Indentation": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 32
+                },
+                "FileNameCase": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 28
+                },
+                "CommentedOutCode": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 14
+                },
+                "version": {
+                    "maximum": 1,
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "Return": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 63
+                },
+                "SimplifyBooleanReturn": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 69
+                },
+                "TODOComment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 72
+                },
+                "VarTypeHint": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 82
+                },
+                "NestedControlFlow": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 50
+                },
+                "OperatorWhitespace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 55
+                },
+                "Spacing": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 70
+                },
+                "IndentationCharacter": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 33
+                },
+                "MagicNumber": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 41
+                },
+                "ArrayLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 6
+                },
+                "TrailingWhitespace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 75
+                },
+                "VariableInitialisation": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 83
+                },
+                "LineLength": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 37
+                },
+                "ListenerName": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 38
+                },
+                "FileLength": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 27
+                },
+                "CyclomaticComplexity": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 17
+                },
+                "StringLiteral": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 71
+                },
+                "Trace": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 74
+                },
+                "ArrayAccess": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 5
+                },
+                "PublicAccessor": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 59
+                },
+                "DocCommentStyle": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 19
+                },
+                "InnerAssignment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 34
+                },
+                "RedundantAccessMeta": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 60
+                },
+                "CodeSimilarity": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 13
+                },
+                "OperatorWrap": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 56
+                },
+                "TypeDocComment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 77
+                },
+                "LeftCurly": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 36
+                },
+                "ModifierOrder": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 46
+                },
+                "FieldDocComment": {
+                    "$ref": "#/definitions/ExcludeFilterList",
+                    "propertyOrder": 26
                 }
             },
-            "description": "Checks that each variable declaration is in its own statement and on its own line.",
-            "additionalProperties": false,
             "type": "object"
         },
         "RedundantModifierCheck": {
+            "description": "Checks for redundant modifiers.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks for redundant modifiers.",
+                    "type": "string",
+                    "enum": [
+                        "RedundantModifier"
+                    ]
+                },
                 "props": {
+                    "description": "Checks for redundant modifiers.",
+                    "additionalProperties": false,
                     "properties": {
-                        "enforcePublic": {
-                            "description": "enforce use of \"public\" modifiers",
-                            "propertyOrder": 1,
-                            "type": "boolean"
+                        "enforcePrivate": {
+                            "description": "enforce use of \"private\" modifiers",
+                            "type": "boolean",
+                            "propertyOrder": 2
                         },
                         "enforcePublicPrivate": {
                             "description": "enforce use of \"public\" and \"private\" modifiers\n\t\timplies enforcePublic and enforcePrivate",
-                            "propertyOrder": 0,
-                            "type": "boolean"
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        },
+                        "enforcePublic": {
+                            "description": "enforce use of \"public\" modifiers",
+                            "type": "boolean",
+                            "propertyOrder": 1
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
-                        },
-                        "enforcePrivate": {
-                            "description": "enforce use of \"private\" modifiers",
-                            "propertyOrder": 2,
-                            "type": "boolean"
+                            "propertyOrder": 3
                         }
                     },
-                    "description": "Checks for redundant modifiers.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks for redundant modifiers.",
-                    "enum": [
-                        "RedundantModifier"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks for redundant modifiers.",
+            "type": "object"
+        },
+        "TODOCommentCheck": {
+            "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
             "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
+                    "type": "string",
+                    "enum": [
+                        "TODOComment"
+                    ]
+                },
+                "props": {
+                    "description": "A check for TODO/FIXME/HACK/XXX/BUG comments. The format can be customised by changing `format` property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "format": {
+                            "description": "regex todo comment format, defaults to \"^\\\\s*(TODO|FIXME|HACK|XXX|BUG)\"",
+                            "type": "string",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "BlockBreakingConditionalCheck": {
+            "description": "Checks for block breaking conditionals.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for block breaking conditionals.",
+                    "type": "string",
+                    "enum": [
+                        "BlockBreakingConditional"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for block breaking conditionals.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
             "type": "object"
         },
         "VarTypeHintCheck": {
+            "description": "Checks type hints of variables.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks type hints of variables.",
+                    "type": "string",
+                    "enum": [
+                        "VarTypeHint"
+                    ]
+                },
                 "props": {
+                    "description": "Checks type hints of variables.",
+                    "additionalProperties": false,
                     "properties": {
+                        "ignoreEnumAbstractValues": {
+                            "description": "ignores fields inside abstract enums",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        },
                         "typeHintPolicy": {
                             "description": "policy for type hints on var and final",
-                            "propertyOrder": 0,
+                            "type": "string",
                             "enum": [
                                 "enforce_all",
                                 "infer_new_or_const",
                                 "infer_all"
                             ],
-                            "type": "string"
-                        },
-                        "ignoreEnumAbstractValues": {
-                            "description": "ignores fields inside abstract enums",
-                            "propertyOrder": 1,
-                            "type": "boolean"
+                            "propertyOrder": 0
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 2
                         }
                     },
-                    "description": "Checks type hints of variables.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks type hints of variables.",
-                    "enum": [
-                        "VarTypeHint"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks type hints of variables.",
-            "additionalProperties": false,
             "type": "object"
         },
-        "FileNameCaseCheck": {
+        "CodeSimilarityCheck": {
+            "description": "Checks for identical or similar code.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks for identical or similar code.",
+                    "type": "string",
+                    "enum": [
+                        "CodeSimilarity"
+                    ]
+                },
                 "props": {
+                    "description": "Checks for identical or similar code.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "thresholdSimilar": {
+                            "description": "maximum number of tokens allowed before detecting similar code blocks",
+                            "type": "integer",
+                            "propertyOrder": 2
+                        },
+                        "thresholdIdentical": {
+                            "description": "maximum number of tokens allowed before detecting identical code blocks",
+                            "type": "integer",
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 3
+                        },
+                        "severityIdentical": {
+                            "description": "severity level for identical code blocks",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "UnnecessaryConstructorCheck": {
+            "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
+                    "type": "string",
+                    "enum": [
+                        "UnnecessaryConstructor"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for unnecessary constructor in classes that contain only static methods or fields.",
+                    "additionalProperties": false,
                     "properties": {
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 0
                         }
                     },
-                    "description": "Checks that file names match the case of their module name.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks that file names match the case of their module name.",
-                    "enum": [
-                        "FileNameCase"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks that file names match the case of their module name.",
+            "type": "object"
+        },
+        "ParameterNameCheck": {
+            "description": "Checks that parameter names conform to a format specified by the `format` property.",
             "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that parameter names conform to a format specified by the `format` property.",
+                    "type": "string",
+                    "enum": [
+                        "ParameterName"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that parameter names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "type": "boolean",
+                            "propertyOrder": 2
+                        },
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 3
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "type": "string",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "AnonymousCheck": {
+            "description": "Check to find any anonymous type structures used.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Check to find any anonymous type structures used.",
+                    "type": "string",
+                    "enum": [
+                        "Anonymous"
+                    ]
+                },
+                "props": {
+                    "description": "Check to find any anonymous type structures used.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "MethodCountCheck": {
+            "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
+                    "type": "string",
+                    "enum": [
+                        "MethodCount"
+                    ]
+                },
+                "props": {
+                    "description": "Checks the number of methods declared in each type. This includes the number of each scope (`private` and `public`) as well as an overall total.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "maxTotal": {
+                            "description": "maximum number of functions permitted per file (default: 100)",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "maxPublic": {
+                            "description": "maximum number of public functions permitted per file (default: 100)",
+                            "type": "integer",
+                            "propertyOrder": 2
+                        },
+                        "maxPrivate": {
+                            "description": "maximum number of private functions permitted per file (default: 100)",
+                            "type": "integer",
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 3
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "FinalCheck": {
+            "description": "Checks for places that use var instead of final (Haxe 4+).",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for places that use var instead of final (Haxe 4+).",
+                    "type": "string",
+                    "enum": [
+                        "Final"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for places that use var instead of final (Haxe 4+).",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ConditionalCompilationCheck": {
+            "description": "Checks placement and indentation of conditional compilation flags.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks placement and indentation of conditional compilation flags.",
+                    "type": "string",
+                    "enum": [
+                        "ConditionalCompilation"
+                    ]
+                },
+                "props": {
+                    "description": "Checks placement and indentation of conditional compilation flags.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "allowSingleline": {
+                            "description": "allows or prevents using single line conditional compilation flags.",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        },
+                        "policy": {
+                            "description": "indentation of conditional statements\n\t\t- startOfLine = #if, #else, #elseif and #end must start at beginning of line\n\t\t- aligned = indentation of #if, #else, #elseif and #end must match surrounding code\n\n\t\tBoth \"aligned\" and \"startOfLine\" will produce a message if conditional compilation flags are not on a separate line.\n\t\tAll #else, #elseif and #end flags must have the same indentation as their corresponding #if.",
+                            "type": "string",
+                            "enum": [
+                                "startOfLine",
+                                "aligned"
+                            ],
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "MemberNameCheck": {
+            "description": "Checks that instance variable names conform to a format specified by the `format` property.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks that instance variable names conform to a format specified by the `format` property.",
+                    "type": "string",
+                    "enum": [
+                        "MemberName"
+                    ]
+                },
+                "props": {
+                    "description": "Checks that instance variable names conform to a format specified by the `format` property.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignoreExtern": {
+                            "description": "ignores names inside extern types",
+                            "type": "boolean",
+                            "propertyOrder": 2
+                        },
+                        "tokens": {
+                            "description": "list of tokens to limit where names should conform to \"format\"",
+                            "items": {
+                                "description": "check applies to:\n\t- PUBLIC = all public fields\n\t- PRIVATE = all private fields\n\t- ENUM = all enum fields\n\t- CLASS = all class fields, use in combination with PUBLIC and PRIVATE to only match public/private class fields\n\t- ABSTRACT = all abstract fields, use in combination with PUBLIC and PRIVATE to only match public/private abstract fields\n\t- TYPEDEF = all typedef fields",
+                                "type": "string",
+                                "enum": [
+                                    "PUBLIC",
+                                    "PRIVATE",
+                                    "ENUM",
+                                    "CLASS",
+                                    "ABSTRACT",
+                                    "TYPEDEF"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 3
+                        },
+                        "format": {
+                            "description": "regex name format",
+                            "type": "string",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ERegLiteralCheck": {
+            "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
+                    "type": "string",
+                    "enum": [
+                        "ERegLiteral"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "SimplifyBooleanExpressionCheck": {
+            "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
+                    "type": "string",
+                    "enum": [
+                        "SimplifyBooleanExpression"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for over-complicated boolean expressions. Finds code like `if (b == true), b || true, !false`, etc.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "VariableInitialisationCheck": {
+            "description": "Checks for instance variables that are initialised at class level.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for instance variables that are initialised at class level.",
+                    "type": "string",
+                    "enum": [
+                        "VariableInitialisation"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for instance variables that are initialised at class level.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "allowFinal": {
+                            "description": "final fields must be initialised either immediately or in constructor\n\t\twhen allowFinal is true then VariableInitialisation won't complain about initialisation at class level for final fields",
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "MethodLengthCheck": {
+            "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
+                    "type": "string",
+                    "enum": [
+                        "MethodLength"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "max": {
+                            "description": "maximum number of lines per method (default: 50)",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "ignoreEmptyLines": {
+                            "description": "ignores or includes empty lines when counting method length",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "AvoidIdentifierCheck": {
+            "description": "Checks for identifiers to avoid.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for identifiers to avoid.",
+                    "type": "string",
+                    "enum": [
+                        "AvoidIdentifier"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for identifiers to avoid.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        },
+                        "avoidIdentifiers": {
+                            "description": "list of identifiers to avoid",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "NeedBracesCheck": {
+            "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
+                    "type": "string",
+                    "enum": [
+                        "NeedBraces"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "tokens": {
+                            "description": "matches only statements specified in tokens list:\n\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if body \"if (test) {} else {}\"\n\t\t- ELSE_IF = if body \"if (test) {} else if {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- DO_WHILE = do…while body \"do {} while (test)\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "FUNCTION",
+                                    "FOR",
+                                    "IF",
+                                    "ELSE_IF",
+                                    "WHILE",
+                                    "DO_WHILE",
+                                    "CATCH"
+                                ]
+                            },
+                            "type": "array",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 2
+                        },
+                        "allowSingleLineStatement": {
+                            "description": "allow / disallow use of single line statements without braces",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "NullableParameterCheck": {
+            "description": "Enforces a style for nullable parameters.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Enforces a style for nullable parameters.",
+                    "type": "string",
+                    "enum": [
+                        "NullableParameter"
+                    ]
+                },
+                "props": {
+                    "description": "Enforces a style for nullable parameters.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "option": {
+                            "description": "nullable style to enforece\n\t\t- questionMark = nullable parameters should use \"?name:Type\"\n\t\t- nullDefault = nullable parameters should use \"name:Type = null\"",
+                            "type": "string",
+                            "enum": [
+                                "questionMark",
+                                "nullDefault"
+                            ],
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 1
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ReturnCheck": {
+            "description": "Warns if Void is used for return or if return type is not specified when returning.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Warns if Void is used for return or if return type is not specified when returning.",
+                    "type": "string",
+                    "enum": [
+                        "Return"
+                    ]
+                },
+                "props": {
+                    "description": "Warns if Void is used for return or if return type is not specified when returning.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enforceReturnType": {
+                            "description": "enforces return type for every function",
+                            "type": "boolean",
+                            "propertyOrder": 1
+                        },
+                        "enforceReturnTypeForAnonymous": {
+                            "description": "enforces return type for anonymous functions",
+                            "type": "boolean",
+                            "propertyOrder": 2
+                        },
+                        "allowEmptyReturn": {
+                            "description": "allows empty return which is mostly used to exit functions.",
+                            "type": "boolean",
+                            "propertyOrder": 0
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 3
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "MultipleStringLiteralsCheck": {
+            "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
+                    "type": "string",
+                    "enum": [
+                        "MultipleStringLiterals"
+                    ]
+                },
+                "props": {
+                    "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ignore": {
+                            "description": "ignore string literals matching regex",
+                            "type": "string",
+                            "propertyOrder": 2
+                        },
+                        "minLength": {
+                            "description": "string literals must be \"minLength\" or more characters before including them",
+                            "type": "integer",
+                            "propertyOrder": 1
+                        },
+                        "severity": {
+                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                            "type": "string",
+                            "enum": [
+                                "INFO",
+                                "WARNING",
+                                "ERROR",
+                                "IGNORE"
+                            ],
+                            "propertyOrder": 3
+                        },
+                        "allowDuplicates": {
+                            "description": "number of occurrences to allow",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        }
+                    },
+                    "type": "object"
+                }
+            },
             "type": "object"
         },
         "Config": {
+            "additionalProperties": false,
             "properties": {
+                "baseDefines": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "defineCombinations": {
+                    "items": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "type": "array"
+                },
+                "defaultSeverity": {
+                    "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
+                    "type": "string",
+                    "enum": [
+                        "INFO",
+                        "WARNING",
+                        "ERROR",
+                        "IGNORE"
+                    ]
+                },
+                "extendsConfigPath": {
+                    "type": "string"
+                },
+                "version": {
+                    "maximum": 1,
+                    "type": "integer",
+                    "minimum": 1
+                },
                 "checks": {
                     "items": {
                         "anyOf": [
@@ -2315,2448 +4632,140 @@
                     },
                     "type": "array"
                 },
-                "version": {
-                    "minimum": 1,
-                    "type": "integer",
-                    "maximum": 1
-                },
-                "numberOfCheckerThreads": {
-                    "minimum": 1,
-                    "type": "integer",
-                    "maximum": 15
-                },
                 "exclude": {
                     "$ref": "#/definitions/ExcludeConfig"
                 },
-                "baseDefines": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "defineCombinations": {
-                    "items": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "type": "array"
-                },
-                "extendsConfigPath": {
-                    "type": "string"
-                },
-                "defaultSeverity": {
-                    "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                    "enum": [
-                        "INFO",
-                        "WARNING",
-                        "ERROR",
-                        "IGNORE"
-                    ],
-                    "type": "string"
+                "numberOfCheckerThreads": {
+                    "maximum": 15,
+                    "type": "integer",
+                    "minimum": 1
                 }
             },
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ConditionalCompilationCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "policy": {
-                            "description": "indentation of conditional statements\n\t\t- startOfLine = #if, #else, #elseif and #end must start at beginning of line\n\t\t- aligned = indentation of #if, #else, #elseif and #end must match surrounding code\n\n\t\tBoth \"aligned\" and \"startOfLine\" will produce a message if conditional compilation flags are not on a separate line.\n\t\tAll #else, #elseif and #end flags must have the same indentation as their corresponding #if.",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "startOfLine",
-                                "aligned"
-                            ],
-                            "type": "string"
-                        },
-                        "allowSingleline": {
-                            "description": "allows or prevents using single line conditional compilation flags.",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        }
-                    },
-                    "description": "Checks placement and indentation of conditional compilation flags.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks placement and indentation of conditional compilation flags.",
-                    "enum": [
-                        "ConditionalCompilation"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks placement and indentation of conditional compilation flags.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "TypeCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "ignoreEnumAbstractValues": {
-                            "description": "ignores fields inside abstract enums",
-                            "propertyOrder": 0,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks if type is specified or not for member variables.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks if type is specified or not for member variables.",
-                    "enum": [
-                        "Type"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks if type is specified or not for member variables.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "IndentationCharacterCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "character": {
-                            "description": "set indentation to\n\t\t- tab = tab\n\t\t- space = space",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "tab",
-                                "space"
-                            ],
-                            "type": "string"
-                        },
-                        "ignorePattern": {
-                            "description": "ignore lines that match regex",
-                            "propertyOrder": 1,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks indentation character (tab/space, default is tab).",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks indentation character (tab/space, default is tab).",
-                    "enum": [
-                        "IndentationCharacter"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks indentation character (tab/space, default is tab).",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "RightCurlyCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "matches only right curlys specified in tokens list:\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- OBJECT_DECL = object declaration \"{ x: 0, y: 0, z: 0}\"\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if / else body \"if (test) {} else {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- SWITCH = switch / case body \"switch (test) { case: {} default: {} }\"\n\t\t- TRY = try body \"try {}\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"\n\t\t- REIFICATION = macro reification \"$i{}\"\n\t\t- ARRAY_COMPREHENSION = array comprehension \"[for (i in 0...10) {i * 2}]\"",
-                            "items": {
-                                "enum": [
-                                    "CLASS_DEF",
-                                    "ENUM_DEF",
-                                    "ABSTRACT_DEF",
-                                    "TYPEDEF_DEF",
-                                    "INTERFACE_DEF",
-                                    "OBJECT_DECL",
-                                    "FUNCTION",
-                                    "FOR",
-                                    "IF",
-                                    "WHILE",
-                                    "SWITCH",
-                                    "TRY",
-                                    "CATCH",
-                                    "REIFICATION",
-                                    "ARRAY_COMPREHENSION"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "option": {
-                            "description": "placement of right curly\n\t\t- same = right curly must be alone on a new line, except for \"} else\" and \"} catch\"\n\t\t- alone = alone on a new line\n\t\t- aloneorsingle = right curly can occur on same line as left curly or must be alone on a new line",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "same",
-                                "alone",
-                                "aloneorsingle"
-                            ],
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
-                    "enum": [
-                        "RightCurly"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks the placement of right curly braces (`}`) for code blocks. The policy to verify is specified using the property `option`.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "NullableParameterCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "option": {
-                            "description": "nullable style to enforece\n\t\t- questionMark = nullable parameters should use \"?name:Type\"\n\t\t- nullDefault = nullable parameters should use \"name:Type = null\"",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "questionMark",
-                                "nullDefault"
-                            ],
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Enforces a style for nullable parameters.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Enforces a style for nullable parameters.",
-                    "enum": [
-                        "NullableParameter"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Enforces a style for nullable parameters.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "OperatorWrapCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "list mof wrapping tokens",
-                            "items": {
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "option": {
-                            "description": "policy for wrapping token\n\t\t- eol = wrapping token should be at end of line\n\t\t- nl = wrapping token should start a new line",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "eol",
-                                "nl"
-                            ],
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks line wrapping with operators.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks line wrapping with operators.",
-                    "enum": [
-                        "OperatorWrap"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks line wrapping with operators.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "Threshold": {
-            "properties": {
-                "severity": {
-                    "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                    "propertyOrder": 0,
-                    "enum": [
-                        "INFO",
-                        "WARNING",
-                        "ERROR",
-                        "IGNORE"
-                    ],
-                    "type": "string"
-                },
-                "complexity": {
-                    "description": "complexity value associated with \"severity\"",
-                    "propertyOrder": 1,
-                    "type": "integer"
-                }
-            },
-            "description": "threshold for code complexity",
-            "additionalProperties": false,
-            "required": [
-                "severity",
-                "complexity"
-            ],
-            "type": "object"
-        },
-        "MagicNumberCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "ignoreNumbers": {
-                            "description": "list of magic numbers to ignore during checks",
-                            "items": {
-                                "type": "number"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
-                    "enum": [
-                        "MagicNumber"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that there are no magic numbers. By default, -1, 0, 1, and 2 are not considered to be magic numbers.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ArrayLiteralCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
-                    "enum": [
-                        "ArrayLiteral"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks if the array is instantiated using [] which is shorter and cleaner, not with new.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ReturnCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "enforceReturnType": {
-                            "description": "enforces return type for every function",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        },
-                        "allowEmptyReturn": {
-                            "description": "allows empty return which is mostly used to exit functions.",
-                            "propertyOrder": 0,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "enforceReturnTypeForAnonymous": {
-                            "description": "enforces return type for anonymous functions",
-                            "propertyOrder": 2,
-                            "type": "boolean"
-                        }
-                    },
-                    "description": "Warns if Void is used for return or if return type is not specified when returning.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Warns if Void is used for return or if return type is not specified when returning.",
-                    "enum": [
-                        "Return"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Warns if Void is used for return or if return type is not specified when returning.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "RedundantAccessMetaCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "prohibitMeta": {
-                            "description": "switches behaviour of check to\n\t\t- false = look for redundant access modifications\n\t\t- true = to discourage its use everywhere",
-                            "propertyOrder": 0,
-                            "type": "boolean"
-                        }
-                    },
-                    "description": "Checks for redundant @:access metadata",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for redundant @:access metadata",
-                    "enum": [
-                        "RedundantAccessMeta"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for redundant @:access metadata",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "FieldDocCommentCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "matches only comment docs for types specified in tokens list:\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"",
-                            "items": {
-                                "enum": [
-                                    "ABSTRACT_DEF",
-                                    "CLASS_DEF",
-                                    "ENUM_DEF",
-                                    "INTERFACE_DEF",
-                                    "TYPEDEF_DEF"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "ignoreOverride": {
-                            "description": "ignores methods marked with override",
-                            "propertyOrder": 5,
-                            "type": "boolean"
-                        },
-                        "modifier": {
-                            "description": "only check fields matching modifier\n\t\t- PUBLIC = only public fields\n\t\t- PRIVATE = only private fields\n\t\t- BOTH = public and private fields",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "PUBLIC",
-                                "PRIVATE",
-                                "BOTH"
-                            ],
-                            "type": "string"
-                        },
-                        "excludeNames": {
-                            "description": "exclude field names from check - default: [\"new\", \"toString\"]",
-                            "items": {
-                                "type": "string"
-                            },
-                            "propertyOrder": 6,
-                            "type": "array"
-                        },
-                        "requireReturn": {
-                            "description": "ignores requires a `@return` tag",
-                            "propertyOrder": 4,
-                            "type": "boolean"
-                        },
-                        "requireParams": {
-                            "description": "ignores requires a `@param` tag for every parameter",
-                            "propertyOrder": 3,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 7,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "fieldType": {
-                            "description": "only check fields of type\n\t\t- VARS = only var fields\n\t\t- FUNCTIONS = only functions;\n\t\t- BOTH = both vars and functions;",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "VARS",
-                                "FUNCTIONS",
-                                "BOTH"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks code documentation on fields",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks code documentation on fields",
-                    "enum": [
-                        "FieldDocComment"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks code documentation on fields",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ArrayAccessCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "spaceBefore": {
-                            "description": "set \"spaceBefore\" to false to detect space between array and \"[\"",
-                            "propertyOrder": 0,
-                            "type": "boolean"
-                        },
-                        "spaceInside": {
-                            "description": "set to false to detect space between brackets (\"[\" + \"]\") and index",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
-                    "enum": [
-                        "ArrayAccess"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for spaces before array access or inside array elements. Finds code like `a [0], a[ 0]`, etc.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "FinalCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for places that use var instead of final (Haxe 4+).",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for places that use var instead of final (Haxe 4+).",
-                    "enum": [
-                        "Final"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for places that use var instead of final (Haxe 4+).",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ConstantNameCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "description": "supports inline and non inline constants\n\t- INLINE = \"static inline var\"\n\t- NOTINLINE = \"static var\"",
-                                "enum": [
-                                    "INLINE",
-                                    "NOTINLINE"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 1,
-                            "type": "array"
-                        },
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "propertyOrder": 2,
-                            "type": "boolean"
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "propertyOrder": 0,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
-                    "enum": [
-                        "ConstantName"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that the constants (static / static inline with initialisation) conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "AnonymousCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Check to find any anonymous type structures used.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Check to find any anonymous type structures used.",
-                    "enum": [
-                        "Anonymous"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Check to find any anonymous type structures used.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "CyclomaticComplexityCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "thresholds": {
-                            "description": "list of thresholds that define which severity level to report when complexity of method is above its limit",
-                            "items": {
-                                "$ref": "#/definitions/Threshold"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
-                    "enum": [
-                        "CyclomaticComplexity"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks the complexity of methods using McCabe simplified cyclomatic complexity check. Complexity levels can be customised using `thresholds` property.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "RedundantAllowMetaCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "prohibitMeta": {
-                            "description": "switches behaviour of check to\n\t\t- false = look for redundant access modifications\n\t\t- true = to discourage its use everywhere",
-                            "propertyOrder": 0,
-                            "type": "boolean"
-                        }
-                    },
-                    "description": "Checks for redundant @:allow metadata",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for redundant @:allow metadata",
-                    "enum": [
-                        "RedundantAllowMeta"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for redundant @:allow metadata",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "CommentedOutCodeCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks sections of commented out code",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks sections of commented out code",
-                    "enum": [
-                        "CommentedOutCode"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks sections of commented out code",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "NestedIfDepthCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of nested if statements allowed\n\t\tsetting \"max\" to 1 allows one if inside another",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
-                    "enum": [
-                        "NestedIfDepth"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Restricts nested `if-else` blocks to a specified depth (default = 1).",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "TypeDocCommentCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "matches only comment docs for types specified in tokens list:\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"",
-                            "items": {
-                                "enum": [
-                                    "ABSTRACT_DEF",
-                                    "CLASS_DEF",
-                                    "ENUM_DEF",
-                                    "INTERFACE_DEF",
-                                    "TYPEDEF_DEF"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks code documentation on type level",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks code documentation on type level",
-                    "enum": [
-                        "TypeDocComment"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks code documentation on type level",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "FileLengthCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of lines permitted per file (default: 2000)",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "ignoreEmptyLines": {
-                            "description": "ignores or includes empty lines when counting total file length",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
-                    "enum": [
-                        "FileLength"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for long source files. If a source file becomes very long it is hard to understand. Therefore long classes should usually be refactored into several individual classes that focus on a specific task.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "EmptyPackageCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "enforceEmptyPackage": {
-                            "description": "enforce using a package declaration, even if it is empty",
-                            "propertyOrder": 0,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for empty package names.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for empty package names.",
-                    "enum": [
-                        "EmptyPackage"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for empty package names.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "MemberNameCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "list of tokens to limit where names should conform to \"format\"",
-                            "items": {
-                                "description": "check applies to:\n\t- PUBLIC = all public fields\n\t- PRIVATE = all private fields\n\t- ENUM = all enum fields\n\t- CLASS = all class fields, use in combination with PUBLIC and PRIVATE to only match public/private class fields\n\t- ABSTRACT = all abstract fields, use in combination with PUBLIC and PRIVATE to only match public/private abstract fields\n\t- TYPEDEF = all typedef fields",
-                                "enum": [
-                                    "PUBLIC",
-                                    "PRIVATE",
-                                    "ENUM",
-                                    "CLASS",
-                                    "ABSTRACT",
-                                    "TYPEDEF"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 1,
-                            "type": "array"
-                        },
-                        "ignoreExtern": {
-                            "description": "ignores names inside extern types",
-                            "propertyOrder": 2,
-                            "type": "boolean"
-                        },
-                        "format": {
-                            "description": "regex name format",
-                            "propertyOrder": 0,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks that instance variable names conform to a format specified by the `format` property.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that instance variable names conform to a format specified by the `format` property.",
-                    "enum": [
-                        "MemberName"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that instance variable names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "LeftCurlyCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "tokens": {
-                            "description": "matches only left curlys specified in tokens list:\n\t\t- CLASS_DEF = class definition \"class Test {}\"\n\t\t- ENUM_DEF = enum definition \"enum Test {}\"\n\t\t- ABSTRACT_DEF = abstract definition \"abstract Test {}\"\n\t\t- TYPEDEF_DEF = typdef definition \"typedef Test = {}\"\n\t\t- INTERFACE_DEF = interface definition \"interface Test {}\"\n\t\t- OBJECT_DECL = object declaration \"{ x: 0, y: 0, z: 0}\"\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if / else body \"if (test) {} else {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- SWITCH = switch / case body \"switch (test) { case: {} default: {} }\"\n\t\t- TRY = try body \"try {}\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"\n\t\t- REIFICATION = macro reification \"$i{}\"\n\t\t- ARRAY_COMPREHENSION = array comprehension \"[for (i in 0...10) {i * 2}]\"",
-                            "items": {
-                                "enum": [
-                                    "CLASS_DEF",
-                                    "ENUM_DEF",
-                                    "ABSTRACT_DEF",
-                                    "TYPEDEF_DEF",
-                                    "INTERFACE_DEF",
-                                    "ANON_TYPE",
-                                    "OBJECT_DECL",
-                                    "FUNCTION",
-                                    "FOR",
-                                    "IF",
-                                    "WHILE",
-                                    "SWITCH",
-                                    "TRY",
-                                    "CATCH",
-                                    "REIFICATION",
-                                    "ARRAY_COMPREHENSION"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "option": {
-                            "description": "placement of left curly\n\t\t- eol = should occur at end of line\n\t\t- nl = should occur on a new line\n\t\t- nlow = should occur at end of line unless in wrapped code, then it should occur on a new line",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "eol",
-                                "nl",
-                                "nlow"
-                            ],
-                            "type": "string"
-                        },
-                        "ignoreEmptySingleline": {
-                            "description": "allow empty single line blocks",
-                            "propertyOrder": 2,
-                            "type": "boolean"
-                        },
-                        "ignoreSingleline": {
-                            "description": "allow single line blocks",
-                            "propertyOrder": 3,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 4,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
-                    "enum": [
-                        "LeftCurly"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for the placement of left curly braces (`{`) for code blocks. The policy to verify is specified using the property `option`.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ERegLiteralCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
-                    "enum": [
-                        "ERegLiteral"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for usage of EReg literals (between ~/ and /) instead of new.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "TrailingWhitespaceCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks if there are any trailing white spaces.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks if there are any trailing white spaces.",
-                    "enum": [
-                        "TrailingWhitespace"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks if there are any trailing white spaces.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ParameterNumberCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of parameters per method (default: 7)",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "ignoreOverriddenMethods": {
-                            "description": "ignore methods with \"override\", only base class violates",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        }
-                    },
-                    "description": "Checks the number of parameters of a method.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks the number of parameters of a method.",
-                    "enum": [
-                        "ParameterNumber"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks the number of parameters of a method.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "OperatorWhitespaceCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "oldFunctionTypePolicy": {
-                            "description": "policy for old haxe function type \"Int -> Void\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 10,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "bitwiseOpPolicy": {
-                            "description": "policy for \"&\", \"|\", \"^\", \"<<\", \">>\", \">>>\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 5,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "assignOpPolicy": {
-                            "description": "policy for \"=\", \"+=\", \"-=\", \"*=\", \"/=\", \"<<=\", \">>=\", \">>>=\", \"&=\", \"|=\", \"^=\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "arrowPolicy": {
-                            "description": "policy for \"=>\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 8,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "compareOpPolicy": {
-                            "description": "policy for \"==\", \"!=\", \"<\", \"<=\", \">\", \">=\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 4,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "unaryOpPolicy": {
-                            "description": "policy for \"++\", \"--\", \"!\", \"~\"\n\t\t- inner = enforce whitespace between unary operator and operand\n\t\t- none = enforce no whitespace between unary operator and operand\n\t\t- ignore = skip checks",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "inner",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "newFunctionTypePolicy": {
-                            "description": "policy for new haxe function type \"(param:Int) -> Void\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 11,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "intervalOpPolicy": {
-                            "description": "policy for \"...\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 7,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 12,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "boolOpPolicy": {
-                            "description": "policy for \"&&\", \"||\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 6,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "arithmeticOpPolicy": {
-                            "description": "policy for \"+\", \"-\", \"*\", \"/\", \"%\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "ternaryOpPolicy": {
-                            "description": "policy for \"?:\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        },
-                        "arrowFunctionPolicy": {
-                            "description": "policy for arrow functions \"(i) -> i + 2\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
-                            "propertyOrder": 9,
-                            "enum": [
-                                "before",
-                                "after",
-                                "around",
-                                "none",
-                                "ignore"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks that whitespace is present or absent around a operators.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that whitespace is present or absent around a operators.",
-                    "enum": [
-                        "OperatorWhitespace"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that whitespace is present or absent around a operators.",
-            "additionalProperties": false,
             "type": "object"
         },
         "SeparatorWrapCheck": {
+            "description": "Checks line wrapping with separators.",
+            "additionalProperties": false,
             "properties": {
+                "type": {
+                    "description": "Checks line wrapping with separators.",
+                    "type": "string",
+                    "enum": [
+                        "SeparatorWrap"
+                    ]
+                },
                 "props": {
+                    "description": "Checks line wrapping with separators.",
+                    "additionalProperties": false,
                     "properties": {
                         "tokens": {
                             "description": "list mof wrapping tokens",
                             "items": {
                                 "type": "string"
                             },
-                            "propertyOrder": 0,
-                            "type": "array"
+                            "type": "array",
+                            "propertyOrder": 0
                         },
                         "option": {
                             "description": "policy for wrapping token\n\t\t- eol = wrapping token should be at end of line\n\t\t- nl = wrapping token should start a new line",
-                            "propertyOrder": 1,
+                            "type": "string",
                             "enum": [
                                 "eol",
                                 "nl"
                             ],
-                            "type": "string"
+                            "propertyOrder": 1
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 2
                         }
                     },
-                    "description": "Checks line wrapping with separators.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks line wrapping with separators.",
-                    "enum": [
-                        "SeparatorWrap"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks line wrapping with separators.",
-            "additionalProperties": false,
             "type": "object"
         },
-        "UnusedImportCheck": {
+        "SeparatorWhitespaceCheck": {
+            "description": "Checks that whitespace is present or absent around a separators.",
+            "additionalProperties": false,
             "properties": {
-                "props": {
-                    "properties": {
-                        "ignoreModules": {
-                            "description": "list of module names to ignore, any module from \"ignoreModules\" won't show up as unused in any file during a run",
-                            "items": {
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "moduleTypeMap": {
-                            "description": "modules that define multiple types may show up as unused, unless \"moduleTypeMap\" contains a mapping for it\n\t\te.g. \"haxe.macro.Expr\": [\"ExprDef\", \"ComplexType\"] - would allow \"import haxe.macro.Expr;\" even though you just use \"ComplexType\"",
-                            "propertyOrder": 1,
-                            "type": "object"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for unused or duplicate imports.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
                 "type": {
-                    "description": "Checks for unused or duplicate imports.",
+                    "description": "Checks that whitespace is present or absent around a separators.",
+                    "type": "string",
                     "enum": [
-                        "UnusedImport"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for unused or duplicate imports.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "AvoidTernaryOperatorCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
-                    "additionalProperties": false,
-                    "type": "object"
+                        "SeparatorWhitespace"
+                    ]
                 },
-                "type": {
-                    "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
-                    "enum": [
-                        "AvoidTernaryOperator"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "CatchParameterNameCheck": {
-            "properties": {
                 "props": {
-                    "properties": {
-                        "format": {
-                            "description": "regex name format",
-                            "propertyOrder": 0,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
+                    "description": "Checks that whitespace is present or absent around a separators.",
                     "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
-                    "enum": [
-                        "CatchParameterName"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that catch parameter names conform to a format specified by the `format` property.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "DynamicCheck": {
-            "properties": {
-                "props": {
                     "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
+                        "commaPolicy": {
+                            "description": "policy for \",\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
                             "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for use of Dynamic type anywhere in the code.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for use of Dynamic type anywhere in the code.",
-                    "enum": [
-                        "Dynamic"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for use of Dynamic type anywhere in the code.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "AvoidIdentifierCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "avoidIdentifiers": {
-                            "description": "list of identifiers to avoid",
-                            "items": {
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for identifiers to avoid.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for identifiers to avoid.",
-                    "enum": [
-                        "AvoidIdentifier"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for identifiers to avoid.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "EmptyLinesCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "max": {
-                            "description": "number of empty lines to allow",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "requireEmptyLineAfterClass": {
-                            "description": "require an empty line after class keyword",
-                            "propertyOrder": 4,
-                            "type": "boolean"
-                        },
-                        "requireEmptyLineAfterPackage": {
-                            "description": "require an empty line after package definition",
-                            "propertyOrder": 3,
-                            "type": "boolean"
-                        },
-                        "requireEmptyLineAfterInterface": {
-                            "description": "require an empty line after interface keyword",
-                            "propertyOrder": 5,
-                            "type": "boolean"
-                        },
-                        "allowEmptyLineAfterMultiLineComment": {
-                            "description": "allow empty lines after a mutli line comment",
-                            "propertyOrder": 2,
-                            "type": "boolean"
-                        },
-                        "allowEmptyLineAfterSingleLineComment": {
-                            "description": "allow empty lines after a single line comment",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 7,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "requireEmptyLineAfterAbstract": {
-                            "description": "require an empty line after abstract keyword",
-                            "propertyOrder": 6,
-                            "type": "boolean"
-                        }
-                    },
-                    "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
-                    "enum": [
-                        "EmptyLines"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for consecutive empty lines (default is 1). Also have options to check empty line separators after package, single-line and multi-line comments and class/interface/abstract declarations.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "MethodLengthCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "max": {
-                            "description": "maximum number of lines per method (default: 50)",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "ignoreEmptyLines": {
-                            "description": "ignores or includes empty lines when counting method length",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
-                    "enum": [
-                        "MethodLength"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for long methods. If a method becomes very long it is hard to understand. Therefore long methods should usually be refactored into several individual methods that focus on a specific task.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ExcludeFilterList": {
-            "description": "list of path filters, e.g.\n\t- full type names\n\t- names of individual folder or subfolders\n\t- partial folder or type names\n\n\teach line can have an additional range specification:\n\t- \":<linenumber>\" = only matches a specific line number - valid line number start at 1\n\t- \":<start>-<end>\" = matches line numbers from <start> to <end> (including both)\n\t- \":<identifier>\" = matches any line or block that has <identifier> name (Haxe keywords currently unsupported)",
-            "items": {
-                "type": "string"
-            },
-            "type": "array"
-        },
-        "ArrowFunctionCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "allowSingleArgParens": {
-                            "description": "allow using parenthesis around single argument arrow function (`(arg) -> arg * 2`)",
-                            "propertyOrder": 3,
-                            "type": "boolean"
-                        },
-                        "allowFunction": {
-                            "description": "allow using `function` inside arrow function bodies",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        },
-                        "allowReturn": {
-                            "description": "allow using `return` inside arrow function bodies",
-                            "propertyOrder": 0,
-                            "type": "boolean"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 4,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "allowCurlyBody": {
-                            "description": "allow using curly block as arrow function body (`{...}`)",
-                            "propertyOrder": 2,
-                            "type": "boolean"
-                        }
-                    },
-                    "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
-                    "enum": [
-                        "ArrowFunction"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for use of curlies, nested (non-arrow) functions or returns in arrow functions.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ModifierOrderCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 1,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "modifiers": {
-                            "description": "order in which modifier should occur",
-                            "items": {
-                                "description": "list of modifiers\n\t- PUBLIC_PRIVATE = public / private modifier\n\t- INLINE = inline modifier\n\t- STATIC = static modifier\n\t- OVERRIDE = override modifier\n\t- MACRO = macro modifier\n\t- DYNAMIC = dynamic modifier\n\t- EXTERN = extern modifier\n\t- FINAL = final modifier",
-                                "enum": [
-                                    "PUBLIC_PRIVATE",
-                                    "INLINE",
-                                    "STATIC",
-                                    "OVERRIDE",
-                                    "MACRO",
-                                    "DYNAMIC",
-                                    "EXTERN",
-                                    "FINAL",
-                                    "ABSTRACT",
-                                    "OVERLOAD",
-                                    "ENUM"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        }
-                    },
-                    "description": "Checks that the order of modifiers conforms to the standards.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that the order of modifiers conforms to the standards.",
-                    "enum": [
-                        "ModifierOrder"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that the order of modifiers conforms to the standards.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "UnusedLocalVarCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 0,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        }
-                    },
-                    "description": "Checks for unused local variables.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for unused local variables.",
-                    "enum": [
-                        "UnusedLocalVar"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for unused local variables.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "MultipleStringLiteralsCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "ignore": {
-                            "description": "ignore string literals matching regex",
-                            "propertyOrder": 2,
-                            "type": "string"
-                        },
-                        "minLength": {
-                            "description": "string literals must be \"minLength\" or more characters before including them",
-                            "propertyOrder": 1,
-                            "type": "integer"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 3,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "allowDuplicates": {
-                            "description": "number of occurrences to allow",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        }
-                    },
-                    "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
-                    "enum": [
-                        "MultipleStringLiterals"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for multiple occurrences of the same string literal within a single file. Code duplication makes maintenance more difficult, so it's better to replace the multiple occurrences with a constant.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ListenerNameCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "format": {
-                            "description": "regex name format",
-                            "propertyOrder": 1,
-                            "type": "string"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "listeners": {
-                            "description": "list of function names used to register listeners",
-                            "items": {
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        }
-                    },
-                    "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
-                    "enum": [
-                        "ListenerName"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks the naming conventions of event listener functions specified using `listeners` property.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "LongNumberCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "decimalGroupSize": {
-                            "description": "for decimal numbers, the number of consecutive digits before it's a long number\n\t\tdefaults to `3`, where `1000` is a long number but `1_000` is valid\n\t\tuse `-1` to disable the check entirely",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "fractionalGroupSize": {
-                            "description": "for floating point decimal numbers, the number of consecutive digits after the decimal pointbefore it's a long number\n\t\tfor example, where `1000` is a long number but `1_000` is valid\n\t\tdefaults to `-1` to disable the check\n\t\tuse `-1` to disable the check entirely",
-                            "propertyOrder": 1,
-                            "type": "integer"
-                        },
-                        "binaryGroupSize": {
-                            "description": "for binary numbers, the number of consecutive digits before it's a long number\n\t\tdefaults to `8`, where `0b101010101` is a long number but `0b1_01010101` is valid\n\t\tuse `-1` to disable the check entirely",
-                            "propertyOrder": 3,
-                            "type": "integer"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 4,
-                            "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
-                            ],
-                            "type": "string"
-                        },
-                        "hexadecimalGroupSize": {
-                            "description": "for hexadecimal numbers, the number of consecutive digits before it's a long number\n\t\tdefaults to `8`, where `0x123456789` is a long number but `0x1_2345678` is valid\n\t\tuse `-1` to disable the check entirely",
-                            "propertyOrder": 2,
-                            "type": "integer"
-                        }
-                    },
-                    "description": "Checks that there are no long decimal numbers without separators.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks that there are no long decimal numbers without separators.",
-                    "enum": [
-                        "LongNumber"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks that there are no long decimal numbers without separators.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "ExtendedEmptyLinesCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "exact": {
-                            "description": "list of places where exactly \"max\" empty lines are required",
-                            "items": {
-                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
-                                "enum": [
-                                    "beforePackage",
-                                    "afterPackage",
-                                    "betweenImports",
-                                    "beforeUsing",
-                                    "afterImports",
-                                    "anywhereInFile",
-                                    "betweenTypes",
-                                    "beforeFileEnd",
-                                    "inFunction",
-                                    "afterLeftCurly",
-                                    "beforeRightCurly",
-                                    "typeDefinition",
-                                    "beginClass",
-                                    "endClass",
-                                    "afterClassStaticVars",
-                                    "afterClassVars",
-                                    "betweenClassStaticVars",
-                                    "betweenClassVars",
-                                    "betweenClassMethods",
-                                    "beginAbstract",
-                                    "endAbstract",
-                                    "afterAbstractVars",
-                                    "betweenAbstractVars",
-                                    "betweenAbstractMethods",
-                                    "beginInterface",
-                                    "endInterface",
-                                    "betweenInterfaceFields",
-                                    "beginEnum",
-                                    "endEnum",
-                                    "betweenEnumFields",
-                                    "beginTypedef",
-                                    "endTypedef",
-                                    "betweenTypedefFields",
-                                    "afterSingleLineComment",
-                                    "afterMultiLineComment",
-                                    "beforeSingleLineComment",
-                                    "beforeMultiLineComment",
-                                    "afterDocCommentField"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 5,
-                            "type": "array"
-                        },
-                        "defaultPolicy": {
-                            "description": "\"defaultPolicy\" applies to all places not in \"ignore\", \"none\", \"exact\", \"upto\" or \"atleast\"",
-                            "propertyOrder": 2,
-                            "enum": [
-                                "ignore",
+                                "before",
+                                "after",
+                                "around",
                                 "none",
-                                "exact",
-                                "upto",
-                                "atleast"
+                                "ignore"
                             ],
-                            "type": "string"
+                            "propertyOrder": 1
                         },
-                        "upto": {
-                            "description": "list of places where up to \"max\" empty lines are permitted",
-                            "items": {
-                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
-                                "enum": [
-                                    "beforePackage",
-                                    "afterPackage",
-                                    "betweenImports",
-                                    "beforeUsing",
-                                    "afterImports",
-                                    "anywhereInFile",
-                                    "betweenTypes",
-                                    "beforeFileEnd",
-                                    "inFunction",
-                                    "afterLeftCurly",
-                                    "beforeRightCurly",
-                                    "typeDefinition",
-                                    "beginClass",
-                                    "endClass",
-                                    "afterClassStaticVars",
-                                    "afterClassVars",
-                                    "betweenClassStaticVars",
-                                    "betweenClassVars",
-                                    "betweenClassMethods",
-                                    "beginAbstract",
-                                    "endAbstract",
-                                    "afterAbstractVars",
-                                    "betweenAbstractVars",
-                                    "betweenAbstractMethods",
-                                    "beginInterface",
-                                    "endInterface",
-                                    "betweenInterfaceFields",
-                                    "beginEnum",
-                                    "endEnum",
-                                    "betweenEnumFields",
-                                    "beginTypedef",
-                                    "endTypedef",
-                                    "betweenTypedefFields",
-                                    "afterSingleLineComment",
-                                    "afterMultiLineComment",
-                                    "beforeSingleLineComment",
-                                    "beforeMultiLineComment",
-                                    "afterDocCommentField"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 6,
-                            "type": "array"
-                        },
-                        "max": {
-                            "description": "number of empty lines to allow / enforce (used by \"exact\", \"upto\" and \"atleast\" policies)",
-                            "propertyOrder": 0,
-                            "type": "integer"
-                        },
-                        "none": {
-                            "description": "list of places where no empty line is permitted",
-                            "items": {
-                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
-                                "enum": [
-                                    "beforePackage",
-                                    "afterPackage",
-                                    "betweenImports",
-                                    "beforeUsing",
-                                    "afterImports",
-                                    "anywhereInFile",
-                                    "betweenTypes",
-                                    "beforeFileEnd",
-                                    "inFunction",
-                                    "afterLeftCurly",
-                                    "beforeRightCurly",
-                                    "typeDefinition",
-                                    "beginClass",
-                                    "endClass",
-                                    "afterClassStaticVars",
-                                    "afterClassVars",
-                                    "betweenClassStaticVars",
-                                    "betweenClassVars",
-                                    "betweenClassMethods",
-                                    "beginAbstract",
-                                    "endAbstract",
-                                    "afterAbstractVars",
-                                    "betweenAbstractVars",
-                                    "betweenAbstractMethods",
-                                    "beginInterface",
-                                    "endInterface",
-                                    "betweenInterfaceFields",
-                                    "beginEnum",
-                                    "endEnum",
-                                    "betweenEnumFields",
-                                    "beginTypedef",
-                                    "endTypedef",
-                                    "betweenTypedefFields",
-                                    "afterSingleLineComment",
-                                    "afterMultiLineComment",
-                                    "beforeSingleLineComment",
-                                    "beforeMultiLineComment",
-                                    "afterDocCommentField"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 4,
-                            "type": "array"
-                        },
-                        "ignore": {
-                            "description": "list of places to ignore",
-                            "items": {
-                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
-                                "enum": [
-                                    "beforePackage",
-                                    "afterPackage",
-                                    "betweenImports",
-                                    "beforeUsing",
-                                    "afterImports",
-                                    "anywhereInFile",
-                                    "betweenTypes",
-                                    "beforeFileEnd",
-                                    "inFunction",
-                                    "afterLeftCurly",
-                                    "beforeRightCurly",
-                                    "typeDefinition",
-                                    "beginClass",
-                                    "endClass",
-                                    "afterClassStaticVars",
-                                    "afterClassVars",
-                                    "betweenClassStaticVars",
-                                    "betweenClassVars",
-                                    "betweenClassMethods",
-                                    "beginAbstract",
-                                    "endAbstract",
-                                    "afterAbstractVars",
-                                    "betweenAbstractVars",
-                                    "betweenAbstractMethods",
-                                    "beginInterface",
-                                    "endInterface",
-                                    "betweenInterfaceFields",
-                                    "beginEnum",
-                                    "endEnum",
-                                    "betweenEnumFields",
-                                    "beginTypedef",
-                                    "endTypedef",
-                                    "betweenTypedefFields",
-                                    "afterSingleLineComment",
-                                    "afterMultiLineComment",
-                                    "beforeSingleLineComment",
-                                    "beforeMultiLineComment",
-                                    "afterDocCommentField"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 3,
-                            "type": "array"
+                        "semicolonPolicy": {
+                            "description": "policy for \";\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
+                            "enum": [
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
+                            ],
+                            "propertyOrder": 3
                         },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 8,
+                            "type": "string",
                             "enum": [
                                 "INFO",
                                 "WARNING",
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "type": "string"
+                            "propertyOrder": 4
                         },
-                        "atleast": {
-                            "description": "list of places where at least \"max\" empty lines are required",
-                            "items": {
-                                "description": "empty line check supports the following places\n\t- afterAbstractVars = after abstract var block\n\t- afterClassStaticVars = after static class var block\n\t- afterClassVars = after class var block\n\t- afterImports = after all imports/usings\n\t- afterLeftCurly = after left curly\n\t- afterMultiLineComment = after multi line comment\n\t- afterPackage = after package\n\t- afterSingleLineComment = after single line comment\n\t- anywhereInFile = anywhere in file\n\t- beforePackage = before package\n\t- beforeRightCurly = before right curly\n\t- beforeUsing = before using block\n\t- beginAbstract = after abstract left curly\n\t- beginClass = after class left curly\n\t- beginEnum = after enum left curly\n\t- beforeFileEnd = before EOF\n\t- beginInterface = after interface left curly\n\t- beginTypedef = after typedef left curly\n\t- betweenAbstractMethods = between abstract methods\n\t- betweenAbstractVars = between abstract vars\n\t- betweenClassMethods = between class methods\n\t- betweenClassStaticVars = between static class vars\n\t- betweenClassVars = between class vars\n\t- betweenEnumFields = between enum fields\n\t- betweenImports = between imports/usings\n\t- betweenInterfaceFields = between interface fields\n\t- betweenTypedefFields = between typedef fields\n\t- betweenTypes = betgween two types\n\t- endClass = before class right curly\n\t- endAbstract = before abstract right curly\n\t- endInterface = before interface right curly\n\t- endEnum = before enum right curly\n\t- endTypedef = before typedef right curly\n\t- inFunction = anywhere inside function body\n\t- typeDefinition = between type and left curly",
-                                "enum": [
-                                    "beforePackage",
-                                    "afterPackage",
-                                    "betweenImports",
-                                    "beforeUsing",
-                                    "afterImports",
-                                    "anywhereInFile",
-                                    "betweenTypes",
-                                    "beforeFileEnd",
-                                    "inFunction",
-                                    "afterLeftCurly",
-                                    "beforeRightCurly",
-                                    "typeDefinition",
-                                    "beginClass",
-                                    "endClass",
-                                    "afterClassStaticVars",
-                                    "afterClassVars",
-                                    "betweenClassStaticVars",
-                                    "betweenClassVars",
-                                    "betweenClassMethods",
-                                    "beginAbstract",
-                                    "endAbstract",
-                                    "afterAbstractVars",
-                                    "betweenAbstractVars",
-                                    "betweenAbstractMethods",
-                                    "beginInterface",
-                                    "endInterface",
-                                    "betweenInterfaceFields",
-                                    "beginEnum",
-                                    "endEnum",
-                                    "betweenEnumFields",
-                                    "beginTypedef",
-                                    "endTypedef",
-                                    "betweenTypedefFields",
-                                    "afterSingleLineComment",
-                                    "afterMultiLineComment",
-                                    "beforeSingleLineComment",
-                                    "beforeMultiLineComment",
-                                    "afterDocCommentField"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 7,
-                            "type": "array"
-                        },
-                        "skipSingleLineTypes": {
-                            "description": "skips single line type definitions",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        }
-                    },
-                    "description": "Checks for consecutive empty lines.",
-                    "additionalProperties": false,
-                    "type": "object"
-                },
-                "type": {
-                    "description": "Checks for consecutive empty lines.",
-                    "enum": [
-                        "ExtendedEmptyLines"
-                    ],
-                    "type": "string"
-                }
-            },
-            "description": "Checks for consecutive empty lines.",
-            "additionalProperties": false,
-            "type": "object"
-        },
-        "NeedBracesCheck": {
-            "properties": {
-                "props": {
-                    "properties": {
-                        "allowSingleLineStatement": {
-                            "description": "allow / disallow use of single line statements without braces",
-                            "propertyOrder": 1,
-                            "type": "boolean"
-                        },
-                        "tokens": {
-                            "description": "matches only statements specified in tokens list:\n\n\t\t- FUNCTION = function body \"funnction test () {}\"\n\t\t- FOR = for body \"for (i in 0..10) {}\"\n\t\t- IF = if body \"if (test) {} else {}\"\n\t\t- ELSE_IF = if body \"if (test) {} else if {}\"\n\t\t- WHILE = while body \"while (test) {}\"\n\t\t- DO_WHILE = do…while body \"do {} while (test)\"\n\t\t- CATCH = catch body \"catch (e:Dynamic) {}\"",
-                            "items": {
-                                "enum": [
-                                    "FUNCTION",
-                                    "FOR",
-                                    "IF",
-                                    "ELSE_IF",
-                                    "WHILE",
-                                    "DO_WHILE",
-                                    "CATCH"
-                                ],
-                                "type": "string"
-                            },
-                            "propertyOrder": 0,
-                            "type": "array"
-                        },
-                        "severity": {
-                            "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
-                            "propertyOrder": 2,
+                        "dotPolicy": {
+                            "description": "policy for \".\"\n\t\t- around = enforce whitespace before and after operator\n\t\t- before = enforce whitespace before and no whitespace after operator\n\t\t- after = enforce no whitespace before and whitespace after operator\n\t\t- none = enforce no whitespace before and after operator\n\t\t- ignore = skip checks",
+                            "type": "string",
                             "enum": [
-                                "INFO",
-                                "WARNING",
-                                "ERROR",
-                                "IGNORE"
+                                "before",
+                                "after",
+                                "around",
+                                "none",
+                                "ignore"
                             ],
-                            "type": "string"
+                            "propertyOrder": 0
+                        },
+                        "allowTrailingComma": {
+                            "description": "no violoation for missing whitespace after trailing commas",
+                            "type": "boolean",
+                            "propertyOrder": 2
                         }
                     },
-                    "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
-                    "additionalProperties": false,
                     "type": "object"
-                },
-                "type": {
-                    "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
-                    "enum": [
-                        "NeedBraces"
-                    ],
-                    "type": "string"
                 }
             },
-            "description": "Checks for braces on function, if, for and while statements. It has an option to allow single line statements without braces using property `allowSingleLineStatement` like `if (b) return 10;`.",
-            "additionalProperties": false,
             "type": "object"
         }
     },
     "$ref": "#/definitions/Config",
-    "id": "https://raw.githubusercontent.com/HaxeCheckstyle/haxe-checkstyle/dev/resources/checkstyle-schema.json",
-    "$schema": "http://json-schema.org/schema#"
+    "id": "https://raw.githubusercontent.com/HaxeCheckstyle/haxe-checkstyle/dev/resources/checkstyle-schema.json"
 }

--- a/src/checkstyle/checks/coding/LongNumberCheck.hx
+++ b/src/checkstyle/checks/coding/LongNumberCheck.hx
@@ -67,6 +67,13 @@ class LongNumberCheck extends Check {
 	}
 
 	/**
+		for decimal numbers, the minimum quantity before it's a long number
+		for example, if set to `1000000`, `999999` requires no separators but `1_000_000` does
+		defaults to `0` to disable the check
+	**/
+	public var decimalMinimum:Int;
+
+	/**
 		for floating point decimal numbers, the number of consecutive digits after the decimal pointbefore it's a long number
 		for example, where `1000` is a long number but `1_000` is valid
 		defaults to `-1` to disable the check
@@ -92,6 +99,13 @@ class LongNumberCheck extends Check {
 		if (initialized) updateRegex();
 		return hexadecimalGroupSize;
 	}
+
+	/**
+		for hexadecimal numbers, the minimum quantity before it's a long number
+		for example, if set to `0x1000000000`, `0x123456789` requires no separators but `0x12_34567890` does
+		defaults to `0` to disable the check
+	**/
+	public var hexadecimalMinimum:Int;
 
 	/**
 	 	for binary numbers, the number of consecutive digits before it's a long number
@@ -134,6 +148,10 @@ class LongNumberCheck extends Check {
 		fractionalGroupSize = -1;
 		hexadecimalGroupSize = 8;
 		binaryGroupSize = 8;
+
+		// minimum quantity
+		decimalMinimum = 0;
+		hexadecimalMinimum = 0;
 
 		initialized = true;
 
@@ -215,6 +233,7 @@ class LongNumberCheck extends Check {
 	function queryInteger(n:String, suffix:String, pos:Position) {
 		if (n.startsWith(HEXADECIMAL_PREFIX)) {
 			if (hexadecimalGroupRegex == null) return;
+			if (Std.parseInt(n) < hexadecimalMinimum) return;
 			if (hexadecimalGroupRegex.match(n)) return;
 
 			if (n.contains(SEPARATOR)) {
@@ -241,6 +260,7 @@ class LongNumberCheck extends Check {
 		}
 		else {
 			if (decimalGroupRegex == null) return;
+			if (Std.parseInt(n) < decimalMinimum) return;
 			if (decimalGroupRegex.match(n)) return;
 
 			if (n.contains(SEPARATOR)) {
@@ -257,6 +277,10 @@ class LongNumberCheck extends Check {
 	function queryFloat(n:String, suffix:String, pos:Position) {
 		if (decimalGroupSize <= 0) return;
 		if (decimalGroupRegex.match(n)) return;
+
+		var f = Std.parseFloat(n);
+		if (Math.isNaN(f)) return;
+		if (f < decimalMinimum) return;
 
 		if (n.contains(SEPARATOR)) {
 			if (n.contains(FRACTIONAL_SEPARATOR) && fractionalGroupSize <= 0) {

--- a/src/checkstyle/checks/coding/LongNumberCheck.hx
+++ b/src/checkstyle/checks/coding/LongNumberCheck.hx
@@ -6,29 +6,171 @@ package checkstyle.checks.coding;
 @name("LongNumber")
 @desc("Checks that there are no long decimal numbers without separators.")
 class LongNumberCheck extends Check {
-	/**
-		list of long numbers to ignore during checks
-	**/
-	public var ignoreNumbers:Array<Float>;
 
 	/**
-	 	whether to check hexadecimal (`0x12345678`) numbers
+		the separator used for long numbers
+		this isn't configurable because it's part of the Haxe language syntax
 	**/
-	public var checkHexadecimal:Bool;
+	static final SEPARATOR:String = "_";
 
 	/**
-	 	whether to check binary (`0b10001001`) numbers
+		the separator used for the fractional part of floating point numbers
 	**/
-	public var checkBinary:Bool;
+	static final FRACTIONAL_SEPARATOR:String = ".";
+
+	/**
+		regular expression used to validate decimal numbers for separators
+		`n` is replaced with the value of `decimalGroupSize`
+	**/
+	static final DECIMAL_GROUP_REGEX:String = "^\\d{1,n}(_\\d{n})*(\\.\\d*?)?$";
+
+	/**
+		regular expression used to validate decimal numbers for separators
+		`n` is replaced with the value of `decimalGroupSize`
+		`m` is replaced with the value of `fractionalGroupSize`
+	**/
+	static final DECIMAL_FRACTIONAL_GROUP_REGEX:String = "^\\d{1,n}(_\\d{n})*(\\.(\\d{1,m}(_\\d{m})*)?)?$";
+
+	/**
+		the prefix used to identify hexadecimal numbers
+	**/
+	static final HEXADECIMAL_PREFIX:String = "0x";
+
+	/**
+		regular expression used to validate hexadecimal numbers for separators
+		`n` is replaced with the value of `hexadecimalGroupSize`
+	**/
+	static final HEXADECIMAL_GROUP_REGEX:String = "^0x[0-9A-Fa-f]{1,n}(_[0-9A-Fa-f]{n})*$";
+
+	/**
+		the prefix used to identify binary numbers
+	**/
+	static final BINARY_PREFIX:String = "0b";
+
+	/**
+		regular expression used to validate binary numbers for separators
+		`n` is replaced with the value of `binaryGroupSize`
+	**/
+	static final BINARY_GROUP_REGEX:String = "^0b[0-1]{1,n}(_[0-1]{n})*$";
+
+	/**
+		for decimal numbers, the number of consecutive digits before it's a long number
+		defaults to `3`, where `1000` is a long number but `1_000` is valid
+		use `-1` to disable the check entirely
+	**/
+	public var decimalGroupSize(default, set):Int;
+
+	function set_decimalGroupSize(value:Int):Int {
+		decimalGroupSize = value;
+		if (initialized) updateRegex();
+		return decimalGroupSize;
+	}
+
+	/**
+		for floating point decimal numbers, the number of consecutive digits after the decimal pointbefore it's a long number
+		for example, where `1000` is a long number but `1_000` is valid
+		defaults to `-1` to disable the check
+		use `-1` to disable the check entirely
+	**/
+	public var fractionalGroupSize(default, set):Int;
+
+	function set_fractionalGroupSize(value:Int):Int {
+		fractionalGroupSize = value;
+		if (initialized) updateRegex();
+		return fractionalGroupSize;
+	}
+
+	/**
+	 	for hexadecimal numbers, the number of consecutive digits before it's a long number
+		defaults to `8`, where `0x123456789` is a long number but `0x1_2345678` is valid
+		use `-1` to disable the check entirely
+	**/
+	public var hexadecimalGroupSize(default, set):Int;
+
+	function set_hexadecimalGroupSize(value:Int):Int {
+		hexadecimalGroupSize = value;
+		if (initialized) updateRegex();
+		return hexadecimalGroupSize;
+	}
+
+	/**
+	 	for binary numbers, the number of consecutive digits before it's a long number
+		defaults to `8`, where `0b101010101` is a long number but `0b1_01010101` is valid
+		use `-1` to disable the check entirely
+	**/
+	public var binaryGroupSize(default, set):Int;
+
+	function set_binaryGroupSize(value:Int):Int {
+		binaryGroupSize = value;
+		if (initialized) updateRegex();
+		return binaryGroupSize;
+	}
+
+	/**
+		the regular expression used to validate decimal numbers are properly separated
+		`null` if the decimal group size is `-1` to indicate grouping is disabled
+	**/
+	var decimalGroupRegex:Null<EReg>;
+
+	/**
+		the regular expression used to validate decimal numbers are properly separated
+		`null` if the hexadecimal group size is `-1` to indicate grouping is disabled
+	**/
+	var hexadecimalGroupRegex:Null<EReg>;
+
+	/**
+		the regular expression used to validate decimal numbers are properly separated
+		`null` if the binary group size is `-1` to indicate grouping is disabled
+	**/
+	var binaryGroupRegex:Null<EReg>;
 
 	public function new() {
 		super(TOKEN);
 		categories = [Category.CLARITY, Category.COMPLEXITY];
 		points = 3;
 
-		ignoreNumbers = [];
-		checkHexadecimal = false;
-		checkBinary = false;
+		// default group sizes
+		decimalGroupSize = 3;
+		fractionalGroupSize = -1;
+		hexadecimalGroupSize = 8;
+		binaryGroupSize = 8;
+
+		initialized = true;
+
+		updateRegex();
+	}
+
+	/**
+		first time regex generation happens only after every group size is initialized
+	**/
+	var initialized:Bool;
+
+	function updateRegex() {
+		if (decimalGroupSize > 0) {
+			if (fractionalGroupSize <= 0) {
+				decimalGroupRegex = new EReg(DECIMAL_GROUP_REGEX.replace("n", Std.string(decimalGroupSize)), "");
+			}
+			else {
+				decimalGroupRegex = new EReg(DECIMAL_FRACTIONAL_GROUP_REGEX.replace("n", Std.string(decimalGroupSize)).replace("m", Std.string(fractionalGroupSize)), "");
+			}
+		}
+		else {
+			decimalGroupRegex = null;
+		}
+
+		if (hexadecimalGroupSize > 0) {
+			hexadecimalGroupRegex = new EReg(HEXADECIMAL_GROUP_REGEX.replace("n", Std.string(hexadecimalGroupSize)), "");
+		}
+		else {
+			hexadecimalGroupRegex = null;
+		}
+
+		if (binaryGroupSize > 0) {
+			binaryGroupRegex = new EReg(BINARY_GROUP_REGEX.replace("n", Std.string(binaryGroupSize)), "");
+		}
+		else {
+			binaryGroupRegex = null;
+		}
 	}
 
 	override function actualRun() {
@@ -42,7 +184,6 @@ class LongNumberCheck extends Check {
 			}
 		});
 		for (type in allTypes) {
-			if (TokenTreeCheckUtils.isTypeEnumAbstract(type)) continue;
 			checkForNumbers(type);
 		}
 	}
@@ -56,28 +197,85 @@ class LongNumberCheck extends Check {
 			}
 		});
 
-		var longNumber:EReg = ~/[0-9]{4,}/;
-
 		for (numberToken in allNumbers) {
 			if (isPosSuppressed(numberToken.pos)) continue;
 			if (filterNumber(numberToken)) continue;
 			switch (numberToken.tok) {
 				case Const(CInt(n, s)):
-					var number:Int = Std.parseInt(n.replace("_", ""));
-					if (ignoreNumbers.contains(number)) continue;
-					if (s == null) s = "";
+					queryInteger(n, s ?? "", numberToken.pos);
 
-					if (!checkHexadecimal && n.startsWith("0x")) continue;
-					if (!checkBinary && n.startsWith("0b")) continue;
-
-					if (longNumber.match(n)) logPos('"$n${s ?? ''}" is a long number, use _ as a separator', numberToken.pos);
 				case Const(CFloat(n, s)):
-					var number:Float = Std.parseFloat(n.replace("_", ""));
-					if (ignoreNumbers.contains(number)) continue;
-					if (s == null) s = "";
+					queryFloat(n, s ?? "", numberToken.pos);
 
-					if (longNumber.match(n)) logPos('"$n${s ?? ''}" is a long number, use _ as a separator', numberToken.pos);
 				default:
+			}
+		}
+	}
+
+	function queryInteger(n:String, suffix:String, pos:Position) {
+		if (n.startsWith(HEXADECIMAL_PREFIX)) {
+			if (hexadecimalGroupRegex == null) return;
+			if (hexadecimalGroupRegex.match(n)) return;
+
+			if (n.contains(SEPARATOR)) {
+				// improper use of separators on a hexadecimal number
+				logPos('"$n$suffix" uses separators improperly, use _ every $hexadecimalGroupSize digits', pos);
+			}
+			else {
+				// missing separators on a hexadecimal number
+				logPos('"$n$suffix" is a long hexadecimal number, use _ as a separator', pos);
+			}
+		}
+		else if (n.startsWith(BINARY_PREFIX)) {
+			if (binaryGroupRegex == null) return;
+			if (binaryGroupRegex.match(n)) return;
+
+			if (n.contains(SEPARATOR)) {
+				// improper use of separators on a binary number
+				logPos('"$n$suffix" uses separators improperly, use _ every $binaryGroupSize digits', pos);
+			}
+			else {
+				// missing separators on a binary number
+				logPos('"$suffix$n" is a long binary number, use _ as a separator', pos);
+			}
+		}
+		else {
+			if (decimalGroupRegex == null) return;
+			if (decimalGroupRegex.match(n)) return;
+
+			if (n.contains(SEPARATOR)) {
+				// improper use of separators on a decimal number
+				logPos('"$n$suffix" uses separators improperly, use _ every $decimalGroupSize digits', pos);
+			}
+			else {
+				// missing separators on a decimal number
+				logPos('"$n$suffix" is a long number, use _ as a separator', pos);
+			}
+		}
+	}
+
+	function queryFloat(n:String, suffix:String, pos:Position) {
+		if (decimalGroupSize <= 0) return;
+		if (decimalGroupRegex.match(n)) return;
+
+		if (n.contains(SEPARATOR)) {
+			if (n.contains(FRACTIONAL_SEPARATOR) && fractionalGroupSize <= 0) {
+				// improper use of separators on a float with fractional part
+				logPos('"$n$suffix" uses separators improperly, use _ every $decimalGroupSize digits before the . and $fractionalGroupSize after the .', pos);
+			}
+			else {
+				// improper use of separators on a float with no fractional part
+				logPos('"$n$suffix" uses separators improperly, use _ every $decimalGroupSize digits', pos);
+			}
+		}
+		else {
+			if (n.contains(FRACTIONAL_SEPARATOR) && fractionalGroupSize <= 0) {
+				// missing separators on a float with fractional part
+				logPos('"$n$suffix" is a long number, use _ as a separator before the fractional part', pos);
+			}
+			else {
+				// missing separators on a float with no fractional part
+				logPos('"$n$suffix" is a long number, use _ as a separator', pos);
 			}
 		}
 	}

--- a/src/checkstyle/checks/coding/LongNumberCheck.hx
+++ b/src/checkstyle/checks/coding/LongNumberCheck.hx
@@ -11,11 +11,24 @@ class LongNumberCheck extends Check {
 	**/
 	public var ignoreNumbers:Array<Float>;
 
+	/**
+	 	whether to check hexadecimal (`0x12345678`) numbers
+	**/
+	public var checkHexadecimal:Bool;
+
+	/**
+	 	whether to check binary (`0b10001001`) numbers
+	**/
+	public var checkBinary:Bool;
+
 	public function new() {
 		super(TOKEN);
-		ignoreNumbers = [];
 		categories = [Category.CLARITY, Category.COMPLEXITY];
 		points = 3;
+
+		ignoreNumbers = [];
+		checkHexadecimal = false;
+		checkBinary = false;
 	}
 
 	override function actualRun() {
@@ -53,6 +66,9 @@ class LongNumberCheck extends Check {
 					var number:Int = Std.parseInt(n.replace("_", ""));
 					if (ignoreNumbers.contains(number)) continue;
 					if (s == null) s = "";
+
+					if (!checkHexadecimal && n.startsWith("0x")) continue;
+					if (!checkBinary && n.startsWith("0b")) continue;
 
 					if (longNumber.match(n)) logPos('"$n${s ?? ''}" is a long number, use _ as a separator', numberToken.pos);
 				case Const(CFloat(n, s)):

--- a/src/checkstyle/checks/coding/LongNumberCheck.hx
+++ b/src/checkstyle/checks/coding/LongNumberCheck.hx
@@ -1,0 +1,91 @@
+package checkstyle.checks.coding;
+
+/**
+	Checks that long decimal numbers include underscores as a separator.
+**/
+@name("LongNumber")
+@desc("Checks that there are no long decimal numbers without separators.")
+class LongNumberCheck extends Check {
+	/**
+		list of long numbers to ignore during checks
+	**/
+	public var ignoreNumbers:Array<Float>;
+
+	public function new() {
+		super(TOKEN);
+		ignoreNumbers = [];
+		categories = [Category.CLARITY, Category.COMPLEXITY];
+		points = 3;
+	}
+
+	override function actualRun() {
+		var root:TokenTree = checker.getTokenTree();
+		var allTypes:Array<TokenTree> = root.filterCallback(function(token:TokenTree, depth:Int):FilterResult {
+			return switch (token.tok) {
+				case Kwd(KwdAbstract) | Kwd(KwdClass) | Kwd(KwdEnum) | Kwd(KwdInterface) | Kwd(KwdTypedef):
+					FoundSkipSubtree;
+				default:
+					GoDeeper;
+			}
+		});
+		for (type in allTypes) {
+			if (TokenTreeCheckUtils.isTypeEnumAbstract(type)) continue;
+			checkForNumbers(type);
+		}
+	}
+
+	function checkForNumbers(parent:TokenTree) {
+		var allNumbers:Array<TokenTree> = parent.filterCallback(function(token:TokenTree, depth:Int):FilterResult {
+			return switch (token.tok) {
+				case Const(CInt(_)): FoundGoDeeper;
+				case Const(CFloat(_)): FoundGoDeeper;
+				default: GoDeeper;
+			}
+		});
+
+		var longNumber:EReg = ~/[0-9]{4,}/;
+
+		for (numberToken in allNumbers) {
+			if (isPosSuppressed(numberToken.pos)) continue;
+			if (filterNumber(numberToken)) continue;
+			switch (numberToken.tok) {
+				case Const(CInt(n, s)):
+					var number:Int = Std.parseInt(n.replace("_", ""));
+					if (ignoreNumbers.contains(number)) continue;
+					if (s == null) s = "";
+
+					if (longNumber.match(n)) logPos('"$n${s ?? ''}" is a long number, use _ as a separator', numberToken.pos);
+				case Const(CFloat(n, s)):
+					var number:Float = Std.parseFloat(n.replace("_", ""));
+					if (ignoreNumbers.contains(number)) continue;
+					if (s == null) s = "";
+
+					if (longNumber.match(n)) logPos('"$n${s ?? ''}" is a long number, use _ as a separator', numberToken.pos);
+				default:
+			}
+		}
+	}
+
+	function filterNumber(token:TokenTree):Bool {
+		if ((token == null) || (token.tok == Root)) return false;
+		return switch (token.tok) {
+			case At: true;
+			case Kwd(KwdFinal): true;
+			case BrOpen: false;
+			case Kwd(KwdVar): if (token.filterCallback(function(token:TokenTree, depth:Int):FilterResult {
+					return switch (token.tok) {
+						case Kwd(KwdStatic):
+							FoundSkipSubtree;
+						default:
+							GoDeeper;
+					}
+				}).length > 0) {
+					true;
+				}
+				else {
+					false;
+				}
+			default: filterNumber(token.parent);
+		}
+	}
+}

--- a/test/checkstyle/checks/coding/LongNumberCheckTest.hx
+++ b/test/checkstyle/checks/coding/LongNumberCheckTest.hx
@@ -130,6 +130,26 @@ class LongNumberCheckTest extends CheckTestCase<LongNumberCheckTests> {
 			"\"0b10_01000101\" uses separators improperly, use _ every 4 digits"
 		]);
 	}
+
+	@Test
+	public function testMinimum() {
+		var check = new LongNumberCheck();
+		check.decimalGroupSize = 3;
+		check.hexadecimalGroupSize = 4;
+		check.binaryGroupSize = 4;
+		check.decimalMinimum = 1_000_000;
+		check.hexadecimalMinimum = 0x100_0000;
+
+		assertNoMsg(check, TEST_DECIMAL);
+		assertNoMsg(check, TEST_DECIMAL_LONG);
+		assertNoMsg(check, TEST_DECIMAL_FIXED);
+		assertMessages(check, TEST_HEXADECIMAL, [
+			// Not long enough
+			// "\"0x123456\" is a long hexadecimal number, use _ as a separator",
+			// Long enough
+			"\"0x10233023\" is a long hexadecimal number, use _ as a separator"
+		]);
+	}
 }
 
 enum abstract LongNumberCheckTests(String) to String {

--- a/test/checkstyle/checks/coding/LongNumberCheckTest.hx
+++ b/test/checkstyle/checks/coding/LongNumberCheckTest.hx
@@ -4,83 +4,139 @@ class LongNumberCheckTest extends CheckTestCase<LongNumberCheckTests> {
 	@Test
 	public function test() {
 		var check = new LongNumberCheck();
-		assertNoMsg(check, TEST_STANDARD_NUMBERS);
-		assertMessages(check, TEST_LONG_NUMBERS, [
-			"\"10123\" is a long number, use _ as a separator",
+
+		assertNoMsg(check, TEST_DECIMAL);
+		assertMessages(check, TEST_DECIMAL_LONG, [
+			"\"1012\" is a long number, use _ as a separator",
 			"\"20123\" is a long number, use _ as a separator",
-			"\"30123\" is a long number, use _ as a separator",
+			"\"3012\" is a long number, use _ as a separator",
 			"\"40123\" is a long number, use _ as a separator",
-			"\"50123\" is a long number, use _ as a separator",
-			"\"10.123456\" is a long number, use _ as a separator"
+			"\"50123\" is a long number, use _ as a separator"
 		]);
-		assertNoMsg(check, TEST_FIXED_LONG_NUMBERS);
+		assertNoMsg(check, TEST_DECIMAL_FIXED);
+
 		assertNoMsg(check, TEST_HEXADECIMAL);
+		assertMessages(check, TEST_HEXADECIMAL_LONG, [
+			"\"0x1234_5678\" uses separators improperly, use _ every 8 digits",
+			"\"0x10233023AF\" is a long hexadecimal number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_HEXADECIMAL_FIXED);
+
 		assertNoMsg(check, TEST_BINARY);
+		assertMessages(check, TEST_BINARY_LONG, [
+			"\"0b1001_0001\" uses separators improperly, use _ every 8 digits",
+			"\"0b1001000101\" is a long binary number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_BINARY_FIXED);
 	}
 
 	@Test
-	public function testIgnore() {
+	public function testDecimalGroupSize() {
 		var check = new LongNumberCheck();
-		check.ignoreNumbers = [10_123, 30_123, 10.123_456];
+		check.decimalGroupSize = 4;
 
-		assertNoMsg(check, TEST_STANDARD_NUMBERS);
-		assertMessages(check, TEST_LONG_NUMBERS, [
+		assertNoMsg(check, TEST_DECIMAL);
+		assertMessages(check, TEST_DECIMAL_LONG, [
 			"\"20123\" is a long number, use _ as a separator",
 			"\"40123\" is a long number, use _ as a separator",
 			"\"50123\" is a long number, use _ as a separator"
 		]);
-		assertNoMsg(check, TEST_FIXED_LONG_NUMBERS);
+		assertMessages(check, TEST_DECIMAL_FIXED, [
+			"\"1_012\" uses separators improperly, use _ every 4 digits",
+			"\"20_123\" uses separators improperly, use _ every 4 digits",
+			"\"3_012\" uses separators improperly, use _ every 4 digits",
+			"\"40_123\" uses separators improperly, use _ every 4 digits",
+			"\"50_123\" uses separators improperly, use _ every 4 digits"
+		]);
+		
 		assertNoMsg(check, TEST_HEXADECIMAL);
+		assertMessages(check, TEST_HEXADECIMAL_LONG, [
+			"\"0x1234_5678\" uses separators improperly, use _ every 8 digits",
+			"\"0x10233023AF\" is a long hexadecimal number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_HEXADECIMAL_FIXED);
+
 		assertNoMsg(check, TEST_BINARY);
+		assertMessages(check, TEST_BINARY_LONG, [
+			"\"0b1001_0001\" uses separators improperly, use _ every 8 digits",
+			"\"0b1001000101\" is a long binary number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_BINARY_FIXED);
 	}
 
 	@Test
-	public function testHexadecimal() {
+	public function testFractionalGroupSize() {
 		var check = new LongNumberCheck();
-		check.checkHexadecimal = true;
+		check.decimalGroupSize = 3;
+		check.fractionalGroupSize = 3;
 
-		assertNoMsg(check, TEST_STANDARD_NUMBERS);
-		assertMessages(check, TEST_LONG_NUMBERS, [
-			"\"10123\" is a long number, use _ as a separator",
+		assertNoMsg(check, TEST_DECIMAL);
+		assertMessages(check, TEST_DECIMAL_LONG, [
+			"\"1012\" is a long number, use _ as a separator",
 			"\"20123\" is a long number, use _ as a separator",
-			"\"30123\" is a long number, use _ as a separator",
+			"\"3012\" is a long number, use _ as a separator",
 			"\"40123\" is a long number, use _ as a separator",
 			"\"50123\" is a long number, use _ as a separator",
 			"\"10.123456\" is a long number, use _ as a separator"
 		]);
-		assertNoMsg(check, TEST_FIXED_LONG_NUMBERS);
+		assertMsg(check, TEST_DECIMAL_FIXED, "\"10.123456\" is a long number, use _ as a separator");
+
+		assertNoMsg(check, TEST_HEXADECIMAL);
+		assertMessages(check, TEST_HEXADECIMAL_LONG, [
+			"\"0x1234_5678\" uses separators improperly, use _ every 8 digits",
+			"\"0x10233023AF\" is a long hexadecimal number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_HEXADECIMAL_FIXED);
+
+		assertNoMsg(check, TEST_BINARY);
+		assertMessages(check, TEST_BINARY_LONG, [
+			"\"0b1001_0001\" uses separators improperly, use _ every 8 digits",
+			"\"0b1001000101\" is a long binary number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_BINARY_FIXED);
+	}
+
+	@Test
+	public function testHexadecimalGroupSize() {
+		var check = new LongNumberCheck();
+		check.decimalGroupSize = -1;
+		check.hexadecimalGroupSize = 4;
+
+		assertNoMsg(check, TEST_DECIMAL);
+		assertNoMsg(check, TEST_DECIMAL_LONG);
+		assertNoMsg(check, TEST_DECIMAL_FIXED);
 		assertMessages(check, TEST_HEXADECIMAL, [
-			"\"0x123456\" is a long number, use _ as a separator",
-			"\"0x10233023\" is a long number, use _ as a separator"
+			"\"0x123456\" is a long hexadecimal number, use _ as a separator",
+			"\"0x10233023\" is a long hexadecimal number, use _ as a separator"
 		]);
 		assertNoMsg(check, TEST_BINARY);
 	}
 
 	@Test
-	public function testBinary() {
+	public function testBinaryGroupSize() {
 		var check = new LongNumberCheck();
-		check.checkBinary = true;
+		check.decimalGroupSize = -1;
+		check.binaryGroupSize = 4;
 
-		assertNoMsg(check, TEST_STANDARD_NUMBERS);
-		assertMessages(check, TEST_LONG_NUMBERS, [
-			"\"10123\" is a long number, use _ as a separator",
-			"\"20123\" is a long number, use _ as a separator",
-			"\"30123\" is a long number, use _ as a separator",
-			"\"40123\" is a long number, use _ as a separator",
-			"\"50123\" is a long number, use _ as a separator",
-			"\"10.123456\" is a long number, use _ as a separator"
-		]);
-		assertNoMsg(check, TEST_FIXED_LONG_NUMBERS);
+		assertNoMsg(check, TEST_DECIMAL);
+		assertNoMsg(check, TEST_DECIMAL_LONG);
+		assertNoMsg(check, TEST_DECIMAL_FIXED);
 		assertNoMsg(check, TEST_HEXADECIMAL);
 		assertMessages(check, TEST_BINARY, [
-			"\"0b101010\" is a long number, use _ as a separator",
-			"\"0b10010001\" is a long number, use _ as a separator"
+			"\"0b101010\" is a long binary number, use _ as a separator",
+			"\"0b10010001\" is a long binary number, use _ as a separator"
+		]);
+		assertMessages(check, TEST_BINARY_LONG, [
+			"\"0b1001000101\" is a long binary number, use _ as a separator"
+		]);
+		assertMessages(check, TEST_BINARY_FIXED, [
+			"\"0b10_01000101\" uses separators improperly, use _ every 4 digits"
 		]);
 	}
 }
 
 enum abstract LongNumberCheckTests(String) to String {
-	var TEST_STANDARD_NUMBERS = "
+	var TEST_DECIMAL = "
 	abstractAndClass Test {
 		public function new() {
 			var a = 10;
@@ -92,31 +148,31 @@ enum abstract LongNumberCheckTests(String) to String {
 			var e = 10.123;
 		}
 	}";
-	var TEST_LONG_NUMBERS = "
+	var TEST_DECIMAL_LONG = "
 	abstractAndClass Test {
 		public function new() {
-			var a = 10123;
+			var a = 1012;
 			var b = 20123;
-			var c = 30123;
+			var c = 3012;
 			var d = 40123;
 			var d = 50123;
 
 			var e = 10.123456;
 		}
 	}";
-	var TEST_FIXED_LONG_NUMBERS = "
+	var TEST_DECIMAL_FIXED = "
 	abstractAndClass Test {
 		public function new() {
-			var a = 10_123;
+			var a = 1_012;
 			var b = 20_123;
-			var c = 30_123;
+			var c = 3_012;
 			var d = 40_123;
 			var d = 50_123;
 
-			var e = 10.123_456;
-			var f = 10.12_34_56;
+			var e = 10.123456;
 		}
 	}";
+	
 	var TEST_HEXADECIMAL = "
 	abstractAndClass Test {
 		public function new() {
@@ -125,12 +181,40 @@ enum abstract LongNumberCheckTests(String) to String {
 			var c = 0x10233023;
 		}
 	}";
+	var TEST_HEXADECIMAL_LONG = "
+	abstractAndClass Test {
+		public function new() {
+			var c = 0x1234_5678;
+			var c = 0x10233023AF;
+		}
+	}";
+	var TEST_HEXADECIMAL_FIXED = "
+	abstractAndClass Test {
+		public function new() {
+			var c = 0x12345678;
+			var c = 0x10_233023AF;
+		}
+	}";
+
 	var TEST_BINARY = "
 	abstractAndClass Test {
 		public function new() {
 			var a = 0b101;
 			var b = 0b101010;
 			var c = 0b10010001;
+		}
+	}";
+	var TEST_BINARY_LONG = "
+	abstractAndClass Test {
+		public function new() {
+			var c = 0b1001_0001;
+			var c = 0b1001000101;
+		}
+	}";
+	var TEST_BINARY_FIXED = "
+	abstractAndClass Test {
+		public function new() {
+			var c = 0b10_01000101;
 		}
 	}";
 }

--- a/test/checkstyle/checks/coding/LongNumberCheckTest.hx
+++ b/test/checkstyle/checks/coding/LongNumberCheckTest.hx
@@ -14,6 +14,8 @@ class LongNumberCheckTest extends CheckTestCase<LongNumberCheckTests> {
 			"\"10.123456\" is a long number, use _ as a separator"
 		]);
 		assertNoMsg(check, TEST_FIXED_LONG_NUMBERS);
+		assertNoMsg(check, TEST_HEXADECIMAL);
+		assertNoMsg(check, TEST_BINARY);
 	}
 
 	@Test
@@ -28,6 +30,52 @@ class LongNumberCheckTest extends CheckTestCase<LongNumberCheckTests> {
 			"\"50123\" is a long number, use _ as a separator"
 		]);
 		assertNoMsg(check, TEST_FIXED_LONG_NUMBERS);
+		assertNoMsg(check, TEST_HEXADECIMAL);
+		assertNoMsg(check, TEST_BINARY);
+	}
+
+	@Test
+	public function testHexadecimal() {
+		var check = new LongNumberCheck();
+		check.checkHexadecimal = true;
+
+		assertNoMsg(check, TEST_STANDARD_NUMBERS);
+		assertMessages(check, TEST_LONG_NUMBERS, [
+			"\"10123\" is a long number, use _ as a separator",
+			"\"20123\" is a long number, use _ as a separator",
+			"\"30123\" is a long number, use _ as a separator",
+			"\"40123\" is a long number, use _ as a separator",
+			"\"50123\" is a long number, use _ as a separator",
+			"\"10.123456\" is a long number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_FIXED_LONG_NUMBERS);
+		assertMessages(check, TEST_HEXADECIMAL, [
+			"\"0x123456\" is a long number, use _ as a separator",
+			"\"0x10233023\" is a long number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_BINARY);
+	}
+
+	@Test
+	public function testBinary() {
+		var check = new LongNumberCheck();
+		check.checkBinary = true;
+
+		assertNoMsg(check, TEST_STANDARD_NUMBERS);
+		assertMessages(check, TEST_LONG_NUMBERS, [
+			"\"10123\" is a long number, use _ as a separator",
+			"\"20123\" is a long number, use _ as a separator",
+			"\"30123\" is a long number, use _ as a separator",
+			"\"40123\" is a long number, use _ as a separator",
+			"\"50123\" is a long number, use _ as a separator",
+			"\"10.123456\" is a long number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_FIXED_LONG_NUMBERS);
+		assertNoMsg(check, TEST_HEXADECIMAL);
+		assertMessages(check, TEST_BINARY, [
+			"\"0b101010\" is a long number, use _ as a separator",
+			"\"0b10010001\" is a long number, use _ as a separator"
+		]);
 	}
 }
 
@@ -67,6 +115,22 @@ enum abstract LongNumberCheckTests(String) to String {
 
 			var e = 10.123_456;
 			var f = 10.12_34_56;
+		}
+	}";
+	var TEST_HEXADECIMAL = "
+	abstractAndClass Test {
+		public function new() {
+			var a = 0x123;
+			var b = 0x123456;
+			var c = 0x10233023;
+		}
+	}";
+	var TEST_BINARY = "
+	abstractAndClass Test {
+		public function new() {
+			var a = 0b101;
+			var b = 0b101010;
+			var c = 0b10010001;
 		}
 	}";
 }

--- a/test/checkstyle/checks/coding/LongNumberCheckTest.hx
+++ b/test/checkstyle/checks/coding/LongNumberCheckTest.hx
@@ -17,8 +17,7 @@ class LongNumberCheckTest extends CheckTestCase<LongNumberCheckTests> {
 
 		assertNoMsg(check, TEST_HEXADECIMAL);
 		assertMessages(check, TEST_HEXADECIMAL_LONG, [
-			"\"0x1234_5678\" uses separators improperly, use _ every 8 digits",
-			"\"0x10233023AF\" is a long hexadecimal number, use _ as a separator"
+			"\"0x1234_5678\" uses separators improperly, use _ every 8 digits"
 		]);
 		assertNoMsg(check, TEST_HEXADECIMAL_FIXED);
 
@@ -51,8 +50,7 @@ class LongNumberCheckTest extends CheckTestCase<LongNumberCheckTests> {
 		
 		assertNoMsg(check, TEST_HEXADECIMAL);
 		assertMessages(check, TEST_HEXADECIMAL_LONG, [
-			"\"0x1234_5678\" uses separators improperly, use _ every 8 digits",
-			"\"0x10233023AF\" is a long hexadecimal number, use _ as a separator"
+			"\"0x1234_5678\" uses separators improperly, use _ every 8 digits"
 		]);
 		assertNoMsg(check, TEST_HEXADECIMAL_FIXED);
 
@@ -83,8 +81,7 @@ class LongNumberCheckTest extends CheckTestCase<LongNumberCheckTests> {
 
 		assertNoMsg(check, TEST_HEXADECIMAL);
 		assertMessages(check, TEST_HEXADECIMAL_LONG, [
-			"\"0x1234_5678\" uses separators improperly, use _ every 8 digits",
-			"\"0x10233023AF\" is a long hexadecimal number, use _ as a separator"
+			"\"0x1234_5678\" uses separators improperly, use _ every 8 digits"
 		]);
 		assertNoMsg(check, TEST_HEXADECIMAL_FIXED);
 
@@ -185,14 +182,14 @@ enum abstract LongNumberCheckTests(String) to String {
 	abstractAndClass Test {
 		public function new() {
 			var c = 0x1234_5678;
-			var c = 0x10233023AF;
+			var c = 0x10233023;
 		}
 	}";
 	var TEST_HEXADECIMAL_FIXED = "
 	abstractAndClass Test {
 		public function new() {
 			var c = 0x12345678;
-			var c = 0x10_233023AF;
+			var c = 0x10233023;
 		}
 	}";
 

--- a/test/checkstyle/checks/coding/LongNumberCheckTest.hx
+++ b/test/checkstyle/checks/coding/LongNumberCheckTest.hx
@@ -1,0 +1,72 @@
+package checkstyle.checks.coding;
+
+class LongNumberCheckTest extends CheckTestCase<LongNumberCheckTests> {
+	@Test
+	public function test() {
+		var check = new LongNumberCheck();
+		assertNoMsg(check, TEST_STANDARD_NUMBERS);
+		assertMessages(check, TEST_LONG_NUMBERS, [
+			"\"10123\" is a long number, use _ as a separator",
+			"\"20123\" is a long number, use _ as a separator",
+			"\"30123\" is a long number, use _ as a separator",
+			"\"40123\" is a long number, use _ as a separator",
+			"\"50123\" is a long number, use _ as a separator",
+			"\"10.123456\" is a long number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_FIXED_LONG_NUMBERS);
+	}
+
+	@Test
+	public function testIgnore() {
+		var check = new LongNumberCheck();
+		check.ignoreNumbers = [10_123, 30_123, 10.123_456];
+
+		assertNoMsg(check, TEST_STANDARD_NUMBERS);
+		assertMessages(check, TEST_LONG_NUMBERS, [
+			"\"20123\" is a long number, use _ as a separator",
+			"\"40123\" is a long number, use _ as a separator",
+			"\"50123\" is a long number, use _ as a separator"
+		]);
+		assertNoMsg(check, TEST_FIXED_LONG_NUMBERS);
+	}
+}
+
+enum abstract LongNumberCheckTests(String) to String {
+	var TEST_STANDARD_NUMBERS = "
+	abstractAndClass Test {
+		public function new() {
+			var a = 10;
+			var b = 20;
+			var c = 30;
+			var d = 40;
+			var d = 50;
+
+			var e = 10.123;
+		}
+	}";
+	var TEST_LONG_NUMBERS = "
+	abstractAndClass Test {
+		public function new() {
+			var a = 10123;
+			var b = 20123;
+			var c = 30123;
+			var d = 40123;
+			var d = 50123;
+
+			var e = 10.123456;
+		}
+	}";
+	var TEST_FIXED_LONG_NUMBERS = "
+	abstractAndClass Test {
+		public function new() {
+			var a = 10_123;
+			var b = 20_123;
+			var c = 30_123;
+			var d = 40_123;
+			var d = 50_123;
+
+			var e = 10.123_456;
+			var f = 10.12_34_56;
+		}
+	}";
+}

--- a/test/checkstyle/config/ConfigParserTest.hx
+++ b/test/checkstyle/config/ConfigParserTest.hx
@@ -4,7 +4,7 @@ import checkstyle.utils.ConfigUtils;
 
 class ConfigParserTest implements ITest {
 	static inline var LOCAL_PATH:String = "./";
-	static inline var TEST_COUNT:Int = 81;
+	static inline var TEST_COUNT:Int = 82;
 
 	public function new() {}
 


### PR DESCRIPTION
Implemented a new check which validates that long numbers contain thousands separators (i.e. replacing 10234 with `10_234`). This keeps longer numbers easily readable even if they are larger.

It includes the following properties:
- `decimalGroupSize`: the number of digits between each separator for decimal numbers. defaults to `3`, use `-1` to disable checks for decimal numbers
- `fractionalGroupSize`: the number of digits between each seperator for the fractional part of floating point numbers. defaults to `-1` to disable checks for the fractional part of floating part numbers
- `hexadecimalGroupSize`: the number of digits between each separator for hexadecimal numbers. defaults to `8`, use `-1` to disable checks for hexadecimal numbers
- `binaryGroupSize`: the number of digits between each separator for binary numbers. defaults to `8`, use `-1` to disable checks for binary numbers

```haxe
// Fails with: "10123" is a long number, use _ as a separator
var a = 10123;
// Passes with default decimalGroupSize
var a = 10_123;

// Passes with default fractionalGroupSize
var e = 10.123456;
// Fails unless fractionalGroupSize is 3
var e = 10.123_456;

// Passes by default, fails if hexadecimalGroupSize is not 8
var c = 0x10233023;
// Passes by default, fails if binaryGroupSize is not 8
var c = 0b10010001;
```