### PR TITLE
Added a maxDepth option to AvoidTernaryOperator

### DIFF
--- a/resources/checkstyle-schema.json
+++ b/resources/checkstyle-schema.json
@@ -1664,6 +1664,11 @@
                     "description": "Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.",
                     "additionalProperties": false,
                     "properties": {
+                        "maxDepth": {
+                            "description": "the maximum number of levels of depth a ternary operator can be nested in\n\t\t0 (default) = no ternaries allowed\n\t\t1 = no nested ternaries\n\t\t2 = no nested ternaries inside nested ternaries, etc.",
+                            "type": "integer",
+                            "propertyOrder": 0
+                        },
                         "severity": {
                             "description": "sets gravity of reported violations:\n\t- IGNORE = do not report violations, violations do not appear anywhere in output\n\t- INFO = all violations have info / lowest priority\n\t- WARNING = all violations have warning / medium priority\n\t- ERROR = all violations have error / highest priority",
                             "type": "string",
@@ -1673,7 +1678,7 @@
                                 "ERROR",
                                 "IGNORE"
                             ],
-                            "propertyOrder": 0
+                            "propertyOrder": 1
                         }
                     },
                     "type": "object"

--- a/src/checkstyle/checks/coding/AvoidTernaryOperatorCheck.hx
+++ b/src/checkstyle/checks/coding/AvoidTernaryOperatorCheck.hx
@@ -6,22 +6,64 @@ package checkstyle.checks.coding;
 @name("AvoidTernaryOperator", "AvoidInlineConditionals")
 @desc("Detects ternary operators. Useful for developers who find ternary operators hard to read and want forbid them.")
 class AvoidTernaryOperatorCheck extends Check {
+
+	/**
+	 	the maximum number of levels of depth a ternary operator can be nested in
+		0 (default) = no ternaries allowed
+		1 = no nested ternaries
+		2 = no nested ternaries inside nested ternaries, etc.
+	**/
+	public var maxDepth:Int;
+
 	public function new() {
 		super(AST);
 		severity = SeverityLevel.IGNORE;
 		categories = [Category.COMPLEXITY];
 		points = 3;
+
+		maxDepth = 0;
 	}
 
 	override function actualRun() {
-		if (checker.ast == null) return;
-		checker.ast.walkFile(function(e:Expr) {
-			if (isPosSuppressed(e.pos)) return;
-			switch (e.expr) {
-				case ETernary(econd, eif, eelse):
-					logPos("Avoid ternary operator", e.pos);
-				default:
+		forEachField(function(f, _) {
+			switch (f.kind) {
+				case FVar(type, expr):
+					scanExprs([expr], 0);
+				case FProp(get, set, t, expr):
+					scanExprs([expr], 0);
+				case FFun(fun):
+					scanExprs([fun.expr], 0);
 			}
 		});
+	}
+
+	function scanExprs(exprs:Array<Expr>, ternaryDepth:Int) {
+		for (e in exprs) {
+			if (e == null) continue;
+			if (isPosSuppressed(e.pos)) continue;
+
+			switch (e.expr) {
+				case EBlock(exprs):
+					scanExprs(exprs, ternaryDepth);
+				case EParenthesis(expr):
+					scanExprs([expr], ternaryDepth);
+				case EVars(vars):
+					for (v in vars) scanExprs([v.expr], ternaryDepth);
+
+				case ETernary(_, eif, eelse):
+					if (maxDepth == 0) {
+						logPos("Avoid use of ternary operators", e.pos);
+					}
+					else if ((ternaryDepth + 1) > maxDepth) {
+						logPos("Maximum ternary depth exceeded", e.pos);
+					}
+					else {
+						scanExprs([eif, eelse], ternaryDepth + 1);
+					}
+				
+				default:
+					continue;
+			}
+		}
 	}
 }

--- a/test/checkstyle/checks/coding/AvoidTernaryOperatorCheckTest.hx
+++ b/test/checkstyle/checks/coding/AvoidTernaryOperatorCheckTest.hx
@@ -4,17 +4,81 @@ import checkstyle.SeverityLevel;
 
 class AvoidTernaryOperatorCheckTest extends CheckTestCase<AvoidTernaryOperatorCheckTests> {
 	@Test
-	public function testInlineCondition() {
+	public function testTernaryDepth0() {
 		var check = new AvoidTernaryOperatorCheck();
 		check.severity = SeverityLevel.INFO;
-		assertMsg(check, TEST1, "Avoid ternary operator");
+
+		check.maxDepth = 0;
+
+		assertMsg(check, TEST_VAR, "Avoid use of ternary operators");
+		assertMsg(check, TEST_FUNC, "Avoid use of ternary operators");
+		assertMessages(check, TEST_NESTED, [
+			"Avoid use of ternary operators",
+			"Avoid use of ternary operators"
+		]);
+		assertMsg(check, TEST_DOUBLE_NESTED, "Avoid use of ternary operators");
+	}
+
+	@Test
+	public function testTernaryDepth1() {
+		var check = new AvoidTernaryOperatorCheck();
+		check.severity = SeverityLevel.INFO;
+
+		check.maxDepth = 1;
+
+		assertNoMsg(check, TEST_VAR);
+		assertNoMsg(check, TEST_FUNC);
+		assertMessages(check, TEST_NESTED, [
+			"Maximum ternary depth exceeded",
+			"Maximum ternary depth exceeded",
+			"Maximum ternary depth exceeded",
+			"Maximum ternary depth exceeded"
+		]);
+		assertMessages(check, TEST_DOUBLE_NESTED, [
+			"Maximum ternary depth exceeded",
+			"Maximum ternary depth exceeded"
+		]);
+	}
+
+	@Test
+	public function testTernaryDepth2() {
+		var check = new AvoidTernaryOperatorCheck();
+		check.severity = SeverityLevel.INFO;
+
+		check.maxDepth = 2;
+
+		assertNoMsg(check, TEST_VAR);
+		assertNoMsg(check, TEST_FUNC);
+		assertNoMsg(check, TEST_NESTED);
+		assertMsg(check, TEST_DOUBLE_NESTED, "Maximum ternary depth exceeded");
 	}
 }
 
 enum abstract AvoidTernaryOperatorCheckTests(String) to String {
-	var TEST1 = "
+	var TEST_VAR = "
 	abstractAndClass Test {
 		var a:Array<Int> = [];
 		var x = (a == null || a.length < 1) ? null : a[0];
 	}";
+
+	var TEST_FUNC = "
+	abstractAndClass Test {
+		function test() {
+			var result = (foo) ? (bar) : (baz);
+		}
+	}
+	";
+
+	var TEST_NESTED = "
+	abstractAndClass Test {
+		var result = foo ? (bar ? baz : null) : (bar ? baz : null);
+		var result = foo ? bar ? baz : null : bar ? baz : null;
+	}
+	";
+
+	var TEST_DOUBLE_NESTED = "
+	abstractAndClass Test {
+		var result = foo ? (bar ? baz : (hello ? world : null)) : (bar ? baz : null);
+	}
+	";
 }


### PR DESCRIPTION
Currently, there is no option to allow ternaries, but disallow nested ternaries (which are significantly more confusing than simple ternaries).

This PR adds the `maxDepth` option to the AvoidTernaryOperator check, to allow ternaries but only to a certain depth.

```haxe
// Fails only if maxDepth is 0
var result = foo ? bar : baz;

// Fails if maxDepth is 1
var result = foo ? bar ? baz : null : bar ? baz : null;
```

Includes unit tests.