### PR TITLE
Add FINAL and NOTFINAL tokens to LocalVariableName check

### DIFF
--- a/resources/checkstyle-schema.json
+++ b/resources/checkstyle-schema.json
@@ -1003,7 +1003,12 @@
                         "tokens": {
                             "description": "list of tokens to limit where names should conform to \"format\"",
                             "items": {
-                                "type": "string"
+                                "description": "supports final and non final constants\n\t- FINAL = \"final\"\n\t- NOTFINAL = \"var\"",
+                                "type": "string",
+                                "enum": [
+                                    "FINAL",
+                                    "NOTFINAL"
+                                ]
                             },
                             "type": "array",
                             "propertyOrder": 1

--- a/schema/CheckstyleSchemaGenerator.hx
+++ b/schema/CheckstyleSchemaGenerator.hx
@@ -62,7 +62,7 @@ class CheckstyleSchemaGenerator {
 			case "ConstantName.tokens.items":
 				makeAnyOfAbstract(fields, "checkstyle.checks.naming.ConstantNameCheck.ConstantNameCheckToken", pos);
 			case "LocalVariableName.tokens.items":
-				fields.push({field: "type", expr: macro "string"});
+				makeAnyOfAbstract(fields, "checkstyle.checks.naming.LocalVariableNameCheck.LocalVariableNameCheckToken", pos);
 			case "MemberName.tokens.items":
 				makeAnyOfAbstract(fields, "checkstyle.checks.naming.MemberNameCheck.MemberNameCheckToken", pos);
 			case "MethodName.tokens.items":

--- a/src/checkstyle/checks/naming/LocalVariableNameCheck.hx
+++ b/src/checkstyle/checks/naming/LocalVariableNameCheck.hx
@@ -5,10 +5,10 @@ package checkstyle.checks.naming;
 **/
 @name("LocalVariableName")
 @desc("Checks that the local variable names conform to a format specified by the `format` property.")
-class LocalVariableNameCheck extends NameCheckBase<String> {
+class LocalVariableNameCheck extends NameCheckBase<LocalVariableNameCheckToken> {
 	public function new() {
 		super();
-		format = "^[a-z][a-zA-Z0-9]*$";
+		format = LOWER_CASE;
 	}
 
 	override function actualRun() {
@@ -19,11 +19,49 @@ class LocalVariableNameCheck extends NameCheckBase<String> {
 				case EVars(vars):
 					if (ignoreExtern && isPosExtern(e.pos)) return;
 					if (isPosSuppressed(e.pos)) return;
+
 					for (v in vars) {
+						if (hasToken(FINAL) != hasToken(NOTFINAL)) { // != -> xor
+							trace('Checking ', v.name, ' ', hasToken(FINAL), ' ', hasToken(NOTFINAL), ' ', v.isFinal);
+							if (!hasToken(FINAL) && v.isFinal) continue;
+							if (!hasToken(NOTFINAL) && !v.isFinal) continue;
+						}
+
+						trace('Evaluating typename (${v.name} == ${format})');
+
 						matchTypeName("local var", v.name, e.pos);
 					}
 				default:
 			}
 		});
 	}
+
+	override public function detectableInstances():DetectableInstances {
+		return [{
+			fixed: [{
+				propertyName: "tokens",
+				value: [FINAL, NOTFINAL]
+			}],
+			properties: [{
+				propertyName: "format",
+				values: [UPPER_CASE, CAMEL_CASE, LOWER_CASE]
+			}]
+		}];
+	}
+}
+
+/**
+	supports final and non final constants
+	- FINAL = "final"
+	- NOTFINAL = "var"
+**/
+enum abstract LocalVariableNameCheckToken(String) {
+	var FINAL = "FINAL";
+	var NOTFINAL = "NOTFINAL";
+}
+
+enum abstract LocalVariableNameCheckFormt(String) to String {
+	var UPPER_CASE = "^[A-Z][A-Z0-9]*(_[A-Z0-9_]+)*$";
+	var CAMEL_CASE = "^[A-Z]+[a-zA-Z0-9]*$";
+	var LOWER_CASE = "^[a-z][a-zA-Z0-9]*$";
 }

--- a/src/checkstyle/checks/naming/LocalVariableNameCheck.hx
+++ b/src/checkstyle/checks/naming/LocalVariableNameCheck.hx
@@ -40,7 +40,16 @@ class LocalVariableNameCheck extends NameCheckBase<LocalVariableNameCheckToken> 
 		return [{
 			fixed: [{
 				propertyName: "tokens",
-				value: [FINAL, NOTFINAL]
+				value: [FINAL]
+			}],
+			properties: [{
+				propertyName: "format",
+				values: [UPPER_CASE, CAMEL_CASE, LOWER_CASE]
+			}]
+		}, {
+			fixed: [{
+				propertyName: "tokens",
+				value: [NOTFINAL]
 			}],
 			properties: [{
 				propertyName: "format",

--- a/src/checkstyle/checks/naming/LocalVariableNameCheck.hx
+++ b/src/checkstyle/checks/naming/LocalVariableNameCheck.hx
@@ -22,12 +22,9 @@ class LocalVariableNameCheck extends NameCheckBase<LocalVariableNameCheckToken> 
 
 					for (v in vars) {
 						if (hasToken(FINAL) != hasToken(NOTFINAL)) { // != -> xor
-							trace('Checking ', v.name, ' ', hasToken(FINAL), ' ', hasToken(NOTFINAL), ' ', v.isFinal);
 							if (!hasToken(FINAL) && v.isFinal) continue;
 							if (!hasToken(NOTFINAL) && !v.isFinal) continue;
 						}
-
-						trace('Evaluating typename (${v.name} == ${format})');
 
 						matchTypeName("local var", v.name, e.pos);
 					}

--- a/test/checkstyle/checks/naming/LocalVariableNameCheckTest.hx
+++ b/test/checkstyle/checks/naming/LocalVariableNameCheckTest.hx
@@ -4,16 +4,19 @@ class LocalVariableNameCheckTest extends CheckTestCase<LocalVariableNameCheckTes
 	@Test
 	public function testCorrectNaming() {
 		var check = new LocalVariableNameCheck();
+
 		assertNoMsg(check, TEST);
 		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST_FINAL_1);
 	}
 
 	@Test
 	public function testWrongNaming() {
 		var check = new LocalVariableNameCheck();
-		var message = 'Invalid local var signature: "Count" (name should be "~/${check.format}/")';
-		assertMsg(check, TEST1, message);
-		assertMsg(check, TEST3, message);
+
+		assertMsg(check, TEST1, 'Invalid local var signature: "Count" (name should be "~/${check.format}/")');
+		assertMsg(check, TEST3, 'Invalid local var signature: "Count" (name should be "~/${check.format}/")');
+		assertMsg(check, TEST_FINAL_2, 'Invalid local var signature: "Count1" (name should be "~/${check.format}/")');
 	}
 
 	@Test
@@ -22,11 +25,41 @@ class LocalVariableNameCheckTest extends CheckTestCase<LocalVariableNameCheckTes
 		check.ignoreExtern = false;
 
 		assertNoMsg(check, TEST);
+		assertMsg(check, TEST1, 'Invalid local var signature: "Count" (name should be "~/${check.format}/")');
+		assertMsg(check, TEST3, 'Invalid local var signature: "Count" (name should be "~/${check.format}/")');
+		assertMsg(check, TEST4, 'Invalid local var signature: "Count" (name should be "~/${check.format}/")');
+		assertMsg(check, TEST_FINAL_2, 'Invalid local var signature: "Count1" (name should be "~/${check.format}/")');
+	}
 
-		var message = 'Invalid local var signature: "Count" (name should be "~/${check.format}/")';
-		assertMsg(check, TEST1, message);
-		assertMsg(check, TEST3, message);
-		assertMsg(check, TEST4, message);
+	@Test
+	public function testTokenFINAL() {
+		var check = new LocalVariableNameCheck();
+		check.ignoreExtern = false;
+		check.tokens = [FINAL];
+
+		assertNoMsg(check, TEST);
+		assertNoMsg(check, TEST1);
+		assertNoMsg(check, TEST3);
+		assertNoMsg(check, TEST4);
+		assertNoMsg(check, TEST_FINAL_1);
+
+		assertMsg(check, TEST_FINAL_2, 'Invalid local var signature: "Count1" (name should be "~/${check.format}/")');
+	}
+
+	@Test
+	public function testTokenNONFINAL() {
+		var check = new LocalVariableNameCheck();
+		check.ignoreExtern = false;
+		check.tokens = [NOTFINAL];
+
+		assertNoMsg(check, TEST);
+
+		assertMsg(check, TEST1, 'Invalid local var signature: "Count" (name should be "~/${check.format}/")');
+		assertMsg(check, TEST3, 'Invalid local var signature: "Count" (name should be "~/${check.format}/")');
+		assertMsg(check, TEST4, 'Invalid local var signature: "Count" (name should be "~/${check.format}/")');
+
+		assertNoMsg(check, TEST_FINAL_1);
+		assertNoMsg(check, TEST_FINAL_2);
 	}
 
 	@Test
@@ -38,9 +71,13 @@ class LocalVariableNameCheckTest extends CheckTestCase<LocalVariableNameCheckTes
 			'Invalid local var signature: "count1" (name should be "~/${check.format}/")',
 			'Invalid local var signature: "count2" (name should be "~/${check.format}/")'
 		]);
+
 		assertNoMsg(check, TEST1);
 		assertNoMsg(check, TEST3);
 		assertNoMsg(check, TEST4);
+
+		assertMsg(check, TEST_FINAL_1, 'Invalid local var signature: "count1" (name should be "~/${check.format}/")');
+		assertMsg(check, TEST_FINAL_2, 'Invalid local var signature: "Count1" (name should be "~/${check.format}/")');
 	}
 }
 
@@ -93,6 +130,19 @@ enum abstract LocalVariableNameCheckTests(String) to String {
 	extern class Test {
 		public function test() {
 			var Count:Int = 1;
+		}
+	}";
+
+	var TEST_FINAL_1 = "
+	class Test {
+		public function test() {
+			final count1:Int = 1;
+		}
+	}";
+	var TEST_FINAL_2 = "
+	class Test {
+		public function test() {
+			final Count1:Int = 1;
 		}
 	}";
 }


### PR DESCRIPTION
You can now filter the LocalVariableName check to provide different checks to FINAL and NONFINAL variables.

Includes unit tests.